### PR TITLE
[Fix #543] Fix an error for `Rails/ContentTag`

### DIFF
--- a/changelog/fix_error_for_rails_content_tag.md
+++ b/changelog/fix_error_for_rails_content_tag.md
@@ -1,0 +1,1 @@
+* [#543](https://github.com/rubocop/rubocop-rails/issues/543): Fix an error for `Rails/ContentTag` when `tag` is not a top-level method. ([@koic][])

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -168,5 +168,13 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
         RUBY
       end
     end
+
+    context 'when `tag` is not a top-level method (e.g. using intercom-ruby)' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          intercom.tags.tag(foo: 'foo', bar: 'bar')
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #543.

This PR fixes an error for `Rails/ContentTag` when `tag` is not a top-level method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
