### PR TITLE
Fix `UniqueValidationWithoutIndex` cop when validating uniqueness on a polymorphic relation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#517](https://github.com/rubocop/rubocop-rails/pull/517): Fix an issue for `Rails/UniqueValidationWithoutIndex` when validating uniqueness with a polymorphic scope. ([@theunraveler][])
+
 ## 2.11.2 (2021-07-02)
 
 ### Bug fixes
@@ -424,3 +428,4 @@
 [@nvasilevski]: https://github.com/nvasilevski
 [@skryukov]: https://github.com/skryukov
 [@johnsyweb]: https://github.com/johnsyweb
+[@theunraveler]: https://github.com/theunraveler

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -81,7 +81,7 @@ module RuboCop
           names_from_scope = column_names_from_scope(node)
           ret.concat(names_from_scope) if names_from_scope
 
-          ret.map! do |name|
+          ret = ret.flat_map do |name|
             klass = class_node(node)
             resolve_relation_into_column(
               name: name.to_s,


### PR DESCRIPTION
This PR fixes the `UniqueValidationWithoutIndex` cop when the `scope` of the uniqueness constraint is a polymorphic association. The issue detailed in https://github.com/rubocop/rubocop-rails/issues/231#issuecomment-660521974.

Thanks!