### PR TITLE
[Fix #106] Make `Rails/ReflectionClassName` aware of the use of string with `to_s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#403](https://github.com/rubocop/rubocop-rails/pull/403): Mark `Rails/WhereEquals` as unsafe auto-correction. ([@koic][])
 * [#379](https://github.com/rubocop/rubocop-rails/issues/379): Mark `Rails/DynamicFindBy` as unsafe. ([@koic][])
 * [#106](https://github.com/rubocop/rubocop-rails/issues/106): Mark `Rails/ReflectionClassName` as unsafe. ([@koic][])
+* [#106](https://github.com/rubocop/rubocop-rails/issues/106): Make `Rails/ReflectionClassName` aware of the use of string with `to_s`. ([@koic][])
 * [#456](https://github.com/rubocop/rubocop-rails/pull/456): Drop Ruby 2.4 support. ([@koic][])
 * [#462](https://github.com/rubocop/rubocop-rails/pull/462): Require RuboCop 1.7 or higher. ([@koic][])
 

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
       RUBY
     end
 
+    it '.to_s' do
+      expect_offense(<<~RUBY)
+        has_many :accounts, class_name: Account.to_s
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
+      RUBY
+    end
+
     it 'has_one' do
       expect_offense(<<~RUBY)
         has_one :account, class_name: Account
@@ -43,6 +50,12 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
   it 'does not register an offense when using string with interpolation' do
     expect_no_offenses(<<~'RUBY')
       has_many :accounts, class_name: "#{prefix}Account"
+    RUBY
+  end
+
+  it 'does not register an offense when using `class_name: do_something.to_s`' do
+    expect_no_offenses(<<~'RUBY')
+      has_many :accounts, class_name: do_something.to_s
     RUBY
   end
 


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop-rails/pull/469

Fixes #106.

This PR makes `Rails/ReflectionClassName` aware of the use of string with `to_s`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
