### PR TITLE
[Fix #103] Fix a false positive for `Rails/FindEach`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#435](https://github.com/rubocop/rubocop-rails/issues/435): Fix a false negative for `Rails/BelongsTo` when using `belongs_to` lambda block with `required` option. ([@koic][])
 * [#451](https://github.com/rubocop/rubocop-rails/issues/451): Fix a false negative for `Rails/RelativeDateConstant` when a method is chained after a relative date method. ([@koic][])
 * [#450](https://github.com/rubocop/rubocop-rails/issues/450): Fix a crash for `Rails/ContentTag` with nested content tags. ([@tejasbubane][])
+* [#103](https://github.com/rubocop/rubocop-rails/issues/103): Fix a false positive for `Rails/FindEach` when not inheriting `ActiveRecord::Base` and using `all.each`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -8,6 +8,13 @@ module RuboCop
 
       WHERE_METHODS = %i[where rewhere].freeze
 
+      def_node_matcher :active_record?, <<~PATTERN
+        {
+          (const nil? :ApplicationRecord)
+          (const (const nil? :ActiveRecord) :Base)
+        }
+      PATTERN
+
       def_node_search :find_set_table_name, <<~PATTERN
         (send self :table_name= {str sym})
       PATTERN
@@ -15,6 +22,10 @@ module RuboCop
       def_node_search :find_belongs_to, <<~PATTERN
         (send nil? :belongs_to {str sym} ...)
       PATTERN
+
+      def inherit_active_record_base?(node)
+        node.each_ancestor(:class).any? { |class_node| active_record?(class_node.parent_class) }
+      end
 
       def external_dependency_checksum
         return @external_dependency_checksum if defined?(@external_dependency_checksum)

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -17,6 +17,7 @@ module RuboCop
       #   # good
       #   User.order(:foo).each
       class FindEach < Base
+        include ActiveRecordHelper
         extend AutoCorrector
 
         MSG = 'Use `find_each` instead of `each`.'
@@ -30,6 +31,7 @@ module RuboCop
         def on_send(node)
           return unless node.receiver&.send_type?
           return unless SCOPE_METHODS.include?(node.receiver.method_name)
+          return if node.receiver.receiver.nil? && !inherit_active_record_base?(node)
           return if ignored?(node)
 
           range = node.loc.selector

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -65,6 +65,42 @@ RSpec.describe RuboCop::Cop::Rails::FindEach, :config do
     RUBY
   end
 
+  context 'with no receiver' do
+    it 'does not register an offense when not inheriting any class' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          all.each { |u| u.x }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not inheriting `ApplicationRecord`' do
+      expect_no_offenses(<<~RUBY)
+        class C < Foo
+          all.each { |u| u.x }
+        end
+      RUBY
+    end
+
+    it 'registers an offense when inheriting `ApplicationRecord`' do
+      expect_offense(<<~RUBY)
+        class C < ApplicationRecord
+          all.each { |u| u.x }
+              ^^^^ Use `find_each` instead of `each`.
+        end
+      RUBY
+    end
+
+    it 'registers an offense when inheriting `ActiveRecord::Base`' do
+      expect_offense(<<~RUBY)
+        class C < ActiveRecord::Base
+          all.each { |u| u.x }
+              ^^^^ Use `find_each` instead of `each`.
+        end
+      RUBY
+    end
+  end
+
   context 'ignored methods' do
     let(:cop_config) { { 'IgnoredMethods' => %w[order lock] } }
 


### PR DESCRIPTION
Fixes #103.

This PR fixes a false positive for `Rails/FindEach` when not inheriting `ActiveRecord::Base` and using `all.each`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
