### PR TITLE
[Fix #488] Fix a false positive for `Rails/ReversibleMigrationMethodDefinition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#482](https://github.com/rubocop/rubocop-rails/pull/482): Fix a false positive for `Rails/RelativeDateConstant` when assigning (hashes/arrays/etc)-containing procs to a constant. ([@jdelStrother][])
 * [#419](https://github.com/rubocop/rubocop-rails/issues/419): Fix an error for `Rails/UniqueValidationWithoutIndex` when using a unique index and `check_constraint` that has `nil` first argument. ([@koic][])
 * [#70](https://github.com/rubocop/rubocop-rails/issues/70): Fix a false positive for `Rails/TimeZone` when setting `EnforcedStyle: strict` and using `Time.current`. ([@koic][])
+* [#488](https://github.com/rubocop/rubocop-rails/issues/488): Fix a false positive for `Rails/ReversibleMigrationMethodDefinition` when using cbase migration class. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
+++ b/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
@@ -50,7 +50,7 @@ module RuboCop
           (class
             (const nil? _)
             (send
-              (const (const nil? :ActiveRecord) :Migration)
+              (const (const {nil? cbase} :ActiveRecord) :Migration)
               :[]
               (float _))
             _)

--- a/spec/rubocop/cop/rails/reversible_migration_method_definition_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_method_definition_spec.rb
@@ -96,4 +96,14 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigrationMethodDefinition, :config
       end
     RUBY
   end
+
+  it 'does not register offenses correctly with any cbase migration class' do
+    expect_no_offenses(<<~RUBY)
+      class SomeMigration < ::ActiveRecord::Migration[5.2]
+        def change
+          add_column :users, :email, :text, null: false
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #488.

This PR fixes a false positive for `Rails/ReversibleMigrationMethodDefinition` when using cbase migration class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
