### PR TITLE
Fix an error for `Rails/FindBy` when calling `#first` or `#take` on a `Range` object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#509](https://github.com/rubocop/rubocop-rails/pull/509): Fix an error for `Rails/ReflectionClassName` when using `class_name: to_s`. ([@skryukov][])
+* [#510](https://github.com/rubocop/rubocop-rails/pull/510): Fix an error for `Rails/FindBy` when calling `#first` or `#take` on a `Range` object. ([@johnsyweb][])
 * [#507](https://github.com/rubocop/rubocop-rails/pull/507): Fix an error for `Rails/FindBy` when calling `take` after block. ([@koic][])
 * [#504](https://github.com/rubocop/rubocop-rails/issues/504): Fix a false positive for `Rails/FindBy` when receiver is not an Active Record. ([@nvasilevski][])
 
@@ -413,3 +414,4 @@
 [@aesthetikx]: https://github.com/aesthetikx
 [@nvasilevski]: https://github.com/nvasilevski
 [@skryukov]: https://github.com/skryukov
+[@johnsyweb]: https://github.com/johnsyweb

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -32,8 +32,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[first take].freeze
 
         def on_send(node)
-          receiver = node.receiver
-          return unless receiver&.method?(:where)
+          return unless where_method?(node.receiver)
           return if ignore_where_first? && node.method?(:first)
 
           range = range_between(node.receiver.loc.selector.begin_pos, node.loc.selector.end_pos)
@@ -45,6 +44,12 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def where_method?(receiver)
+          return false unless receiver
+
+          receiver.respond_to?(:method?) && receiver.method?(:where)
+        end
 
         def autocorrect(corrector, node)
           return if node.method?(:first)

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -92,5 +92,17 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
         RUBY
       end
     end
+
+    context 'when method is Range#first' do
+      it 'does not register an offense' do
+        expect_no_offenses('(1..2).first')
+      end
+    end
+
+    context 'when method is Range#take' do
+      it 'does not register an offense' do
+        expect_no_offenses('(1..2).take(1)')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Upgrading rubocop-rails from 2.10.1 to 2.11.0 caused the following crash:

```
An error occurred while Rails/FindBy cop was inspecting /Users/paj/src/sso-server/app/models/username_suggestor.rb:63:6.
For /Users/paj/src/sso-server: configuration from /Users/paj/src/sso-server/.rubocop.yml
configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.11.3/config/default.yml
configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.11.3/config/default.yml
Default configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/config/default.yml
configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-rails-2.11.0/config/default.yml
configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-rails-2.11.0/config/default.yml
configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-rspec-2.4.0/config/default.yml
configuration from /Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-rspec-2.4.0/config/default.yml
Inheriting configuration from /Users/paj/src/sso-server/.rubocop_todo.yml
Inspecting 1 file
Scanning /Users/paj/src/sso-server/app/models/username_suggestor.rb
undefined method `selector' for #<Parser::Source::Map::Collection:0x00007fe771ac68d0>
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-rails-2.11.0/lib/rubocop/cop/rails/find_by.rb:37:in `on_send'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:136:in `public_send'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:136:in `block (2 levels) in trigger_restricted_cops'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:160:in `with_cop_error_handling'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:135:in `block in trigger_restricted_cops'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:134:in `each'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:134:in `trigger_restricted_cops'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:70:in `on_send'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:159:in `block in on_send'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:156:in `each'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:156:in `each_with_index'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:156:in `on_send'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:71:in `on_send'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:137:in `block in on_dstr'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:137:in `each'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:137:in `on_dstr'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:71:in `on_begin'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:154:in `on_def'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:71:in `on_def'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:137:in `block in on_dstr'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:137:in `each'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:137:in `on_dstr'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:71:in `on_begin'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:138:in `on_while'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:71:in `on_sclass'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:154:in `on_class'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:71:in `on_class'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.7.0/lib/rubocop/ast/traversal.rb:20:in `walk'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/commissioner.rb:86:in `investigate'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/team.rb:155:in `investigate_partial'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cop/team.rb:83:in `investigate'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:310:in `inspect_file'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:254:in `block in do_inspection_loop'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:288:in `block in iterate_until_no_changes'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:281:in `loop'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:281:in `iterate_until_no_changes'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:250:in `do_inspection_loop'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:130:in `block in file_offenses'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:155:in `file_offense_cache'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:129:in `file_offenses'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:120:in `process_file'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:101:in `block in each_inspected_file'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:100:in `each'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:100:in `reduce'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:100:in `each_inspected_file'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:86:in `inspect_files'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/runner.rb:47:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli/command.rb:11:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli/environment.rb:18:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli.rb:65:in `run_command'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli.rb:72:in `execute_runners'
1 error occurred:
An error occurred while Rails/FindBy cop was inspecting /Users/paj/src/sso-server/app/models/username_suggestor.rb:63:6.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.17.0 (using Parser 3.0.1.1, rubocop-ast 1.7.0, running on ruby 2.7.3 x86_64-darwin19)

/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/lib/rubocop/cli.rb:41:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/exe/rubocop:12:in `block in <top (required)>'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rubocop-1.17.0/exe/rubocop:12:in `<top (required)>'
/Users/paj/.asdf/installs/ruby/2.7.3/bin/rubocop:23:in `load'
/Users/paj/.asdf/installs/ruby/2.7.3/bin/rubocop:23:in `<top (required)>'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli/exec.rb:63:in `load'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli/exec.rb:63:in `kernel_load'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli/exec.rb:28:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:474:in `exec'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:30:in `dispatch'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:24:in `start'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/exe/bundle:49:in `block in <top (required)>'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
/Users/paj/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/exe/bundle:37:in `<top (required)>'
/Users/paj/.asdf/installs/ruby/2.7.3/bin/bundle:23:in `load'
/Users/paj/.asdf/installs/ruby/2.7.3/bin/bundle:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.6480320000555366 seconds
```

## Change

- Minimal working example
- Fix failing spec
- Extract #active_record?
- Add spec for Range#first

## Confirmation

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
