### PR TITLE
[Fix #137] Make `Rails/HasManyOrHasOneDependent` aware of `readonly` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#103](https://github.com/rubocop/rubocop-rails/issues/103): Fix a false positive for `Rails/FindEach` when not inheriting `ActiveRecord::Base` and using `all.each`. ([@koic][])
 * [#466](https://github.com/rubocop/rubocop-rails/pull/466): Fix a false positive for `Rails/DynamicFindBy` when not inheriting `ApplicationRecord` and without no receiver. ([@koic][])
 * [#147](https://github.com/rubocop/rubocop-rails/issues/147): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying default `dependent: nil` strategy. ([@koic][])
+* [#137](https://github.com/rubocop/rubocop-rails/issues/137): Make `Rails/HasManyOrHasOneDependent` aware of `readonly?` is `true`. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1570,8 +1570,9 @@ This cop checks for the use of the has_and_belongs_to_many macro.
 
 This cop looks for `has_many` or `has_one` associations that don't
 specify a `:dependent` option.
+
 It doesn't register an offense if `:through` or `dependent: nil`
-was specified.
+is specified, or if the model is read-only.
 
 === Examples
 
@@ -1589,6 +1590,15 @@ class User < ActiveRecord::Base
   has_one :avatar, dependent: :destroy
   has_many :articles, dependent: nil
   has_many :patients, through: :appointments
+end
+
+class User < ActiveRecord::Base
+  has_many :comments
+  has_one :avatar
+
+  def readonly?
+    true
+  end
 end
 ----
 

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -224,6 +224,33 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
     end
   end
 
+  context 'when defining `readonly?` method' do
+    it 'does not register an offense for `readonly?` is `true`' do
+      expect_no_offenses(<<~RUBY)
+        class Person < ActiveRecord::Base
+          has_one :foo
+
+          def readonly?
+            true
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `readonly?` is not `true`' do
+      expect_offense(<<~RUBY)
+        class Person < ActiveRecord::Base
+          has_one :foo
+          ^^^^^^^ Specify a `:dependent` option.
+
+          def readonly?
+            false
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when an Active Record model does not have any associations' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #137.

This PR makes `Rails/HasManyOrHasOneDependent` aware of `readonly?` is `true`.

There may be false positives or false negatives with just `def readonly? = true`, but it makes it possible to detect perhaps general definition of `readonly?` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
