### PR TITLE
[Fix #532] Fix a false positive for `Rails/HttpPositionalArguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#528](https://github.com/rubocop/rubocop-rails/issues/528): Fix a false positive for `Rails/HasManyOrHasOneDependent` when specifying `:dependent` strategy with double splat. ([@koic][])
 * [#529](https://github.com/rubocop/rubocop-rails/issues/529): Fix a false positive for `Rails/LexicallyScopedActionFilter` when action method is aliased by `alias_method`. ([@koic][])
+* [#532](https://github.com/rubocop/rubocop-rails/issues/532): Fix a false positive for `Rails/HttpPositionalArguments` when defining `get` in `Rails.application.routes.draw` block. ([@koic][])
 
 ## Changes
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -27,6 +27,7 @@ module RuboCop
         KEYWORD_ARGS = %i[
           method params session body flash xhr as headers env to
         ].freeze
+        ROUTING_METHODS = %i[draw routes].freeze
         RESTRICT_ON_SEND = %i[get post put patch delete head].freeze
 
         minimum_target_rails_version 5.0
@@ -40,6 +41,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if in_routing_block?(node)
+
           http_request?(node) do |data|
             return unless needs_conversion?(data)
 
@@ -62,6 +65,10 @@ module RuboCop
         end
 
         private
+
+        def in_routing_block?(node)
+          !!node.each_ancestor(:block).detect { |block| ROUTING_METHODS.include?(block.send_node.method_name) }
+        end
 
         def needs_conversion?(data)
           return true unless data.hash_type?

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -415,5 +415,21 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments, :config, :config do
         RUBY
       end
     end
+
+    it 'does not register an offense when defining `get` in `routes` block' do
+      expect_no_offenses(<<~RUBY)
+        routes do
+          get :list, on: :collection
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when defining `get` in `routes.draw` block' do
+      expect_no_offenses(<<~RUBY)
+        Rails.application.routes.draw do
+          get :list, on: :collection
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #532.

This PR fixes a false positive for `Rails/HttpPositionalArguments` when defining `get` in `Rails.application.routes.draw` block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
