### PR TITLE
Fix a false positive for `Rails/DynamicFindBy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#419](https://github.com/rubocop/rubocop-rails/issues/419): Fix an error for `Rails/UniqueValidationWithoutIndex` when using a unique index and `check_constraint` that has `nil` first argument. ([@koic][])
 * [#70](https://github.com/rubocop/rubocop-rails/issues/70): Fix a false positive for `Rails/TimeZone` when setting `EnforcedStyle: strict` and using `Time.current`. ([@koic][])
 * [#488](https://github.com/rubocop/rubocop-rails/issues/488): Fix a false positive for `Rails/ReversibleMigrationMethodDefinition` when using cbase migration class. ([@koic][])
+* [#500](https://github.com/rubocop/rubocop-rails/issues/500): Fix a false positive for `Rails/DynamicFindBy` when using dynamic finder with hash argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -37,6 +37,7 @@ module RuboCop
 
         MSG = 'Use `%<static_name>s` instead of dynamic `%<method>s`.'
         METHOD_PATTERN = /^find_by_(.+?)(!)?$/.freeze
+        IGNORED_ARGUMENT_TYPES = %i[hash splat].freeze
 
         def on_send(node)
           return if node.receiver.nil? && !inherit_active_record_base?(node) || allowed_invocation?(node)
@@ -44,7 +45,7 @@ module RuboCop
           method_name = node.method_name
           static_name = static_method_name(method_name)
           return unless static_name
-          return if node.arguments.any?(&:splat_type?)
+          return if node.arguments.any? { |argument| IGNORED_ARGUMENT_TYPES.include?(argument.type) }
 
           message = format(MSG, static_name: static_name, method: method_name)
           add_offense(node, message: message) do |corrector|

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe RuboCop::Cop::Rails::DynamicFindBy, :config do
     expect_no_offenses('User.find_by_foo_and_bar(arg, *args)')
   end
 
+  it 'accepts dynamic finder with single hash argument' do
+    expect_no_offenses('Post.find_by_id(limit: 1)')
+  end
+
+  it 'accepts dynamic finder with multiple arguments including hash' do
+    expect_no_offenses('Post.find_by_title_and_id("foo", limit: 1)')
+  end
+
   it 'accepts method in whitelist' do
     expect_no_offenses(<<~RUBY)
       User.find_by_sql(["select * from users where name = ?", name])


### PR DESCRIPTION
This PR fixes a false positive for `Rails/DynamicFindBy` when using dynamic finder with hash.

It prevents the following incorrect auto-correction (syntax error).

```diff
 def test_find_by_id_with_hash
   assert_nothing_raised do
-    Post.find_by_id(limit: 1)
+    Post.find_by(id: limit: 1)
   end
 end

 def test_find_by_title_and_id_with_hash
   assert_nothing_raised do
-    Post.find_by_title_and_id("foo", limit: 1)
+    Post.find_by(title: 'foo', id: limit: 1)
   end
 end
```

Refer https://github.com/rails/rails/pull/25671

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
