### PR TITLE
[Fix #70] Fix a false positive for `Rails/TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#482](https://github.com/rubocop/rubocop-rails/pull/482): Fix a false positive for `Rails/RelativeDateConstant` when assigning (hashes/arrays/etc)-containing procs to a constant. ([@jdelStrother][])
 * [#419](https://github.com/rubocop/rubocop-rails/issues/419): Fix an error for `Rails/UniqueValidationWithoutIndex` when using a unique index and `check_constraint` that has `nil` first argument. ([@koic][])
+* [#70](https://github.com/rubocop/rubocop-rails/issues/70): Fix a false positive for `Rails/TimeZone` when setting `EnforcedStyle: strict` and using `Time.current`. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4366,13 +4366,26 @@ This cop checks for the use of Time methods without zone.
 Built on top of Ruby on Rails style guide (https://rails.rubystyle.guide#time)
 and the article http://danilenko.org/2012/7/6/rails_timezones/
 
-Two styles are supported for this cop. When EnforcedStyle is 'strict'
-then only use of Time.zone is allowed.
+Two styles are supported for this cop. When `EnforcedStyle` is 'strict'
+then only use of `Time.zone` is allowed.
 
 When EnforcedStyle is 'flexible' then it's also allowed
-to use Time.in_time_zone.
+to use `Time#in_time_zone`.
 
 === Examples
+
+[source,ruby]
+----
+# bad
+Time.now
+Time.parse('2015-03-02T19:05:37')
+
+# good
+Time.current
+Time.zone.now
+Time.zone.parse('2015-03-02T19:05:37')
+Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone specifier.
+----
 
 ==== EnforcedStyle: strict
 
@@ -4381,17 +4394,7 @@ to use Time.in_time_zone.
 # `strict` means that `Time` should be used with `zone`.
 
 # bad
-Time.now
-Time.parse('2015-03-02T19:05:37')
-
-# bad
-Time.current
 Time.at(timestamp).in_time_zone
-
-# good
-Time.zone.now
-Time.zone.parse('2015-03-02T19:05:37')
-Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone specifier.
 ----
 
 ==== EnforcedStyle: flexible (default)
@@ -4400,16 +4403,7 @@ Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone 
 ----
 # `flexible` allows usage of `in_time_zone` instead of `zone`.
 
-# bad
-Time.now
-Time.parse('2015-03-02T19:05:37')
-
 # good
-Time.zone.now
-Time.zone.parse('2015-03-02T19:05:37')
-
-# good
-Time.current
 Time.at(timestamp).in_time_zone
 ----
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -8,41 +8,33 @@ module RuboCop
       # Built on top of Ruby on Rails style guide (https://rails.rubystyle.guide#time)
       # and the article http://danilenko.org/2012/7/6/rails_timezones/
       #
-      # Two styles are supported for this cop. When EnforcedStyle is 'strict'
-      # then only use of Time.zone is allowed.
+      # Two styles are supported for this cop. When `EnforcedStyle` is 'strict'
+      # then only use of `Time.zone` is allowed.
       #
       # When EnforcedStyle is 'flexible' then it's also allowed
-      # to use Time.in_time_zone.
+      # to use `Time#in_time_zone`.
+      #
+      # @example
+      #   # bad
+      #   Time.now
+      #   Time.parse('2015-03-02T19:05:37')
+      #
+      #   # good
+      #   Time.current
+      #   Time.zone.now
+      #   Time.zone.parse('2015-03-02T19:05:37')
+      #   Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone specifier.
       #
       # @example EnforcedStyle: strict
       #   # `strict` means that `Time` should be used with `zone`.
       #
       #   # bad
-      #   Time.now
-      #   Time.parse('2015-03-02T19:05:37')
-      #
-      #   # bad
-      #   Time.current
       #   Time.at(timestamp).in_time_zone
-      #
-      #   # good
-      #   Time.zone.now
-      #   Time.zone.parse('2015-03-02T19:05:37')
-      #   Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone specifier.
       #
       # @example EnforcedStyle: flexible (default)
       #   # `flexible` allows usage of `in_time_zone` instead of `zone`.
       #
-      #   # bad
-      #   Time.now
-      #   Time.parse('2015-03-02T19:05:37')
-      #
       #   # good
-      #   Time.zone.now
-      #   Time.zone.parse('2015-03-02T19:05:37')
-      #
-      #   # good
-      #   Time.current
       #   Time.at(timestamp).in_time_zone
       class TimeZone < Base
         include ConfigurableEnforcedStyle
@@ -59,7 +51,7 @@ module RuboCop
 
         GOOD_METHODS = %i[zone zone_default find_zone find_zone!].freeze
 
-        DANGEROUS_METHODS = %i[now local new parse at current].freeze
+        DANGEROUS_METHODS = %i[now local new parse at].freeze
 
         ACCEPTED_METHODS = %i[in_time_zone utc getlocal xmlschema iso8601
                               jisx0301 rfc3339 httpdate to_i to_f].freeze

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -11,13 +11,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       RUBY
     end
 
-    it 'registers an offense for Time.current' do
-      expect_offense(<<~RUBY)
-        Time.current
-             ^^^^^^^ Do not use `Time.current` without zone. Use `Time.zone.now` instead.
-      RUBY
-    end
-
     it 'registers an offense for Time.new without argument' do
       expect_offense(<<~RUBY)
         Time.new
@@ -104,19 +97,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
           RUBY
         end
       end
-
-      describe '.current' do
-        it 'corrects the error' do
-          expect_offense(<<~RUBY)
-            Time.current
-                 ^^^^^^^ Do not use `Time.current` without zone. Use `Time.zone.now` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            Time.zone.now
-          RUBY
-        end
-      end
     end
 
     it 'registers an offense for Time.parse' do
@@ -176,6 +156,12 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       expect_offense(<<~RUBY)
         return Foo, Time.parse("2012-03-02 16:05:37")
                          ^^^^^ Do not use `Time.parse` without zone. Use `Time.zone.parse` instead.
+      RUBY
+    end
+
+    it 'accepts Time.current' do
+      expect_no_offenses(<<~RUBY)
+        Time.current
       RUBY
     end
 


### PR DESCRIPTION
Fixes #70.

This PR fixes a false positive for `Rails/TimeZone` when setting `EnforcedStyle: strict` and using `Time.current`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
