### PR TITLE
Fix a false negative for `Rails/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#466](https://github.com/rubocop/rubocop-rails/pull/466): Fix a false positive for `Rails/DynamicFindBy` when not inheriting `ApplicationRecord` and without no receiver. ([@koic][])
 * [#147](https://github.com/rubocop/rubocop-rails/issues/147): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying default `dependent: nil` strategy. ([@koic][])
 * [#137](https://github.com/rubocop/rubocop-rails/issues/137): Make `Rails/HasManyOrHasOneDependent` aware of `readonly?` is `true`. ([@koic][])
+* [#474](https://github.com/rubocop/rubocop-rails/pull/474): Fix a false negative for `Rails/SafeNavigation` when using `try!` without receiver. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -44,7 +44,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[try try!].freeze
 
         def_node_matcher :try_call, <<~PATTERN
-          (send !nil? ${:try :try!} $_ ...)
+          (send _ ${:try :try!} $_ ...)
         PATTERN
 
         def on_send(node)
@@ -64,7 +64,12 @@ module RuboCop
           method_node, *params = *node.arguments
           method = method_node.source[1..-1]
 
-          range = range_between(node.loc.dot.begin_pos, node.loc.expression.end_pos)
+          range = if node.receiver
+                    range_between(node.loc.dot.begin_pos, node.loc.expression.end_pos)
+                  else
+                    corrector.insert_before(node, 'self')
+                    node
+                  end
 
           corrector.replace(range, replacement(method, params))
         end

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
       it_behaves_like 'accepts', 'try! with a method stored as a variable',
                       ['bar = :==',
                        'foo.try!(baz, bar)'].join("\n")
-
-      it 'accepts usages of try! without receiver' do
-        expect_no_offenses('try!(:something)')
-      end
     end
 
     context 'try' do
@@ -118,6 +114,8 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
                       '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
       it_behaves_like 'autocorrect', 'try! with multiple parameters',
                       '[1, 2].try!(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
+      it_behaves_like 'autocorrect', 'try! without receiver',
+                      'try!(:join)', 'self&.join'
       it_behaves_like 'autocorrect', 'try! with a block',
                       ['[foo, bar].try!(:map) do |e|',
                        '  e.some_method',


### PR DESCRIPTION
This PR fixes a false negative for `Rails/SafeNavigation` when using `try!` without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
