### PR TITLE
[Fix #546] Exclude `app/models` by default for `Rails/ContentTag`

### DIFF
--- a/changelog/change_exclude_models_by_default_for_rails_content_tag.md
+++ b/changelog/change_exclude_models_by_default_for_rails_content_tag.md
@@ -1,0 +1,1 @@
+* [#546](https://github.com/rubocop/rubocop-rails/issues/546): Exclude `app/models` by default for `Rails/ContentTag`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -189,6 +189,9 @@ Rails/ContentTag:
   Enabled: true
   VersionAdded: '2.6'
   VersionChanged: '2.12'
+  # This `Exclude` config prevents false positives for `tag` calls to `has_one: tag`. No helpers are used in normal models.
+  Exclude:
+    - app/models/**/*.rb
 
 Rails/CreateTableWithTimestamps:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -845,6 +845,16 @@ tag.br(class: 'classname')
 tag(name, class: 'classname')
 ----
 
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| Exclude
+| `app/models/**/*.rb`
+| Array
+|===
+
 === References
 
 * https://github.com/rubocop/rubocop-rails/issues/260


### PR DESCRIPTION
Fixes #546

This PR excludes `app/models` by default for `Rails/ContentTag`. Because it prevents false positives for `tag` calls to `has_one: tag`. No helpers are used in normal models.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
