### PR TITLE
Add `Rails/DeleteBy` and `Rails/DestroyBy` cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#446](https://github.com/rubocop/rubocop-rails/issues/446): Add new `Rails/RequireDependency` cop. ([@tubaxenor][])
+* [#453](https://github.com/rubocop/rubocop-rails/pull/453): Add new `Rails/DeleteBy` and `Rails/DestroyBy` cops. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -225,6 +225,18 @@ Rails/DelegateAllowBlank:
   Enabled: true
   VersionAdded: '0.44'
 
+Rails/DeleteBy:
+  Description: 'Use `delete_by` as a relation method.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '2.10'
+
+Rails/DestroyBy:
+  Description: 'Use `destroy_by` as a relation method.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '2.10'
+
 Rails/DynamicFindBy:
   Description: 'Use `find_by` instead of dynamic `find_by_*`.'
   StyleGuide: 'https://rails.rubystyle.guide#find_by'

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -38,6 +38,8 @@ based on the https://rails.rubystyle.guide/[Rails Style Guide].
 * xref:cops_rails.adoc#railsdefaultscope[Rails/DefaultScope]
 * xref:cops_rails.adoc#railsdelegate[Rails/Delegate]
 * xref:cops_rails.adoc#railsdelegateallowblank[Rails/DelegateAllowBlank]
+* xref:cops_rails.adoc#railsdeleteby[Rails/DeleteBy]
+* xref:cops_rails.adoc#railsdestroyby[Rails/DestroyBy]
 * xref:cops_rails.adoc#railsdynamicfindby[Rails/DynamicFindBy]
 * xref:cops_rails.adoc#railsenumhash[Rails/EnumHash]
 * xref:cops_rails.adoc#railsenumuniqueness[Rails/EnumUniqueness]

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1097,6 +1097,64 @@ delegate :foo, to: :bar, allow_blank: true
 delegate :foo, to: :bar, allow_nil: true
 ----
 
+== Rails/DeleteBy
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Pending
+| No
+| Yes (Unsafe)
+| 2.10
+| -
+|===
+
+Rails 6.0 has added `delete_by` as a relation method.
+
+This cop identifies places where `find_by(...)&.delete` and `where(...).delete_all`
+can be replaced by `delete_by`.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+unreads.find_by(readable: readable)&.delete
+unreads.where(readable: readable).delete_all
+
+# good
+unreads.delete_by(readable: readable)
+----
+
+== Rails/DestroyBy
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Pending
+| No
+| Yes (Unsafe)
+| 2.10
+| -
+|===
+
+Rails 6.0 has added `delete_by` as a relation method.
+
+This cop identifies places where `find_by(...)&.destroy` and `where(...).destroy_all`
+can be replaced by `destroy_by`.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+unreads.find_by(readable: readable)&.destroy
+unreads.where(readable: readable).destroy_all
+
+# good
+unreads.destroy_by(readable: readable)
+----
+
 == Rails/DynamicFindBy
 
 |===

--- a/lib/rubocop/cop/mixin/delete_by_and_destroy_by_methods.rb
+++ b/lib/rubocop/cop/mixin/delete_by_and_destroy_by_methods.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Common functionality for `Rails/DeleteBy` and `Rails/DestroyBy` cops.
+    module DeleteByAndDestroyByMethods
+      include RangeHelp
+
+      MSG = 'Use `%<preferred_method>s(%<arguments>s)` instead.'
+
+      private
+
+      def register_offense(node, receiver)
+        range = range_between(receiver.loc.selector.begin_pos, node.source_range.end_pos)
+        arguments = receiver.arguments.map(&:source).join(', ')
+        message = format(MSG, preferred_method: preferred_method, arguments: arguments)
+
+        add_offense(range, message: message) do |corrector|
+          autocorrect(corrector, node, receiver)
+        end
+      end
+
+      def autocorrect(corrector, node, receiver)
+        corrector.replace(receiver.loc.selector, preferred_method)
+        corrector.remove(node.loc.dot)
+        corrector.remove(node.loc.selector)
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails/delete_by.rb
+++ b/lib/rubocop/cop/rails/delete_by.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Rails 6.0 has added `delete_by` as a relation method.
+      #
+      # This cop identifies places where `find_by(...)&.delete` and `where(...).delete_all`
+      # can be replaced by `delete_by`.
+      #
+      # @example
+      #   # bad
+      #   unreads.find_by(readable: readable)&.delete
+      #   unreads.where(readable: readable).delete_all
+      #
+      #   # good
+      #   unreads.delete_by(readable: readable)
+      #
+      class DeleteBy < Base
+        include DeleteByAndDestroyByMethods
+        extend AutoCorrector
+        extend TargetRailsVersion
+
+        minimum_target_rails_version 6.0
+
+        RESTRICT_ON_SEND = %i[delete delete_all].freeze
+
+        def on_send(node)
+          return unless (receiver = node.receiver)&.send_type?
+          return unless node.method?(:delete) && receiver.method?(:find_by) ||
+                        node.method?(:delete_all) && receiver.method?(:where)
+
+          register_offense(node, receiver)
+        end
+
+        alias on_csend on_send
+
+        private
+
+        def preferred_method
+          'delete_by'
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails/destroy_by.rb
+++ b/lib/rubocop/cop/rails/destroy_by.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Rails 6.0 has added `delete_by` as a relation method.
+      #
+      # This cop identifies places where `find_by(...)&.destroy` and `where(...).destroy_all`
+      # can be replaced by `destroy_by`.
+      #
+      # @example
+      #   # bad
+      #   unreads.find_by(readable: readable)&.destroy
+      #   unreads.where(readable: readable).destroy_all
+      #
+      #   # good
+      #   unreads.destroy_by(readable: readable)
+      #
+      class DestroyBy < Base
+        include DeleteByAndDestroyByMethods
+        extend AutoCorrector
+        extend TargetRailsVersion
+
+        minimum_target_rails_version 6.0
+
+        def on_send(node)
+          return unless (receiver = node.receiver)&.send_type?
+          return unless node.method?(:destroy) && receiver.method?(:find_by) ||
+                        node.method?(:destroy_all) && receiver.method?(:where)
+
+          register_offense(node, receiver)
+        end
+
+        alias on_csend on_send
+
+        private
+
+        def preferred_method
+          'destroy_by'
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'mixin/active_record_helper'
+require_relative 'mixin/delete_by_and_destroy_by_methods'
 require_relative 'mixin/enforce_superclass'
 require_relative 'mixin/index_method'
 require_relative 'mixin/target_rails_version'
@@ -27,6 +28,8 @@ require_relative 'rails/date'
 require_relative 'rails/default_scope'
 require_relative 'rails/delegate'
 require_relative 'rails/delegate_allow_blank'
+require_relative 'rails/delete_by'
+require_relative 'rails/destroy_by'
 require_relative 'rails/dynamic_find_by'
 require_relative 'rails/enum_hash'
 require_relative 'rails/enum_uniqueness'

--- a/spec/rubocop/cop/rails/delete_by_spec.rb
+++ b/spec/rubocop/cop/rails/delete_by_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::DeleteBy, :config do
+  context 'Rails >= 6.0', :rails60 do
+    it 'registers and corrects an offense when using `find_by&.delete`' do
+      expect_offense(<<~RUBY)
+        unreads.find_by(readable: readable)&.delete
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `delete_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.delete_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `where.delete_all`' do
+      expect_offense(<<~RUBY)
+        unreads.where(readable: readable).delete_all
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `delete_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.delete_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `find_by.delete`' do
+      expect_offense(<<~RUBY)
+        unreads.find_by(readable: readable).delete
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `delete_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.delete_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `where&.delete_all`' do
+      expect_offense(<<~RUBY)
+        unreads.where(readable: readable)&.delete_all
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `delete_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.delete_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `where&.delete_all` with multiple arguments' do
+      expect_offense(<<~RUBY)
+        model.where(foo: foo, bar: bar)&.delete_all
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `delete_by(foo: foo, bar: bar)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        model.delete_by(foo: foo, bar: bar)
+      RUBY
+    end
+
+    it 'does not register an offense when using `delete_by`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.delete_by(readable: readable)
+      RUBY
+    end
+
+    it 'does not register an offense when using `do_something.delete`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.do_something(readable: readable).delete
+      RUBY
+    end
+
+    it 'does not register an offense when using `do_something.delete_all`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.do_something(readable: readable).delete_all
+      RUBY
+    end
+
+    it 'does not register an offense when using `model.delete`' do
+      expect_no_offenses(<<~RUBY)
+        model = Model.first
+        model.delete
+      RUBY
+    end
+
+    it 'does not register an offense when using `delete`' do
+      expect_no_offenses(<<~RUBY)
+        delete
+      RUBY
+    end
+  end
+
+  context 'Rails <= 5.2', :rails52 do
+    it 'does not register an offense when using `find_by&.delete`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.find_by(readable: readable)&.delete
+      RUBY
+    end
+
+    it 'does not register an offense when using `where.delete_all`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.where(readable: readable).delete_all
+      RUBY
+    end
+
+    it 'does not register an offense when using `find_by.delete`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.find_by(readable: readable).delete
+      RUBY
+    end
+
+    it 'does not register an offense when using `where&.delete_all`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.where(readable: readable)&.delete_all
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/rails/destroy_by_spec.rb
+++ b/spec/rubocop/cop/rails/destroy_by_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::DestroyBy, :config do
+  context 'Rails >= 6.0', :rails60 do
+    it 'registers and corrects an offense when using `find_by&.destroy`' do
+      expect_offense(<<~RUBY)
+        unreads.find_by(readable: readable)&.destroy
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `destroy_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.destroy_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `where.destroy_all`' do
+      expect_offense(<<~RUBY)
+        unreads.where(readable: readable).destroy_all
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `destroy_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.destroy_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `find_by.destroy`' do
+      expect_offense(<<~RUBY)
+        unreads.find_by(readable: readable).destroy
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `destroy_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.destroy_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `where&.destroy_all`' do
+      expect_offense(<<~RUBY)
+        unreads.where(readable: readable)&.destroy_all
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `destroy_by(readable: readable)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unreads.destroy_by(readable: readable)
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `where&.destroy_all` with multiple arguments' do
+      expect_offense(<<~RUBY)
+        model.where(foo: foo, bar: bar)&.destroy_all
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `destroy_by(foo: foo, bar: bar)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        model.destroy_by(foo: foo, bar: bar)
+      RUBY
+    end
+
+    it 'does not register an offense when using `destroy_by`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.destroy_by(readable: readable)
+      RUBY
+    end
+
+    it 'does not register an offense when using `do_something.destroy`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.do_something(readable: readable).destroy
+      RUBY
+    end
+
+    it 'does not register an offense when using `do_something.destroy_all`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.do_something(readable: readable).destroy_all
+      RUBY
+    end
+
+    it 'does not register an offense when using `model.destroy`' do
+      expect_no_offenses(<<~RUBY)
+        model = Model.first
+        model.destroy
+      RUBY
+    end
+
+    it 'does not register an offense when using `destroy`' do
+      expect_no_offenses(<<~RUBY)
+        destroy
+      RUBY
+    end
+  end
+
+  context 'Rails <= 5.2', :rails52 do
+    it 'does not register an offense when using `find_by&.destroy`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.find_by(readable: readable)&.destroy
+      RUBY
+    end
+
+    it 'does not register an offense when using `where.destroy_all`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.where(readable: readable).destroy_all
+      RUBY
+    end
+
+    it 'does not register an offense when using `find_by.destroy`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.find_by(readable: readable).destroy
+      RUBY
+    end
+
+    it 'does not register an offense when using `where&.destroy_all`' do
+      expect_no_offenses(<<~RUBY)
+        unreads.where(readable: readable)&.destroy_all
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Follow https://github.com/rubocop/rails-style-guide/pull/283

Rails 6.0 has been added `delete_by` and `destroy_by` as relation methods.

## `Rails/DeleteBy` cop

This cop identifies places where `find_by(...)&.delete` and `where(...).delete_all` can be replaced by `delete_by`.

```ruby
# bad
unreads.find_by(readable: readable)&.delete
unreads.where(readable: readable).delete_all

# good
unreads.delete_by(readable: readable)
```

## `Rails/DestroyBy` cop

This cop identifies places where `find_by(...)&.destroy` and `where(...).destroy_all`
can be replaced by `destroy_by`.

```ruby
# bad
unreads.find_by(readable: readable)&.destroy
unreads.where(readable: readable).destroy_all

# good
unreads.destroy_by(readable: readable)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
