### PR TITLE
[Fix #528] Fix a false positive for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#520](https://github.com/rubocop/rubocop-rails/pull/520): Support auto-correction for `Rails/ScopeArgs`. ([@koic][])
 * [#524](https://github.com/rubocop/rubocop-rails/pull/524): Add new `Rails/RedundantTravelBack` cop. ([@koic][])
 
+### Bug fixes
+
+* [#528](https://github.com/rubocop/rubocop-rails/issues/528): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying `:dependent` strategy with double splat. ([@koic][])
+
 ## Changes
 
 * [#260](https://github.com/rubocop/rubocop-rails/issues/260): Change target of `Rails/ContentTag` from `content_tag` method to `tag` method. ([@tabuchi0919][])

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -114,6 +114,8 @@ module RuboCop
         end
 
         def valid_options?(options)
+          options = options.first.children.first.pairs if options.first.kwsplat_type?
+
           return true unless options
           return true if options.any? do |o|
             dependent_option?(o) || present_option?(o)

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
+    it 'does not register an offense when specifying `:dependent` strategy with double splat' do
+      expect_no_offenses(<<~RUBY)
+        class Person < ApplicationRecord
+          has_one :foo, **{dependent: :destroy}
+        end
+      RUBY
+    end
+
     it 'does not register an offense when specifying default `dependent: nil` strategy' do
       expect_no_offenses(<<~RUBY)
         class Person < ApplicationRecord


### PR DESCRIPTION
Fixes #528.

This PR fixes a false positive for `Rails/HasManyOrHasOneDependent` when specifying `:dependent` strategy with double splat.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
