### PR TITLE
Add new config `arguments_or_slashes` to `Rails/FilePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#298](https://github.com/rubocop-hq/rubocop-rails/pull/298): Allow multiple enforced styles for `Rails/FilePath` cop. ([@tejasbubane][])
+
 ### Bug fixes
 
 * [#482](https://github.com/rubocop/rubocop-rails/pull/482): Fix a false positive for `Rails/RelativeDateConstant` when assigning (hashes/arrays/etc)-containing procs to a constant. ([@jdelStrother][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -291,7 +291,8 @@ Rails/FilePath:
   Description: 'Use `Rails.root.join` for file path joining.'
   Enabled: true
   VersionAdded: '0.47'
-  VersionChanged: '2.4'
+  VersionChanged: '2.11'
+  AllowMultipleStyles: true
   EnforcedStyle: slashes
   SupportedStyles:
     - slashes

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1452,7 +1452,7 @@ raise 'a bad error has happened'
 | Yes
 | No
 | 0.47
-| 2.4
+| 2.11
 |===
 
 This cop is used to identify usages of file path joining process

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -31,6 +31,8 @@ module RuboCop
 
         MSG_SLASHES = 'Prefer `Rails.root.join(\'path/to\')`.'
         MSG_ARGUMENTS = 'Prefer `Rails.root.join(\'path\', \'to\')`.'
+        MSG_RAILS_ROOT = 'Prefer `Rails.root.join` instead.'
+
         RESTRICT_ON_SEND = %i[join].freeze
 
         def_node_matcher :file_join_nodes?, <<~PATTERN
@@ -100,6 +102,8 @@ module RuboCop
         end
 
         def message(_range)
+          return MSG_RAILS_ROOT if style.is_a?(Array) && style.sort == [:arguments, :slashes]
+
           format(style == :arguments ? MSG_ARGUMENTS : MSG_SLASHES)
         end
       end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -246,4 +246,40 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
   end
+
+  context 'when EnforcedStyle is slashes or arguments' do
+    let(:cop_config) { { 'EnforcedStyle' => %w[arguments slashes] } }
+
+    context 'when using File.join with Rails.root and slash arguments' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, 'app/models/user.rb')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join` instead.
+        RUBY
+      end
+    end
+
+    context 'when using File.join with multiple arguments' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, 'app', 'models')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join` instead.
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with some path strings' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app', 'models', 'user.rb')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with slash separated path string' do
+      it 'does not register an offense' do
+        expect_no_offenses("Rails.root.join('app/models/goober')")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Config to just check for usage of `File.path`, but doesn't care about arguments to `Rails.root.join`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/