### PR TITLE
[Fix #288] Add `AllowToTime` option to `Rails/Date`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#419](https://github.com/rubocop/rubocop-rails/issues/419): Fix an error for `Rails/UniqueValidationWithoutIndex` when using a unique index and `check_constraint` that has `nil` first argument. ([@koic][])
 
+### Changes
+
+* [#288](https://github.com/rubocop/rubocop-rails/issues/288): Add `AllowToTime` option (`true` by default) to `Rails/Date`. ([@koic][])
+
 ## 2.10.1 (2021-05-06)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -193,7 +193,7 @@ Rails/Date:
                   such as Date.today, Date.current etc.
   Enabled: true
   VersionAdded: '0.30'
-  VersionChanged: '0.33'
+  VersionChanged: '2.11'
   # The value `strict` disallows usage of `Date.today`, `Date.current`,
   # `Date#to_time` etc.
   # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
@@ -203,6 +203,7 @@ Rails/Date:
   SupportedStyles:
     - strict
     - flexible
+  AllowToTime: true
 
 Rails/DefaultScope:
   Description: 'Avoid use of `default_scope`.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -884,7 +884,7 @@ end
 | Yes
 | No
 | 0.30
-| 0.33
+| 2.11
 |===
 
 This cop checks for the correct use of Date methods,
@@ -896,13 +896,15 @@ Rails time zone. You must use `Time.zone.today` instead.
 The cop also reports warnings when you are using `to_time` method,
 because it doesn't know about Rails time zone either.
 
-Two styles are supported for this cop. When EnforcedStyle is 'strict'
+Two styles are supported for this cop. When `EnforcedStyle` is 'strict'
 then the Date methods `today`, `current`, `yesterday`, and `tomorrow`
 are prohibited and the usage of both `to_time`
 and 'to_time_in_current_zone' are reported as warning.
 
-When EnforcedStyle is 'flexible' then only `Date.today` is prohibited
-and only `to_time` is reported as warning.
+When `EnforcedStyle` is `flexible` then only `Date.today` is prohibited.
+
+And you can set a warning for `to_time` with `AllowToTime: false`.
+`AllowToTime` is `true` by default to prevent false positive on `DateTime` object.
 
 === Examples
 
@@ -914,7 +916,6 @@ and only `to_time` is reported as warning.
 Date.current
 Date.yesterday
 Date.today
-date.to_time
 
 # good
 Time.zone.today
@@ -927,7 +928,6 @@ Time.zone.today - 1.day
 ----
 # bad
 Date.today
-date.to_time
 
 # good
 Time.zone.today
@@ -935,6 +935,22 @@ Time.zone.today - 1.day
 Date.current
 Date.yesterday
 date.in_time_zone
+----
+
+==== AllowToTime: true (default)
+
+[source,ruby]
+----
+# good
+date.to_time
+----
+
+==== AllowToTime: false
+
+[source,ruby]
+----
+# bad
+date.to_time
 ----
 
 === Configurable attributes
@@ -945,6 +961,10 @@ date.in_time_zone
 | EnforcedStyle
 | `flexible`
 | `strict`, `flexible`
+
+| AllowToTime
+| `true`
+| Boolean
 |===
 
 == Rails/DefaultScope

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe RuboCop::Cop::Rails::Date, :config do
   context 'when EnforcedStyle is "strict"' do
-    let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
+    let(:cop_config) { { 'EnforcedStyle' => 'strict', 'AllowToTime' => allow_to_time } }
+    let(:allow_to_time) { true }
 
     shared_examples 'offense' do |method, message|
       it "registers an offense for #{method}" do
@@ -47,25 +48,29 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
-    %w[to_time to_time_in_current_zone].each do |method|
-      it "registers an offense for ##{method}" do
-        offenses = inspect_source("date.#{method}")
-        expect(offenses.size).to eq(1)
+    context 'when using `to_time_in_current_zone`' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          date.to_time_in_current_zone
+               ^^^^^^^^^^^^^^^^^^^^^^^ `to_time_in_current_zone` is deprecated. Use `in_time_zone` instead.
+        RUBY
       end
 
       context 'when using safe navigation operator' do
-        it "registers an offense for ##{method}" do
-          offenses = inspect_source("date&.#{method}")
-          expect(offenses.size).to eq(1)
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            date&.to_time_in_current_zone
+                  ^^^^^^^^^^^^^^^^^^^^^^^ `to_time_in_current_zone` is deprecated. Use `in_time_zone` instead.
+          RUBY
         end
       end
 
-      it "accepts variable named #{method}" do
-        expect_no_offenses("#{method} = 1")
+      it 'accepts variable named `to_time_in_current_zone`' do
+        expect_no_offenses('to_time_in_current_zone = 1')
       end
 
-      it "accepts variable #{method} as range end" do
-        expect_no_offenses("date..#{method}")
+      it 'accepts variable `to_time_in_current_zone` as range end' do
+        expect_no_offenses('date..to_time_in_current_zone')
       end
     end
 
@@ -81,12 +86,91 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
-    context 'when a string literal without timezone' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          "2016-07-12 14:36:31".to_time(:utc)
-                                ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
-        RUBY
+    context 'when using `to_time`' do
+      context 'when `AllowToTime: true`' do
+        let(:allow_to_time) { true }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            date.to_time
+          RUBY
+        end
+
+        context 'when using safe navigation operator' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              date&.to_time
+            RUBY
+          end
+        end
+
+        it 'accepts variable named `to_time`' do
+          expect_no_offenses('to_time = 1')
+        end
+
+        it 'accepts variable `to_time` as range end' do
+          expect_no_offenses('date..to_time')
+        end
+
+        context 'when a string literal without timezone' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              "2016-07-12 14:36:31".to_time(:utc)
+            RUBY
+          end
+        end
+
+        RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
+          it "does not register an offense for val.to_time.#{a_method}" do
+            expect_no_offenses(<<~RUBY)
+              val.to_time.#{a_method}
+            RUBY
+          end
+        end
+      end
+
+      context 'when `AllowToTime: false`' do
+        let(:allow_to_time) { false }
+
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            date.to_time
+                 ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
+          RUBY
+        end
+
+        context 'when using safe navigation operator' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              date&.to_time
+                    ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
+            RUBY
+          end
+        end
+
+        it 'accepts variable named `to_time`' do
+          expect_no_offenses('to_time = 1')
+        end
+
+        it 'accepts variable `to_time` as range end' do
+          expect_no_offenses('date..to_time')
+        end
+
+        context 'when a string literal without timezone' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              "2016-07-12 14:36:31".to_time(:utc)
+                                    ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
+            RUBY
+          end
+        end
+
+        RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
+          it "registers an offense for val.to_time.#{a_method}" do
+            offenses = inspect_source("val.to_time.#{a_method}")
+            expect(offenses.size).to eq(1)
+          end
+        end
       end
     end
 
@@ -98,13 +182,6 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
 
     it 'does not blow up in the presence of a single constant to inspect' do
       expect_no_offenses('A')
-    end
-
-    RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
-      it "registers an offense for val.to_time.#{a_method}" do
-        offenses = inspect_source("val.to_time.#{a_method}")
-        expect(offenses.size).to eq(1)
-      end
     end
 
     it 'registers an offense for #to_time_in_current_zone' do


### PR DESCRIPTION
Fixes #288.

This PR adds `AllowToTime` option (`true` by default) to `Rails/Date`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
