### PR TITLE
[Fix #512] Fix a false positive for `Rails/FindBy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#515](https://github.com/rubocop/rubocop-rails/issues/515): Fix an error for `Rails/BulkChangeTable` when using Psych 4.0. ([@koic][])
+* [#512](https://github.com/rubocop/rubocop-rails/issues/512): Fix a false positive for `Rails/FindBy` when using `take` with arguments. ([@koic][])
 
 ## 2.11.1 (2021-06-25)
 

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -32,10 +32,10 @@ module RuboCop
         RESTRICT_ON_SEND = %i[first take].freeze
 
         def on_send(node)
-          return unless where_method?(node.receiver)
+          return unless node.arguments.empty? && where_method?(node.receiver)
           return if ignore_where_first? && node.method?(:first)
 
-          range = range_between(node.receiver.loc.selector.begin_pos, node.loc.selector.end_pos)
+          range = offense_range(node)
 
           add_offense(range, message: format(MSG, method: node.method_name)) do |corrector|
             autocorrect(corrector, node)
@@ -49,6 +49,10 @@ module RuboCop
           return false unless receiver
 
           receiver.respond_to?(:method?) && receiver.method?(:where)
+        end
+
+        def offense_range(node)
+          range_between(node.receiver.loc.selector.begin_pos, node.loc.selector.end_pos)
         end
 
         def autocorrect(corrector, node)

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `take` with arguments' do
+    expect_no_offenses(<<~RUBY)
+      User.where(attr: arg).take(5)
+    RUBY
+  end
+
   it 'does not register an offense when calling `take` after block' do
     expect_no_offenses(<<~RUBY)
       do_something {}.take(5)
@@ -71,6 +77,12 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
       RUBY
 
       expect_no_corrections
+    end
+
+    it 'does not register an offense when using `first` with arguments' do
+      expect_no_offenses(<<~RUBY)
+        User.where(attr: arg).first(5)
+      RUBY
     end
   end
 


### PR DESCRIPTION
Fix #512

This PR fixes a false positive for `Rails/FindBy` when using `take` with arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
