### PR TITLE
[Fix #504] Rails/FindBy being wrongly triggered on non Active Record methods

### DIFF
--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -32,8 +32,9 @@ module RuboCop
         RESTRICT_ON_SEND = %i[first take].freeze
 
         def on_send(node)
-          return unless (receiver = node.receiver)
-          return if receiver.block_type? || ignore_where_first? && node.method?(:first)
+          receiver = node.receiver
+          return unless receiver&.method?(:where)
+          return if ignore_where_first? && node.method?(:first)
 
           range = range_between(node.receiver.loc.selector.begin_pos, node.loc.selector.end_pos)
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -67,4 +67,24 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
       expect_no_corrections
     end
   end
+
+  context 'when receiver is not an Active Record' do
+    context 'when method is Array#take' do
+      it 'does not register an offence' do
+        expect_no_offenses(<<~RUBY)
+          array = Array.new(1) { rand }
+          array.compact.take
+        RUBY
+      end
+    end
+
+    context 'when method is Array#first' do
+      it 'does not register an offence' do
+        expect_no_offenses(<<~RUBY)
+          array = Array.new(1) { rand }
+          array.compact.first
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes - https://github.com/rubocop/rubocop-rails/issues/504
If I'm not mistaken the https://github.com/rubocop/rubocop-rails/pull/502 PR removed an important part of the `Rails/FindBy` cop which was checking for a presence of `where()` method call in the method chain.

Without this check the cop tries to autocorrect an offence for regular enumerable `first` and `take` methods

This PR basically brings the check back with a bit different name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
