### PR TITLE
Mark `Rails/WhereExists` as unsafe auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#381](https://github.com/rubocop/rubocop-rails/pull/381): Update `IgnoredMethods` list for `Lint/NumberConversion` to allow Rails' duration methods. ([@dvandersluis][])
 * [#444](https://github.com/rubocop/rubocop-rails/issues/444): Mark `Rails/Blank` as unsafe auto-correction. ([@koic][])
 * [#451](https://github.com/rubocop/rubocop-rails/issues/451): Make `Rails/RelativeDateConstant` aware of `yesterday` and `tomorrow` methods. ([@koic][])
+* [#454](https://github.com/rubocop/rubocop-rails/pull/454): Mark `Rails/WhereExists` as unsafe auto-correction. ([@koic][])
 * [#456](https://github.com/rubocop/rubocop-rails/pull/456): Drop Ruby 2.4 support. ([@koic][])
 
 ## 2.9.1 (2020-12-16)

--- a/config/default.yml
+++ b/config/default.yml
@@ -770,12 +770,13 @@ Rails/WhereEquals:
 Rails/WhereExists:
   Description: 'Prefer `exists?(...)` over `where(...).exists?`.'
   Enabled: 'pending'
+  SafeAutoCorrect: false
   EnforcedStyle: exists
   SupportedStyles:
     - exists
     - where
   VersionAdded: '2.7'
-  VersionChanged: '2.8'
+  VersionChanged: '2.10'
 
 Rails/WhereNot:
   Description: 'Use `where.not(...)` instead of manually constructing negated SQL in `where`.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4512,9 +4512,9 @@ User.where(users: { name: 'Gabe' })
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 2.7
-| 2.8
+| 2.10
 |===
 
 This cop enforces consistent style when using `exists?`.
@@ -4524,6 +4524,17 @@ then the cop enforces `exists?(...)` over `where(...).exists?`.
 
 When EnforcedStyle is 'where' then the cop enforces
 `where(...).exists?` over `exists?(...)`.
+
+This cop is unsafe for auto-correction because the behavior may change on the following case:
+
+[source,ruby]
+----
+Author.includes(:articles).where(articles: {id: id}).exists?
+#=> Perform `eager_load` behavior (`LEFT JOIN` query) and get result.
+
+Author.includes(:articles).exists?(articles: {id: id})
+#=> Perform `preload` behavior and `ActiveRecord::StatementInvalid` error occurs.
+----
 
 === Examples
 

--- a/lib/rubocop/cop/rails/where_exists.rb
+++ b/lib/rubocop/cop/rails/where_exists.rb
@@ -11,6 +11,17 @@ module RuboCop
       # When EnforcedStyle is 'where' then the cop enforces
       # `where(...).exists?` over `exists?(...)`.
       #
+      # This cop is unsafe for auto-correction because the behavior may change on the following case:
+      #
+      # [source,ruby]
+      # ----
+      # Author.includes(:articles).where(articles: {id: id}).exists?
+      # #=> Perform `eager_load` behavior (`LEFT JOIN` query) and get result.
+      #
+      # Author.includes(:articles).exists?(articles: {id: id})
+      # #=> Perform `preload` behavior and `ActiveRecord::StatementInvalid` error occurs.
+      # ----
+      #
       # @example EnforcedStyle: exists (default)
       #   # bad
       #   User.where(name: 'john').exists?


### PR DESCRIPTION
## Summary

This cop is unsafe because the behavior may change on the following case:

```ruby
Author.includes(:articles).where(articles: {id: id}).exists?
#=> Perform `eager_load` behaviour (`LEFT JOIN` query) and get result.

Author.includes(:articles).exists?(articles: {id: id})
#=> Perform `preload` behaviour and `ActiveRecord::StatementInvalid` error occurs.
```

## Additional Information

And this cop may be considered disabled by default as there is no consensus on the default style.

- https://github.com/rubocop/rubocop-rails/pull/286
- https://github.com/rubocop/rubocop-rails/pull/342

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
