### PR TITLE
Support auto-correction for `Rails/ScopeArgs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#521](https://github.com/rubocop/rubocop-rails/pull/521): Support auto-correction for `Rails/Output`. ([@koic][])
+* [#520](https://github.com/rubocop/rubocop-rails/pull/520): Support auto-correction for `Rails/ScopeArgs`. ([@koic][])
 
 ## 2.11.3 (2021-07-11)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -714,6 +714,7 @@ Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: true
   VersionAdded: '0.19'
+  VersionChanged: '2.12'
   Include:
     - app/models/**/*.rb
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4300,9 +4300,9 @@ Service::Mailer::update
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.19
-| -
+| 2.12
 |===
 
 This cop checks for scope calls where it was passed

--- a/lib/rubocop/cop/rails/scope_args.rb
+++ b/lib/rubocop/cop/rails/scope_args.rb
@@ -14,6 +14,8 @@ module RuboCop
       #   # good
       #   scope :something, -> { where(something: true) }
       class ScopeArgs < Base
+        extend AutoCorrector
+
         MSG = 'Use `lambda`/`proc` instead of a plain method call.'
         RESTRICT_ON_SEND = %i[scope].freeze
 
@@ -21,7 +23,9 @@ module RuboCop
 
         def on_send(node)
           scope?(node) do |second_arg|
-            add_offense(second_arg)
+            add_offense(second_arg) do |corrector|
+              corrector.replace(second_arg, "-> { #{second_arg.source} }")
+            end
           end
         end
       end

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ScopeArgs, :config do
-  it 'registers an offense a scope with a method arg' do
+  it 'registers and corrects an offense a scope with a method arg' do
     expect_offense(<<~RUBY)
       scope :active, where(active: true)
                      ^^^^^^^^^^^^^^^^^^^ Use `lambda`/`proc` instead of a plain method call.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      scope :active, -> { where(active: true) }
     RUBY
   end
 


### PR DESCRIPTION
This PR supports auto-correction for `Rails/ScopeArgs`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
