### PR TITLE
[Fix #147] Fix a false positive for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#450](https://github.com/rubocop/rubocop-rails/issues/450): Fix a crash for `Rails/ContentTag` with nested content tags. ([@tejasbubane][])
 * [#103](https://github.com/rubocop/rubocop-rails/issues/103): Fix a false positive for `Rails/FindEach` when not inheriting `ActiveRecord::Base` and using `all.each`. ([@koic][])
 * [#466](https://github.com/rubocop/rubocop-rails/pull/466): Fix a false positive for `Rails/DynamicFindBy` when not inheriting `ApplicationRecord` and without no receiver. ([@koic][])
+* [#147](https://github.com/rubocop/rubocop-rails/issues/147): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying default `dependent: nil` strategy. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1586,6 +1586,7 @@ end
 class User < ActiveRecord::Base
   has_many :comments, dependent: :restrict_with_exception
   has_one :avatar, dependent: :destroy
+  has_many :articles, dependent: nil
   has_many :patients, through: :appointments
 end
 ----

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -18,6 +18,7 @@ module RuboCop
       #   class User < ActiveRecord::Base
       #     has_many :comments, dependent: :restrict_with_exception
       #     has_one :avatar, dependent: :destroy
+      #     has_many :articles, dependent: nil
       #     has_many :patients, through: :appointments
       #   end
       class HasManyOrHasOneDependent < Base
@@ -37,7 +38,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :dependent_option?, <<~PATTERN
-          (pair (sym :dependent) !nil)
+          (pair (sym :dependent) {!nil (nil)})
         PATTERN
 
         def_node_matcher :present_option?, <<~PATTERN

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
+    it 'does not register an offense when specifying default `dependent: nil` strategy' do
+      expect_no_offenses(<<~RUBY)
+        class Person < ApplicationRecord
+          has_one :foo, dependent: nil
+        end
+      RUBY
+    end
+
     context 'with :through option' do
       it 'does not register an offense for non-nil value' do
         expect_no_offenses(<<~RUBY)
@@ -91,6 +99,14 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
 
     it 'does not register an offense when specifying `:dependent` strategy' do
       expect_no_offenses('has_many :foo, dependent: :bar')
+    end
+
+    it 'does not register an offense when specifying default `dependent: nil` strategy' do
+      expect_no_offenses(<<~RUBY)
+        class Person < ApplicationRecord
+          has_many :foo, dependent: nil
+        end
+      RUBY
     end
 
     context 'with :through option' do


### PR DESCRIPTION
Fixes #147.
Closes #176.

This PR fixes a false positive for `Rails/HasManyOrHasOneDependent` when specifying default `dependent: nil` strategy.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
