### PR TITLE
[Fix #529] Fix a false positive for `Rails/LexicallyScopedActionFilter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 * [#528](https://github.com/rubocop/rubocop-rails/issues/528): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying `:dependent` strategy with double splat. ([@koic][])
+* [#529](https://github.com/rubocop/rubocop-rails/issues/529): Fix a false positive for `Rails/LexicallyScopedActionFilter` when action method is aliased by `alias_method`. ([@koic][])
 
 ## Changes
 

--- a/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
@@ -115,6 +115,41 @@ RSpec.describe RuboCop::Cop::Rails::LexicallyScopedActionFilter, :config do
     RUBY
   end
 
+  it 'does not register an offense when action method is aliased by `alias_method`' do
+    expect_no_offenses(<<~RUBY)
+      class FooController < ApplicationController
+        before_action :authorize!, only: %i[index show]
+
+        def index
+        end
+        alias_method :show, :index
+
+        private
+
+        def authorize!
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when action method is not aliased by `alias_method`' do
+    expect_offense(<<~RUBY)
+      class FooController < ApplicationController
+        before_action :authorize!, only: %i[foo show]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `foo` is not explicitly defined on the class.
+
+        def index
+        end
+        alias_method :show, :index
+
+        private
+
+        def authorize!
+        end
+      end
+    RUBY
+  end
+
   it "doesn't register an offense when using conditional statements" do
     expect_no_offenses <<~RUBY
       class Test < ActionController


### PR DESCRIPTION
Fixes #529.

This PR fixes a false positive for `Rails/LexicallyScopedActionFilter` when action method is aliased by `alias_method`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
