### PR TITLE
Fix an error for `Rails/FindBy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#507](https://github.com/rubocop/rubocop-rails/pull/507): Fix an error for `Rails/FindBy` when calling `take` after block. ([@koic][])
+
 ## 2.11.0 (2021-06-21)
 
 ### New features

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -32,7 +32,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[first take].freeze
 
         def on_send(node)
-          return if ignore_where_first? && node.method?(:first)
+          return if node.receiver.block_type? || ignore_where_first? && node.method?(:first)
 
           range = range_between(node.receiver.loc.selector.begin_pos, node.loc.selector.end_pos)
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
     expect_no_offenses('User.find_by(id: x)')
   end
 
+  it 'does not register an offense when calling `take` after block' do
+    expect_no_offenses(<<~RUBY)
+      do_something {}.take(5)
+    RUBY
+  end
+
   context 'when `IgnoreWhereFirst: true' do
     let(:cop_config) do
       { 'IgnoreWhereFirst' => true }


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-rails/pull/506#issuecomment-865651860.

This PR fixes an error for `Rails/FindBy` when calling `take` after block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
