### PR TITLE
[Fix #476] Fix a false positive for `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#137](https://github.com/rubocop/rubocop-rails/issues/137): Make `Rails/HasManyOrHasOneDependent` aware of `readonly?` is `true`. ([@koic][])
 * [#474](https://github.com/rubocop/rubocop-rails/pull/474): Fix a false negative for `Rails/SafeNavigation` when using `try!` without receiver. ([@koic][])
 * [#126](https://github.com/rubocop/rubocop-rails/issues/126): Fix an incorrect auto-correct for `Rails/SafeNavigation` with `Style/RedndantSelf`. ([@koic][])
+* [#476](https://github.com/rubocop/rubocop-rails/issues/476): Fix a false positive for `Rails/ReversibleMigration` when using `drop_table` with symbol proc. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -237,7 +237,7 @@ module RuboCop
 
         def check_drop_table_node(node)
           drop_table_call(node) do
-            unless node.parent.block_type?
+            unless node.parent.block_type? || node.last_argument.block_pass_type?
               add_offense(
                 node,
                 message: format(MSG, action: 'drop_table(without block)')

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -101,6 +101,10 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
       end
     RUBY
 
+    it_behaves_like 'accepts', 'drop_table(with symbol proc)', <<~RUBY
+      drop_table :users, &:timestamps
+    RUBY
+
     it_behaves_like 'offense', 'drop_table(without block)', <<~RUBY
       drop_table :users
     RUBY


### PR DESCRIPTION
Fixes #476.

This PR fixes a false positive for `Rails/ReversibleMigratin` when using `drop_table` with symbol proc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
