### PR TITLE
Require RuboCop 1.7 or higher due to support obsoletion configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#451](https://github.com/rubocop/rubocop-rails/issues/451): Make `Rails/RelativeDateConstant` aware of `yesterday` and `tomorrow` methods. ([@koic][])
 * [#454](https://github.com/rubocop/rubocop-rails/pull/454): Mark `Rails/WhereExists` as unsafe auto-correction. ([@koic][])
 * [#456](https://github.com/rubocop/rubocop-rails/pull/456): Drop Ruby 2.4 support. ([@koic][])
+* [#462](https://github.com/rubocop/rubocop-rails/pull/462): Require RuboCop 1.7 or higher. ([@koic][])
 
 ## 2.9.1 (2020-12-16)
 

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -1,0 +1,7 @@
+#
+# Configuration for obsoletion.
+#
+# See: https://docs.rubocop.org/rubocop/extensions.html#config-obsoletions
+#
+extracted:
+  Rails/*: ~

--- a/lib/rubocop/rails.rb
+++ b/lib/rubocop/rails.rb
@@ -8,5 +8,7 @@ module RuboCop
     CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
 
     private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+
+    ::RuboCop::ConfigObsoletion.files << PROJECT_ROOT.join('config', 'obsoletion.yml')
   end
 end

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_runtime_dependency 'rack', '>= 1.1'
-  s.add_runtime_dependency 'rubocop', '>= 0.90.0', '< 2.0'
+  s.add_runtime_dependency 'rubocop', '>= 1.7.0', '< 2.0'
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe 'RuboCop Rails Project', type: :feature do
   describe 'default configuration file' do
     subject(:config) { RuboCop::ConfigLoader.load_file('config/default.yml') }
 
-    before do
-      allow_any_instance_of(RuboCop::Config).to receive(:loaded_features).and_return('rubocop-rails') # rubocop:disable RSpec/AnyInstance
-    end
-
     let(:registry) { RuboCop::Cop::Registry.global }
     let(:cop_names) do
       registry.with_department(:Rails).cops.map(&:cop_name)


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9206 and https://github.com/rubocop-hq/rubocop/pull/9143.

This PR requires RuboCop 1.7 or higher due to support obsoletion configuration and reverts https://github.com/rubocop/rubocop-rails/commit/151b8a6.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
