### PR TITLE
[Fix #126] Fix an incorrect auto-correct for `Rails/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#147](https://github.com/rubocop/rubocop-rails/issues/147): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying default `dependent: nil` strategy. ([@koic][])
 * [#137](https://github.com/rubocop/rubocop-rails/issues/137): Make `Rails/HasManyOrHasOneDependent` aware of `readonly?` is `true`. ([@koic][])
 * [#474](https://github.com/rubocop/rubocop-rails/pull/474): Fix a false negative for `Rails/SafeNavigation` when using `try!` without receiver. ([@koic][])
+* [#126](https://github.com/rubocop/rubocop-rails/issues/126): Fix an incorrect auto-correct for `Rails/SafeNavigation` with `Style/RedndantSelf`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -47,6 +47,19 @@ module RuboCop
           (send _ ${:try :try!} $_ ...)
         PATTERN
 
+        # Monkey patching for `Style/RedundantSelf` of RuboCop core.
+        # rubocop:disable Style/ClassAndModuleChildren
+        class Style::RedundantSelf
+          def self.autocorrect_incompatible_with
+            [Rails::SafeNavigation]
+          end
+        end
+        # rubocop:enable Style/ClassAndModuleChildren
+
+        def self.autocorrect_incompatible_with
+          [Style::RedundantSelf]
+        end
+
         def on_send(node)
           try_call(node) do |try_method, dispatch|
             return if try_method == :try && !cop_config['ConvertTry']

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'cli spec behavior'
+
+  before do
+    RuboCop::ConfigLoader.default_configuration.for_all_cops['SuggestExtensions'] = false
+  end
+
+  it 'corrects `Rails/SafeNavigation` with `Style/RedndantSelf`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Rails/SafeNavigation:
+        ConvertTry: true
+    YAML
+
+    create_file('example.rb', <<~RUBY)
+      self.try(:bar).try(:baz)
+    RUBY
+
+    expect(cli.run(['-a', '--only', 'Rails/SafeNavigation,Style/RedundantSelf'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      self&.bar&.baz
+    RUBY
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,10 @@ require 'rubocop/rspec/support'
 require_relative 'support/file_helper'
 require_relative 'support/shared_contexts'
 
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories.
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   SimpleCov.start

--- a/spec/support/cli_spec_behavior.rb
+++ b/spec/support/cli_spec_behavior.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'cli spec behavior' do
+  include_context 'mock console output'
+
+  include FileHelper
+
+  def abs(path)
+    File.expand_path(path)
+  end
+
+  before do
+    RuboCop::ConfigLoader.debug = false
+
+    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
+    # .rubocop_cache) is removed afterwards anyway.
+    RuboCop::ResultCache.inhibit_cleanup = true
+  end
+
+  # Wrap all cli specs in `aggregate_failures` so that the expected and
+  # actual results of every expectation per example are shown. This is
+  # helpful because it shows information like expected and actual
+  # $stdout messages while not using `aggregate_failures` will only
+  # show information about expected and actual exit code
+  around { |example| aggregate_failures(&example) }
+
+  after { RuboCop::ResultCache.inhibit_cleanup = false }
+end


### PR DESCRIPTION
Fixes #126.

This PR fixes an incorrect auto-correct for `Rails/SafeNavigation` with `Style/RedndantSelf`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
