### PR TITLE
[Fix #106] Mark `Rails/ReflectionClassName` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#451](https://github.com/rubocop/rubocop-rails/issues/451): Make `Rails/RelativeDateConstant` aware of `yesterday` and `tomorrow` methods. ([@koic][])
 * [#454](https://github.com/rubocop/rubocop-rails/pull/454): Mark `Rails/WhereExists` as unsafe auto-correction. ([@koic][])
 * [#379](https://github.com/rubocop/rubocop-rails/issues/379): Mark `Rails/DynamicFindBy` as unsafe. ([@koic][])
+* [#106](https://github.com/rubocop/rubocop-rails/issues/106): Mark `Rails/ReflectionClassName` as unsafe. ([@koic][])
 * [#456](https://github.com/rubocop/rubocop-rails/pull/456): Drop Ruby 2.4 support. ([@koic][])
 * [#462](https://github.com/rubocop/rubocop-rails/pull/462): Require RuboCop 1.7 or higher. ([@koic][])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -563,7 +563,9 @@ Rails/RedundantReceiverInWithOptions:
 Rails/ReflectionClassName:
   Description: 'Use a string for `class_name` option value in the definition of a reflection.'
   Enabled: true
+  Safe: false
   VersionAdded: '0.64'
+  VersionChanged: '2.10'
 
 Rails/RefuteMethods:
   Description: 'Use `assert_not` methods instead of `refute` methods.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3163,14 +3163,16 @@ end
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
+| No
 | No
 | 0.64
-| -
+| 2.10
 |===
 
 This cop checks if the value of the option `class_name`, in
 the definition of a reflection is a string.
+It is marked as unsafe because it cannot be determined whether
+constant or method return value specified to `class_name` is a string.
 
 === Examples
 

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Rails
       # This cop checks if the value of the option `class_name`, in
       # the definition of a reflection is a string.
+      # It is marked as unsafe because it cannot be determined whether
+      # constant or method return value specified to `class_name` is a string.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Fixes #106.

This PR marks `Rails/ReflectionClassName` as unsafe.

And it would be possible to exclude `to_s` call other than constants. I will consider opening it as a separate PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
