### PR TITLE
[Fix #490] Make `Rails/HttpStatus` aware of `head` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#486](https://github.com/rubocop/rubocop-rails/issues/486): Add new `Rails/ExpandedDateRange` cop. ([@koic][])
 * [#494](https://github.com/rubocop/rubocop-rails/pull/494): Add new `Rails/UnusedIgnoredColumns` cop. ([@pocke][])
+* [#490](https://github.com/rubocop/rubocop-rails/issues/490): Make `Rails/HttpStatus` aware of `head` method. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -368,6 +368,7 @@ Rails/HttpStatus:
   Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
   Enabled: true
   VersionAdded: '0.54'
+  VersionChanged: '2.11'
   EnforcedStyle: symbolic
   SupportedStyles:
     - numeric

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1861,7 +1861,7 @@ get :new, **options
 | Yes
 | Yes
 | 0.54
-| -
+| 2.11
 |===
 
 Enforces use of symbolic or numeric value to define HTTP status.
@@ -1877,12 +1877,14 @@ render :foo, status: 200
 render json: { foo: 'bar' }, status: 200
 render plain: 'foo/bar', status: 304
 redirect_to root_url, status: 301
+head 200
 
 # good
 render :foo, status: :ok
 render json: { foo: 'bar' }, status: :ok
 render plain: 'foo/bar', status: :not_modified
 redirect_to root_url, status: :moved_permanently
+head :ok
 ----
 
 ==== EnforcedStyle: numeric
@@ -1894,12 +1896,14 @@ render :foo, status: :ok
 render json: { foo: 'bar' }, status: :not_found
 render plain: 'foo/bar', status: :not_modified
 redirect_to root_url, status: :moved_permanently
+head :ok
 
 # good
 render :foo, status: 200
 render json: { foo: 'bar' }, status: 404
 render plain: 'foo/bar', status: 304
 redirect_to root_url, status: 301
+head 200
 ----
 
 === Configurable attributes

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
                                              ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
                                                                           ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
+        head 200
+             ^^^ Prefer `:ok` over `200` to define HTTP status code.
+        head 200, location: 'accounts'
+             ^^^ Prefer `:ok` over `200` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -30,6 +34,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: :moved_permanently
         redirect_to action: 'index', status: :moved_permanently
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
+        head :ok
+        head :ok, location: 'accounts'
       RUBY
     end
 
@@ -40,6 +46,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         render plain: 'foo/bar', status: :not_modified
         redirect_to root_url, status: :moved_permanently
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
+        head :ok
       RUBY
     end
 
@@ -50,6 +57,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         render plain: 'foo/bar', status: 550
         redirect_to root_url, status: 550
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 550
+        head 550
       RUBY
     end
   end
@@ -73,6 +81,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
                                              ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
                                                                           ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
+        head :ok
+             ^^^ Prefer `200` over `:ok` to define HTTP status code.
+        head :ok, location: 'accounts'
+             ^^^ Prefer `200` over `:ok` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -83,6 +95,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 301
         redirect_to action: 'index', status: 301
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
+        head 200
+        head 200, location: 'accounts'
       RUBY
     end
 
@@ -93,6 +107,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         render plain: 'foo/bar', status: 304
         redirect_to root_url, status: 301
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
+        head 200
       RUBY
     end
 


### PR DESCRIPTION
Fixes #490.

This PR makes `Rails/HttpStatus` aware of `head` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
