### PR TITLE
Add autocorrection for `Rails/ReflectionClassName`

### DIFF
--- a/changelog/change_add_autocorrect_to_reflection_class_name.md
+++ b/changelog/change_add_autocorrect_to_reflection_class_name.md
@@ -1,0 +1,1 @@
+* [#299](https://github.com/rubocop/rubocop-rails/pull/299): Add autocorrection for `Rails/ReflectionClassName`. ([@tejasbubane][])

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -7,12 +7,20 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
         has_many :accounts, class_name: Account, foreign_key: :account_id
                             ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        has_many :accounts, class_name: "Account", foreign_key: :account_id
+      RUBY
     end
 
     it '.name' do
       expect_offense(<<~RUBY)
         has_many :accounts, class_name: Account.name
                             ^^^^^^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        has_many :accounts, class_name: "Account"
       RUBY
     end
 
@@ -21,6 +29,10 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
         has_many :accounts, class_name: Account.to_s
                             ^^^^^^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        has_many :accounts, class_name: "Account"
+      RUBY
     end
 
     it 'has_one' do
@@ -28,12 +40,20 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
         has_one :account, class_name: Account
                           ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        has_one :account, class_name: "Account"
+      RUBY
     end
 
     it 'belongs_to' do
       expect_offense(<<~RUBY)
         belongs_to :account, class_name: Account
                              ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        belongs_to :account, class_name: "Account"
       RUBY
     end
   end


### PR DESCRIPTION
Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/