### PR TITLE
Fix ReversibleMigrationMethodDefinition "Include" case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#478](https://github.com/rubocop/rubocop-rails/pull/478): Fix `Rails/ReversibleMigrationMethodDefinition` cop's `Include`. ([@rhymes][])
+
 ## 2.10.0 (2021-05-05)
 
 ### New features
@@ -371,3 +373,4 @@
 [@olivierbuffon]: https://github.com/olivierbuffon
 [@leonp1991]: https://github.com/leonp1991
 [@drenmi]: https://github.com/drenmi
+[@rhymes]: https://github.com/rhymes

--- a/config/default.yml
+++ b/config/default.yml
@@ -639,7 +639,7 @@ Rails/ReversibleMigrationMethodDefinition:
   Description: 'Checks whether the migration implements either a `change` method or both an `up` and a `down` method.'
   Enabled: false
   VersionAdded: '2.10'
-  include:
+  Include:
     - db/migrate/*.rb
 
 Rails/SafeNavigation:

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3855,7 +3855,7 @@ end
 |===
 | Name | Default value | Configurable values
 
-| include
+| Include
 | `db/migrate/*.rb`
 | Array
 |===


### PR DESCRIPTION
`Include` instead of `include`, otherwise the cop will target all Ruby files

Related to #457 
