### PR TITLE
[Fix #541] Fix a false positive for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#541](https://github.com/rubocop/rubocop-rails/issues/541): Fix an error for `Rails/HasManyOrHasOneDependent` when using lambda argument and specifying `:dependent` strategy. ([@koic][])
+
 ## 2.12.1 (2021-09-10)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -45,7 +45,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :association_with_options?, <<~PATTERN
-          (send nil? {:has_many :has_one} _ (hash $...))
+          (send nil? {:has_many :has_one} ... (hash $...))
         PATTERN
 
         def_node_matcher :dependent_option?, <<~PATTERN

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -20,15 +20,6 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
-    it 'registers an offense when using lambda argument and not specifying any options' do
-      expect_offense(<<~RUBY)
-        class User < ApplicationRecord
-          has_one :articles, -> { where(active: true) }
-          ^^^^^^^ Specify a `:dependent` option.
-        end
-      RUBY
-    end
-
     it 'does not register an offense when specifying `:dependent` strategy' do
       expect_no_offenses(<<~RUBY)
         class Person < ApplicationRecord
@@ -114,8 +105,25 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
+    it 'registers an offense when using lambda argument and not specifying any options' do
+      expect_offense(<<~RUBY)
+        class User < ApplicationRecord
+          has_many :articles, -> { where(active: true) }
+          ^^^^^^^^ Specify a `:dependent` option.
+        end
+      RUBY
+    end
+
     it 'does not register an offense when specifying `:dependent` strategy' do
       expect_no_offenses('has_many :foo, dependent: :bar')
+    end
+
+    it 'does not register an offense when using lambda argument and specifying `:dependent` strategy' do
+      expect_no_offenses(<<~RUBY)
+        class User < ApplicationRecord
+          has_many :articles, -> { where(active: true) }, dependent: :destroy
+        end
+      RUBY
     end
 
     it 'does not register an offense when specifying default `dependent: nil` strategy' do
@@ -129,6 +137,14 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
     context 'with :through option' do
       it 'does not register an offense for non-nil value' do
         expect_no_offenses('has_many :foo, through: :bars')
+      end
+
+      it 'does not register an offense when using lambda argument and specifying non-nil `:through` option' do
+        expect_no_offenses(<<~RUBY)
+          class User < ApplicationRecord
+            has_many :activities, -> { order(created_at: :desc) }, through: :notes, source: :activities
+          end
+        RUBY
       end
 
       it 'registers an offense for nil value' do


### PR DESCRIPTION
Fixes #541.

This PR fixes a false positive for `Rails/HasManyOrHasOneDependent` when using lambda argument and specifying `:dependent` strategy.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
