### PR TITLE
[Fix #559] Fix an error for `Rails/RelativeDateConstant`

### DIFF
--- a/changelog/fix_error_for_rails_relative_date_constant.md
+++ b/changelog/fix_error_for_rails_relative_date_constant.md
@@ -1,0 +1,1 @@
+* [#559](https://github.com/rubocop/rubocop-rails/issues/559): Fix an error for `Rails/RelativeDateConstant` when using multiple assignment. ([@koic][])

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -90,7 +90,7 @@ module RuboCop
         end
 
         def nested_relative_date(node, &callback)
-          return if node.block_type?
+          return if node.nil? || node.block_type?
 
           node.each_child_node do |child|
             nested_relative_date(child, &callback)

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -172,4 +172,14 @@ RSpec.describe RuboCop::Cop::Rails::RelativeDateConstant, :config do
       RUBY
     end
   end
+
+  context 'when using multiple assignment' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class SomeClass
+          FOO, BAR = *do_something
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #559.

This PR fixes an error for `Rails/RelativeDateConstant` when using multiple assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
