### PR TITLE
[Fix #515] Fix an error for `Rails/BulkChangeTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#515](https://github.com/rubocop/rubocop-rails/issues/515): Fix an error for `Rails/BulkChangeTable` when using Psych 4.0. ([@koic][])
+
 ## 2.11.1 (2021-06-25)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -194,7 +194,11 @@ module RuboCop
         def database_yaml
           return nil unless File.exist?('config/database.yml')
 
-          yaml = YAML.load_file('config/database.yml')
+          yaml = if YAML.respond_to?(:unsafe_load_file)
+                   YAML.unsafe_load_file('config/database.yml')
+                 else
+                   YAML.load_file('config/database.yml')
+                 end
           return nil unless yaml.is_a? Hash
 
           config = yaml['development']

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -414,12 +414,12 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
     let(:yaml) { nil }
 
     before do
-      allow(File).to receive(:exist?)
-        .with('config/database.yml')
-        .and_return(true)
-      allow(YAML).to receive(:load_file)
-        .with('config/database.yml')
-        .and_return(yaml)
+      allow(File).to receive(:exist?).with('config/database.yml').and_return(true)
+      if YAML.respond_to?(:unsafe_load_file)
+        allow(YAML).to receive(:unsafe_load_file).with('config/database.yml').and_return(yaml)
+      else
+        allow(YAML).to receive(:load_file).with('config/database.yml').and_return(yaml)
+      end
     end
 
     context 'mysql2' do


### PR DESCRIPTION
Fixes #515
Follow up https://github.com/ruby/psych/pull/487 and https://github.com/rails/rails/commit/255b5ff

This PR fixes an error for `Rails/BulkChangeTable` when using Psych 4.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
