### PR TITLE
[Fix #444] Mark `Rails/Blank` as unsafe auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#432](https://github.com/rubocop/rubocop-rails/issues/432): Exclude gemspec file by default for `Rails/TimeZone` cop. ([@koic][])
 * [#440](https://github.com/rubocop/rubocop-rails/issues/440): This PR makes `Rails/TimeZone` aware of timezone specifier. ([@koic][])
 * [#381](https://github.com/rubocop/rubocop-rails/pull/381): Update `IgnoredMethods` list for `Lint/NumberConversion` to allow Rails' duration methods. ([@dvandersluis][])
+* [#444](https://github.com/rubocop/rubocop-rails/issues/444): Mark `Rails/Blank` as unsafe auto-correction. ([@koic][])
 
 ## 2.9.1 (2020-12-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -149,8 +149,9 @@ Rails/BelongsTo:
 Rails/Blank:
   Description: 'Enforces use of `blank?`.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.48'
-  VersionChanged: '0.67'
+  VersionChanged: '2.10'
   # Convert usages of `nil? || empty?` to `blank?`
   NilOrEmpty: true
   # Convert usages of `!present?` to `blank?`

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -590,13 +590,17 @@ end
 
 | Enabled
 | Yes
-| Yes
+| Yes (Unsafe)
 | 0.48
-| 0.67
+| 2.10
 |===
 
 This cop checks for code that can be written with simpler conditionals
 using `Object#blank?` defined by Active Support.
+
+This cop is marked as unsafe auto-correction, because `' '.empty?` returns false,
+but `' '.blank?` returns true. Therefore, auto-correction is not compatible
+if the receiver is a non-empty blank string, tab, or newline meta characters.
 
 Interaction with `Style/UnlessElse`:
 The configuration of `NotPresent` will not produce an offense in the

--- a/lib/rubocop/cop/rails/blank.rb
+++ b/lib/rubocop/cop/rails/blank.rb
@@ -6,6 +6,10 @@ module RuboCop
       # This cop checks for code that can be written with simpler conditionals
       # using `Object#blank?` defined by Active Support.
       #
+      # This cop is marked as unsafe auto-correction, because `' '.empty?` returns false,
+      # but `' '.blank?` returns true. Therefore, auto-correction is not compatible
+      # if the receiver is a non-empty blank string, tab, or newline meta characters.
+      #
       # Interaction with `Style/UnlessElse`:
       # The configuration of `NotPresent` will not produce an offense in the
       # context of `unless else` if `Style/UnlessElse` is inabled. This is


### PR DESCRIPTION
Fixes ##444.

This PR marks `Rails/Blank` as unsafe auto-correction because `' '.empty?` returns false, but `' '.blank?` returns true. Therefore, auto-correction is not compatible if the receiver is a non-empty blank string, tab, or newline meta characters.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
