### PR TITLE
Support auto-correction for `Rails/Output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#521](https://github.com/rubocop/rubocop-rails/pull/521): Support auto-correction for `Rails/Output`. ([@koic][])
+
 ## 2.11.3 (2021-07-11)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -499,6 +499,7 @@ Rails/OrderById:
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.15'
   VersionChanged: '0.19'
   Include:

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -2747,7 +2747,7 @@ scope :chronological, -> { order(created_at: :asc) }
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 0.15
 | 0.19
 |===

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -1,22 +1,80 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::Output, :config do
-  it 'registers an offense for methods without a receiver' do
+  it 'registers and corrects an offense for using `p` method without a receiver' do
     expect_offense(<<~RUBY)
       p "edmond dantes"
       ^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "edmond dantes"
+    RUBY
+  end
+
+  it 'registers and corrects an offense for using `puts` method without a receiver' do
+    expect_offense(<<~RUBY)
       puts "sinbad"
       ^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "sinbad"
+    RUBY
+  end
+
+  it 'registers and corrects an offense for using `print` method without a receiver' do
+    expect_offense(<<~RUBY)
       print "abbe busoni"
       ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "abbe busoni"
+    RUBY
+  end
+
+  it 'registers and corrects an offense for using `pp` method without a receiver' do
+    expect_offense(<<~RUBY)
       pp "monte cristo"
       ^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "monte cristo"
+    RUBY
+  end
+
+  it 'registers and corrects an offense for using `$stdout` method without a receiver' do
+    expect_offense(<<~RUBY)
       $stdout.write "lord wilmore"
-              ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+      ^^^^^^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "lord wilmore"
+    RUBY
+  end
+
+  it 'registers and corrects an offense for using `syswrite` method without a receiver' do
+    expect_offense(<<~RUBY)
       $stderr.syswrite "faria"
-              ^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+      ^^^^^^^^^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "faria"
+    RUBY
+  end
+
+  it 'registers and corrects an offense for using `write` method without a receiver' do
+    expect_offense(<<~RUBY)
       STDOUT.write "bertuccio"
-             ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+      ^^^^^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug "bertuccio"
     RUBY
   end
 


### PR DESCRIPTION
This PR supports auto-correction for `Rails/Output`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
