### PR TITLE
Fix a false positive for `Rails/ReversibleMigration`

### DIFF
--- a/changelog/fix_false_positive_for_rails_reversible_migration.md
+++ b/changelog/fix_false_positive_for_rails_reversible_migration.md
@@ -1,0 +1,1 @@
+* [#553](https://github.com/rubocop/rubocop-rails/pull/553): Fix a false positive for `Rails/ReversibleMigration` when using `t.remove` with `type` option in Rails 6.1. ([@koic][])

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -317,16 +317,24 @@ module RuboCop
           return if receiver != node.receiver &&
                     reversible_change_table_call?(node)
 
+          action = if method_name == :remove
+                     target_rails_version >= 6.1 ? 't.remove (without type)' : 't.remove'
+                   else
+                     "change_table(with #{method_name})"
+                   end
+
           add_offense(
             node,
-            message: format(MSG, action: "change_table(with #{method_name})")
+            message: format(MSG, action: action)
           )
         end
 
         def reversible_change_table_call?(node)
           case node.method_name
-          when :change, :remove
+          when :change
             false
+          when :remove
+            target_rails_version >= 6.1 && all_hash_key?(node.arguments.last, :type)
           when :change_default, :change_column_default, :change_table_comment,
                :change_column_comment
             all_hash_key?(node.arguments.last, :from, :to)

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -213,11 +213,35 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
       end
     RUBY
 
-    it_behaves_like 'offense', 'change_table(with remove)', <<~RUBY
-      change_table :users do |t|
-        t.remove :qualification
+    context 'remove' do
+      context 'Rails >= 6.1', :rails61 do
+        it_behaves_like 'accepts', 't.remove (with type)', <<~RUBY
+          change_table :users do |t|
+            t.remove(:posts, type: :text)
+          end
+        RUBY
+
+        it_behaves_like 'offense', 't.remove (without type)', <<~RUBY
+          change_table :users do |t|
+            t.remove(:posts)
+          end
+        RUBY
       end
-    RUBY
+
+      context 'Rails < 6.1', :rails60 do
+        it_behaves_like 'offense', 't.remove', <<~RUBY
+          change_table :users do |t|
+            t.remove(:posts, type: :text)
+          end
+        RUBY
+
+        it_behaves_like 'offense', 't.remove', <<~RUBY
+          change_table :users do |t|
+            t.remove(:posts)
+          end
+        RUBY
+      end
+    end
   end
 
   context 'remove_columns' do


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-rails/issues/110#issuecomment-640359177.

This PR fixes a false positive for `Rails/ReversibleMigration` when using `t.remove` with `type` option in Rails 6.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
