### PR TITLE
[Fix #499] Add `IgnoreWhereFirst` to `Rails/FindBy` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changes
 
 * [#288](https://github.com/rubocop/rubocop-rails/issues/288): Add `AllowToTime` option (`true` by default) to `Rails/Date`. ([@koic][])
+* [#499](https://github.com/rubocop/rubocop-rails/issues/499): Add `IgnoreWhereFirst` option (`true` by default) to `Rails/FindBy`. ([@koic][])
 
 ## 2.10.1 (2021-05-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -307,6 +307,8 @@ Rails/FindBy:
   StyleGuide: 'https://rails.rubystyle.guide#find_by'
   Enabled: true
   VersionAdded: '0.30'
+  VersionChanged: '2.11'
+  IgnoreWhereFirst: true
   Include:
     - app/models/**/*.rb
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1540,28 +1540,51 @@ Rails.root.join('app/models/goober')
 | Yes
 | Yes
 | 0.30
-| -
+| 2.11
 |===
 
-This cop is used to identify usages of `where.first` and
-change them to use `find_by` instead.
+This cop is used to identify usages of `where.take` and change them to use `find_by` instead.
+
+And `where(...).first` can return different results from `find_by`.
+(They order records differently, so the "first" record can be different.)
+
+If you also want to detect `where.first`, you can set `IgnoreWhereFirst` to false.
 
 === Examples
 
 [source,ruby]
 ----
 # bad
-User.where(name: 'Bruce').first
 User.where(name: 'Bruce').take
 
 # good
 User.find_by(name: 'Bruce')
 ----
 
+==== IgnoreWhereFirst: true (default)
+
+[source,ruby]
+----
+# good
+User.where(name: 'Bruce').first
+----
+
+==== IgnoreWhereFirst: false
+
+[source,ruby]
+----
+# bad
+User.where(name: 'Bruce').first
+----
+
 === Configurable attributes
 
 |===
 | Name | Default value | Configurable values
+
+| IgnoreWhereFirst
+| `true`
+| Boolean
 
 | Include
 | `app/models/**/*.rb`

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -3,16 +3,27 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop is used to identify usages of `where.first` and
-      # change them to use `find_by` instead.
+      # This cop is used to identify usages of `where.take` and change them to use `find_by` instead.
+      #
+      # And `where(...).first` can return different results from `find_by`.
+      # (They order records differently, so the "first" record can be different.)
+      #
+      # If you also want to detect `where.first`, you can set `IgnoreWhereFirst` to false.
       #
       # @example
       #   # bad
-      #   User.where(name: 'Bruce').first
       #   User.where(name: 'Bruce').take
       #
       #   # good
       #   User.find_by(name: 'Bruce')
+      #
+      # @example IgnoreWhereFirst: true (default)
+      #   # good
+      #   User.where(name: 'Bruce').first
+      #
+      # @example IgnoreWhereFirst: false
+      #   # bad
+      #   User.where(name: 'Bruce').first
       class FindBy < Base
         include RangeHelp
         extend AutoCorrector
@@ -20,12 +31,8 @@ module RuboCop
         MSG = 'Use `find_by` instead of `where.%<method>s`.'
         RESTRICT_ON_SEND = %i[first take].freeze
 
-        def_node_matcher :where_first?, <<~PATTERN
-          (send ({send csend} _ :where ...) {:first :take})
-        PATTERN
-
         def on_send(node)
-          return unless where_first?(node)
+          return if ignore_where_first? && node.method?(:first)
 
           range = range_between(node.receiver.loc.selector.begin_pos, node.loc.selector.end_pos)
 
@@ -38,9 +45,6 @@ module RuboCop
         private
 
         def autocorrect(corrector, node)
-          # Don't autocorrect where(...).first, because it can return different
-          # results from find_by. (They order records differently, so the
-          # 'first' record can be different.)
           return if node.method?(:first)
 
           where_loc = node.receiver.loc.selector
@@ -48,6 +52,10 @@ module RuboCop
 
           corrector.replace(where_loc, 'find_by')
           corrector.replace(first_loc, '')
+        end
+
+        def ignore_where_first?
+          cop_config.fetch('IgnoreWhereFirst', true)
         end
       end
     end

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -1,16 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
-  it 'registers an offense when using `#first` and does not auto-correct' do
-    expect_offense(<<~RUBY)
-      User.where(id: x).first
-           ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.first`.
-    RUBY
-
-    expect_no_corrections
-  end
-
-  it 'registers an offense when using `#take`' do
+  it 'registers and corrects an offense when using `#take`' do
     expect_offense(<<~RUBY)
       User.where(id: x).take
            ^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.take`.
@@ -21,28 +12,47 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
     RUBY
   end
 
+  context 'when using safe navigation operator' do
+    it 'registers an offense when using `#take`' do
+      expect_offense(<<~RUBY)
+        users&.where(id: x).take
+               ^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.take`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        users&.find_by(id: x)
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using find_by' do
     expect_no_offenses('User.find_by(id: x)')
   end
 
-  it 'autocorrects where.take to find_by' do
-    new_source = autocorrect_source('User.where(id: x).take')
+  context 'when `IgnoreWhereFirst: true' do
+    let(:cop_config) do
+      { 'IgnoreWhereFirst' => true }
+    end
 
-    expect(new_source).to eq('User.find_by(id: x)')
-  end
-
-  it 'does not autocorrect where.first' do
-    new_source = autocorrect_source('User.where(id: x).first')
-
-    expect(new_source).to eq('User.where(id: x).first')
-  end
-
-  context 'when using safe navigation operator' do
-    it 'registers an offense when using `#first`' do
-      expect_offense(<<~RUBY)
-        User&.where(id: x).first
-              ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.first`.
+    it 'does not register an offense when using `#first`' do
+      expect_no_offenses(<<~RUBY)
+        User.where(id: x).first
       RUBY
+    end
+  end
+
+  context 'when `IgnoreWhereFirst: false' do
+    let(:cop_config) do
+      { 'IgnoreWhereFirst' => false }
+    end
+
+    it 'registers an offense when using `#first` and does not auto-correct' do
+      expect_offense(<<~RUBY)
+        User.where(id: x).first
+             ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.first`.
+      RUBY
+
+      expect_no_corrections
     end
   end
 end


### PR DESCRIPTION
Fixes #499.

This PR add `IgnoreWhereFirst` option (`true` by default) to `Rails/FindBy` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
