### PR TITLE
[Fix #535] Fix an error for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#535](https://github.com/rubocop/rubocop-rails/issues/535): Fix an error for `Rails/HasManyOrHasOneDependent` when using lambda argument and not specifying any options. ([@koic][])
+
 ## 2.12.0 (2021-09-09)
 
 ### New features

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -100,8 +100,8 @@ module RuboCop
         end
 
         def contain_valid_options_in_with_options_block?(node)
-          if with_options_block(node)
-            return true if valid_options?(with_options_block(node))
+          if (options = with_options_block(node))
+            return true if valid_options?(options)
 
             return false unless node.parent
 
@@ -114,6 +114,8 @@ module RuboCop
         end
 
         def valid_options?(options)
+          return false if options.nil?
+
           options = options.first.children.first.pairs if options.first.kwsplat_type?
 
           return true unless options

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
+    it 'registers an offense when using lambda argument and not specifying any options' do
+      expect_offense(<<~RUBY)
+        class User < ApplicationRecord
+          has_one :articles, -> { where(active: true) }
+          ^^^^^^^ Specify a `:dependent` option.
+        end
+      RUBY
+    end
+
     it 'does not register an offense when specifying `:dependent` strategy' do
       expect_no_offenses(<<~RUBY)
         class Person < ApplicationRecord


### PR DESCRIPTION
Fixes #535.

This PR fixes an error for `Rails/HasManyOrHasOneDependent` when using lambda argument and not specifying any options.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
