### PR TITLE
[Fix #451] Fix a false negative for `Rails/RelativeDateConstant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#440](https://github.com/rubocop/rubocop-rails/issues/440): This PR makes `Rails/TimeZone` aware of timezone specifier. ([@koic][])
 * [#381](https://github.com/rubocop/rubocop-rails/pull/381): Update `IgnoredMethods` list for `Lint/NumberConversion` to allow Rails' duration methods. ([@dvandersluis][])
 * [#444](https://github.com/rubocop/rubocop-rails/issues/444): Mark `Rails/Blank` as unsafe auto-correction. ([@koic][])
+* [#451](https://github.com/rubocop/rubocop-rails/issues/451): Make `Rails/RelativeDateConstant` aware of `yesterday` and `tomorrow` methods. ([@koic][])
 
 ## 2.9.1 (2020-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#421](https://github.com/rubocop/rubocop-rails/issues/421): Fix incorrect auto-correct for `Rails/LinkToBlank` when using `target: '_blank'` with hash brackets for the option. ([@koic][])
 * [#436](https://github.com/rubocop/rubocop-rails/issues/436): Fix a false positive for `Rails/ContentTag` when the first argument is a splat argument. ([@koic][])
 * [#435](https://github.com/rubocop/rubocop-rails/issues/435): Fix a false negative for `Rails/BelongsTo` when using `belongs_to` lambda block with `required` option. ([@koic][])
+* [#451](https://github.com/rubocop/rubocop-rails/issues/451): Fix a false negative for `Rails/RelativeDateConstant` when a method is chained after a relative date method. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         MSG = 'Do not assign %<method_name>s to constants as it ' \
               'will be evaluated only once.'
-        RELATIVE_DATE_METHODS = %i[since from_now after ago until before].freeze
+        RELATIVE_DATE_METHODS = %i[since from_now after ago until before yesterday tomorrow].freeze
 
         def on_casgn(node)
           return if node.children[2]&.block_type?

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe RuboCop::Cop::Rails::RelativeDateConstant, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when a method is chained after a relative date method' do
+      expect_offense(<<~RUBY)
+        class SomeClass
+          START_DATE = 2.weeks.ago.to_date
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign ago to constants as it will be evaluated only once.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass
+          def self.start_date
+            2.weeks.ago.to_date
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense for exclusive end range' do
       expect_offense(<<~RUBY)
         class SomeClass

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -43,6 +43,40 @@ RSpec.describe RuboCop::Cop::Rails::RelativeDateConstant, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `Date.yesterday`' do
+      expect_offense(<<~RUBY)
+        class SomeClass
+          RECENT_DATE = Date.yesterday
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign yesterday to constants as it will be evaluated only once.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass
+          def self.recent_date
+            Date.yesterday
+          end
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `Time.zone.tomorrow`' do
+      expect_offense(<<~RUBY)
+        class SomeClass
+          FUTURE_DATE = Time.zone.tomorrow
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign tomorrow to constants as it will be evaluated only once.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass
+          def self.future_date
+            Time.zone.tomorrow
+          end
+        end
+      RUBY
+    end
+
     it 'registers and corrects an offense when a method is chained after a relative date method' do
       expect_offense(<<~RUBY)
         class SomeClass


### PR DESCRIPTION
Fixes #451.

This PR fixes a false negative for `Rails/RelativeDateConstant` when a method is chained after a relative method and
makes `Rails/RelativeDateConstant` aware of `yesterday` and `tomorrow` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
