### PR TITLE
Set disabled by default for `Rails/EnvironmentVariableAccess`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * [#288](https://github.com/rubocop/rubocop-rails/issues/288): Add `AllowToTime` option (`true` by default) to `Rails/Date`. ([@koic][])
 * [#499](https://github.com/rubocop/rubocop-rails/issues/499): Add `IgnoreWhereFirst` option (`true` by default) to `Rails/FindBy`. ([@koic][])
+* [#505](https://github.com/rubocop/rubocop-rails/pull/505): Set disabled by default for `Rails/EnvironmentVariableAccess`. ([@koic][])
 
 ## 2.10.1 (2021-05-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -269,8 +269,10 @@ Rails/EnvironmentComparison:
 
 Rails/EnvironmentVariableAccess:
   Description: 'Do not access `ENV` directly after initialization.'
-  Enabled: pending
+  # TODO: Set to `pending` status in RuboCop Rails 2 series when migration doc will be written.
+  Enabled: false
   VersionAdded: '2.10'
+  VersionChanged: '2.11'
   Include:
     - app/**/*.rb
     - lib/**/*.rb

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1348,11 +1348,11 @@ Rails.env.production?
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Disabled
 | Yes
 | No
 | 2.10
-| -
+| 2.11
 |===
 
 This cop looks for direct access to environment variables through the


### PR DESCRIPTION
This PR sets disabled by default for `Rails/EnvironmentVariableAccess`.
The default status will be set to `pending` again when migration doc is written.
https://github.com/rubocop/rubocop-rails/pull/442#issuecomment-835790239

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
