### PR TITLE
[Fix #260] Fix target of `Rails/ContentTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#520](https://github.com/rubocop/rubocop-rails/pull/520): Support auto-correction for `Rails/ScopeArgs`. ([@koic][])
 * [#524](https://github.com/rubocop/rubocop-rails/pull/524): Add new `Rails/RedundantTravelBack` cop. ([@koic][])
 
+## Changes
+
+* [#260](https://github.com/rubocop/rubocop-rails/issues/260): Change target of `Rails/ContentTag` from `content_tag` method to `tag` method. ([@tabuchi0919][])
+
 ## 2.11.3 (2021-07-11)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -181,12 +181,14 @@ Rails/BulkChangeTable:
     - db/migrate/*.rb
 
 Rails/ContentTag:
-  Description: 'Use `tag` instead of `content_tag`.'
+  Description: 'Use `tag.something` instead of `tag(:something)`.'
   Reference:
+    - 'https://github.com/rubocop/rubocop-rails/issues/260'
     - 'https://github.com/rails/rails/issues/25195'
     - 'https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag'
   Enabled: true
   VersionAdded: '2.6'
+  VersionChanged: '2.12'
 
 Rails/CreateTableWithTimestamps:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -822,31 +822,32 @@ end
 | Yes
 | Yes
 | 2.6
-| -
+| 2.12
 |===
 
-This cop checks that `tag` is used instead of `content_tag`
-because `content_tag` is legacy syntax.
+This cop checks legacy syntax usage of `tag`
 
-NOTE: Allow `content_tag` when the first argument is a variable because
-     `content_tag(name)` is simpler rather than `tag.public_send(name)`.
+NOTE: Allow `tag` when the first argument is a variable because
+      `tag(name)` is simpler rather than `tag.public_send(name)`.
+      And this cop will be renamed to something like `LegacyTag` in the future. (e.g. RuboCop Rails 2.0)
 
 === Examples
 
 [source,ruby]
 ----
 # bad
-content_tag(:p, 'Hello world!')
-content_tag(:br)
+tag(:p)
+tag(:br, class: 'classname')
 
 # good
-tag.p('Hello world!')
-tag.br
-content_tag(name, 'Hello world!')
+tag.p
+tag.br(class: 'classname')
+tag(name, class: 'classname')
 ----
 
 === References
 
+* https://github.com/rubocop/rubocop-rails/issues/260
 * https://github.com/rails/rails/issues/25195
 * https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag
 

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -2,127 +2,44 @@
 
 RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
   context 'Rails 5.0', :rails50 do
-    it 'does not register an offense' do
+    it 'does not register an offense with method style' do
       expect_no_offenses(<<~RUBY)
-        content_tag(:p, 'Hello world!')
+        tag.br
       RUBY
     end
 
-    it 'does not register an offense with empty tag' do
+    it 'does not register an offense when `tag` is used with an argument' do
       expect_no_offenses(<<~RUBY)
-        content_tag(:br)
+        tag.p('Hello world!')
       RUBY
     end
 
-    it 'does not register an offense with array of classnames' do
+    it 'does not register an offense when `tag` is used with arguments' do
       expect_no_offenses(<<~RUBY)
-        content_tag(:div, "Hello world!", class: ["strong", "highlight"])
+        tag.div("Hello world!", class: ["strong", "highlight"])
       RUBY
     end
 
-    it 'does not register an offense with nested content_tag' do
+    it 'does not register an offense when `tag` is nested' do
       expect_no_offenses(<<~RUBY)
-        content_tag(:div) { content_tag(:strong, 'Hi') }
+        tag.div() { tag.strong('Hi') }
+      RUBY
+    end
 
-        content_tag(:div, content_tag(:span, 'foo'))
+    it 'does not register an offense with only tag name' do
+      expect_no_offenses(<<~RUBY)
+        tag(:br)
+      RUBY
+    end
+
+    it 'does not register an offense with all arguments' do
+      expect_no_offenses(<<~RUBY)
+        tag(:br, {class: ["strong", "highlight"]}, true, false)
       RUBY
     end
   end
 
   context 'Rails 5.1', :rails51 do
-    it 'corrects an offense' do
-      expect_offense(<<~RUBY)
-        content_tag(:p, 'Hello world!')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.p('Hello world!')
-      RUBY
-    end
-
-    it 'corrects an offense with empty tag' do
-      expect_offense(<<~RUBY)
-        content_tag(:br)
-        ^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.br()
-      RUBY
-    end
-
-    it 'corrects an offense with array of classnames' do
-      expect_offense(<<~RUBY)
-        content_tag(:div, "Hello world!", class: ["strong", "highlight"])
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.div("Hello world!", class: ["strong", "highlight"])
-      RUBY
-    end
-
-    it 'corrects an offense with nested content_tag' do
-      expect_offense(<<~RUBY)
-        content_tag(:div, content_tag(:span, 'foo'))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.div(tag.span('foo'))
-      RUBY
-    end
-
-    it 'corrects an offense with nested content_tag with block' do
-      expect_offense(<<~RUBY)
-        content_tag(:div) { content_tag(:strong, 'Hi') }
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-        ^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.div() { tag.strong('Hi') }
-      RUBY
-    end
-
-    it 'corrects an offense when first argument is hash' do
-      expect_offense(<<~RUBY)
-        content_tag({foo: 1})
-        ^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag({foo: 1})
-      RUBY
-    end
-
-    it 'corrects an offense when first argument is non-identifier string' do
-      expect_offense(<<~RUBY)
-        content_tag('foo-bar', 'baz', class: 'strong')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.foo_bar('baz', class: 'strong')
-      RUBY
-    end
-
-    it 'corrects an offense when called with options hash and block' do
-      expect_offense(<<~RUBY)
-        content_tag :div, { class: 'strong' } do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
-          'body'
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        tag.div({ class: 'strong' }) do
-          'body'
-        end
-      RUBY
-    end
-
     it 'does not register an offense when `tag` is used with an argument' do
       expect_no_offenses(<<~RUBY)
         tag.p('Hello world!')
@@ -147,9 +64,59 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
       RUBY
     end
 
-    it 'does not register an offense when `content_tag` is called with no arguments' do
+    it 'corrects an offense with only tag name' do
+      expect_offense(<<~RUBY)
+        tag(:br)
+        ^^^^^^^^ Use `tag.something` instead of `tag(:something)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        tag.br()
+      RUBY
+    end
+
+    it 'corrects an offense with all arguments' do
+      expect_offense(<<~RUBY)
+        tag(:br, {class: ["strong", "highlight"]}, true, false)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag.something` instead of `tag(:something)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        tag.br({class: ["strong", "highlight"]}, true, false)
+      RUBY
+    end
+
+    it 'corrects an offense when first argument is non-identifier string' do
+      expect_offense(<<~RUBY)
+        tag('foo-bar', class: 'strong')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag.something` instead of `tag(:something)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        tag.foo_bar(class: 'strong')
+      RUBY
+    end
+
+    it 'does not register an offense when first argument is snake case string' do
       expect_no_offenses(<<~RUBY)
-        content_tag
+        tag('foo_bar', class: 'strong')
+      RUBY
+    end
+
+    it 'corrects an offense when first argument is string starts with hyphen' do
+      expect_offense(<<~RUBY)
+        tag('-foo', class: 'strong')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag.something` instead of `tag(:something)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        tag._foo(class: 'strong')
+      RUBY
+    end
+
+    it 'does not register an offense when first argument is a string which starts with an underscore' do
+      expect_no_offenses(<<~RUBY)
+        tag('_foo', class: 'strong')
       RUBY
     end
 
@@ -157,31 +124,31 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
       it 'does not register an offense when the first argument is a lvar' do
         expect_no_offenses(<<~RUBY)
           name = do_something
-          content_tag(name, "Hello world!", class: ["strong", "highlight"])
+          tag(name, class: ["strong", "highlight"])
         RUBY
       end
 
       it 'does not register an offense when the first argument is an ivar' do
         expect_no_offenses(<<~RUBY)
-          content_tag(@name, "Hello world!", class: ["strong", "highlight"])
+          tag(@name, class: ["strong", "highlight"])
         RUBY
       end
 
       it 'does not register an offense when the first argument is a cvar' do
         expect_no_offenses(<<~RUBY)
-          content_tag(@@name, "Hello world!", class: ["strong", "highlight"])
+          tag(@@name, class: ["strong", "highlight"])
         RUBY
       end
 
       it 'does not register an offense when the first argument is a gvar' do
         expect_no_offenses(<<~RUBY)
-          content_tag($name, "Hello world!", class: ["strong", "highlight"])
+          tag($name, class: ["strong", "highlight"])
         RUBY
       end
 
       it 'does not register an offense when the first argument is a splat argument' do
         expect_no_offenses(<<~RUBY)
-          content_tag(*args, &block)
+          tag(*args)
         RUBY
       end
     end
@@ -189,7 +156,7 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
     context 'when the first argument is a method' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
-          content_tag(name, "Hello world!", class: ["strong", "highlight"])
+          tag(name, class: ["strong", "highlight"])
         RUBY
       end
     end
@@ -197,7 +164,7 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
     context 'when the first argument is a constant' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
-          content_tag(CONST, "Hello world!", class: ["strong", "highlight"])
+          tag(CONST, class: ["strong", "highlight"])
         RUBY
       end
     end


### PR DESCRIPTION
Fix #260

This PR fixes target of `Rails/ContentTag` cop.
The reason is that it is unclear wheather `content_tag` is deprecated, and auto-correction may cause performance regression.

Following test cases are added. 
- If first argument is kebab case, it can be autocorrected to snake case method.
- If first argument is snake case, it cannot be autocorrected.

```rb
#!/usr/bin/env rails runner

helper = ApplicationController.helpers
puts helper.tag("foo-bar")
# => <foo-bar />
puts helper.tag("foo_bar")
# => <foo_bar />
puts helper.tag.foo_bar
# => <foo-bar></foo-bar>

puts helper.tag("-foo")
# => <-foo />
puts helper.tag("_foo")
# => <_foo />
puts helper.tag._foo
# => <-foo></-foo>
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
