### PR TITLE
[Fix #551] Fix a false positive for `Rails/FindEach`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_find_each.md
+++ b/changelog/fix_a_false_positive_for_rails_find_each.md
@@ -1,0 +1,1 @@
+* [#551](https://github.com/rubocop/rubocop-rails/issues/551): Fix a false positive for `Rails/FindEach` when using `model.errors.where` in Rails 6.1. ([@koic][])

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -43,8 +43,19 @@ module RuboCop
         private
 
         def ignored?(node)
+          return true if active_model_error_where?(node.receiver)
+
           method_chain = node.each_node(:send).map(&:method_name)
+
           (cop_config['IgnoredMethods'].map(&:to_sym) & method_chain).any?
+        end
+
+        def active_model_error_where?(node)
+          node.method?(:where) && active_model_error?(node.receiver)
+        end
+
+        def active_model_error?(node)
+          node.send_type? && node.method?(:errors)
         end
       end
     end

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe RuboCop::Cop::Rails::FindEach, :config do
     expect_no_offenses('User.all.find_each { |u| u.x }')
   end
 
+  # Active Model Errors slice from the new query interface introduced in Rails 6.1.
+  it 'does not register an offense when using `model.errors.where`' do
+    expect_no_offenses(<<~RUBY)
+      model.errors.where(:title).each { |error| do_something(error)  }
+    RUBY
+  end
+
   it 'auto-corrects each to find_each' do
     expect_offense(<<~RUBY)
       User.all.each { |u| u.x }


### PR DESCRIPTION
Fixes #551.

This PR fixes a false positive for `Rails/FindEach` when using `model.errors.where` in Rails 6.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
