### PR TITLE
Update IgnoredMethods for Lint/NumberConversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#416](https://github.com/rubocop/rubocop-rails/pull/416): Make `Rails/HasManyOrHasOneDependent` accept combination of association extension and `with_options`. ([@ohbarye][])
 * [#432](https://github.com/rubocop/rubocop-rails/issues/432): Exclude gemspec file by default for `Rails/TimeZone` cop. ([@koic][])
 * [#440](https://github.com/rubocop/rubocop-rails/issues/440): This PR makes `Rails/TimeZone` aware of timezone specifier. ([@koic][])
+* [#381](https://github.com/rubocop/rubocop-rails/pull/381): Update `IgnoredMethods` list for `Lint/NumberConversion` to allow Rails' duration methods. ([@dvandersluis][])
 
 ## 2.9.1 (2020-12-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -17,6 +17,27 @@ AllCops:
   # as the default.
   TargetRailsVersion: ~
 
+Lint/NumberConversion:
+  # Add Rails' duration methods to the ignore list for `Lint/NumberConversion`
+  # so that calling `to_i` on one of these does not register an offense.
+  # See: https://github.com/rubocop/rubocop/issues/8950
+  IgnoredMethods:
+    - ago
+    - from_now
+    - second
+    - seconds
+    - minute
+    - minutes
+    - hour
+    - hours
+    - day
+    - days
+    - week
+    - weeks
+    - fortnight
+    - fortnights
+    - in_milliseconds
+
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: true


### PR DESCRIPTION
Follows rubocop-hq/rubocop#8950.

Adds Rails' duration methods to the `IgnoredMethods` list for `Lint/NumberConversion`, so that calling `to_i` on one of them does not register an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
