### PR TITLE
Fix a crash for `Rails/ContentTag` cop with nested tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#436](https://github.com/rubocop/rubocop-rails/issues/436): Fix a false positive for `Rails/ContentTag` when the first argument is a splat argument. ([@koic][])
 * [#435](https://github.com/rubocop/rubocop-rails/issues/435): Fix a false negative for `Rails/BelongsTo` when using `belongs_to` lambda block with `required` option. ([@koic][])
 * [#451](https://github.com/rubocop/rubocop-rails/issues/451): Fix a false negative for `Rails/RelativeDateConstant` when a method is chained after a relative date method. ([@koic][])
+* [#450](https://github.com/rubocop/rubocop-rails/issues/450): Fix a crash for `Rails/ContentTag` with nested content tags. ([@tejasbubane][])
 
 ### Changes
 

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
     it 'does not register an offense with nested content_tag' do
       expect_no_offenses(<<~RUBY)
         content_tag(:div) { content_tag(:strong, 'Hi') }
+
+        content_tag(:div, content_tag(:span, 'foo'))
       RUBY
     end
   end
@@ -62,6 +64,17 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
     end
 
     it 'corrects an offence with nested content_tag' do
+      expect_offense(<<~RUBY)
+        content_tag(:div, content_tag(:span, 'foo'))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        tag.div(tag.span('foo'))
+      RUBY
+    end
+
+    it 'corrects an offence with nested content_tag with block' do
       expect_offense(<<~RUBY)
         content_tag(:div) { content_tag(:strong, 'Hi') }
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop-rails/issues/450

Similar approach as this one: https://github.com/rubocop/rubocop/pull/8893/files

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/