### PR TITLE
Fix an error for `Rails/ReflectionClassName` when using `class_name: to_s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#509](https://github.com/rubocop/rubocop-rails/pull/509): Fix an error for `Rails/ReflectionClassName` when using `class_name: to_s`. ([@skryukov][])
 * [#507](https://github.com/rubocop/rubocop-rails/pull/507): Fix an error for `Rails/FindBy` when calling `take` after block. ([@koic][])
 * [#504](https://github.com/rubocop/rubocop-rails/issues/504): Fix a false positive for `Rails/FindBy` when receiver is not an Active Record. ([@nvasilevski][])
 
@@ -411,3 +412,4 @@
 [@jdelStrother]: https://github.com/jdelStrother
 [@aesthetikx]: https://github.com/aesthetikx
 [@nvasilevski]: https://github.com/nvasilevski
+[@skryukov]: https://github.com/skryukov

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def reflection_class_value?(class_value)
           if class_value.send_type?
-            !class_value.method?(:to_s) || class_value.receiver.const_type?
+            !class_value.method?(:to_s) || class_value.receiver&.const_type?
           else
             !ALLOWED_REFLECTION_CLASS_TYPES.include?(class_value.type)
           end

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `class_name: to_s`' do
+    expect_no_offenses(<<~'RUBY')
+      has_many :accounts, class_name: to_s
+    RUBY
+  end
+
   it 'does not register an offense when using `foreign_key :account_id`' do
     expect_no_offenses(<<~RUBY)
       has_many :accounts, class_name: 'Account', foreign_key: :account_id


### PR DESCRIPTION
This PR fixes bug introduced in https://github.com/rubocop/rubocop-rails/pull/471.

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
