### PR TITLE
Improve wording for `Rails/UniqueValidation` description

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -819,7 +819,7 @@ Rails/UniqBeforePluck:
   AutoCorrect: false
 
 Rails/UniqueValidationWithoutIndex:
-  Description: 'Uniqueness validation should be with a unique index.'
+  Description: 'Uniqueness validation should have a unique index on the database column.'
   Enabled: true
   VersionAdded: '2.5'
   Include:

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -27,7 +27,7 @@ module RuboCop
       class UniqueValidationWithoutIndex < Base
         include ActiveRecordHelper
 
-        MSG = 'Uniqueness validation should be with a unique index.'
+        MSG = 'Uniqueness validation should have a unique index on the database column.'
         RESTRICT_ON_SEND = %i[validates].freeze
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         expect_offense(<<~RUBY)
           class User
             validates :account, uniqueness: true
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
           end
         RUBY
       end
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         expect_offense(<<~RUBY)
           class User
             validates :account, uniqueness: true
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
           end
         RUBY
       end
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           expect_offense(<<~RUBY)
             class WrittenArticles
               validates :user_id, uniqueness: { scope: :article_id }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
             class WrittenArticles
               belongs_to :author, polymorphic: true
               validates :title, uniqueness: { scope: :author }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           expect_offense(<<~RUBY)
             class WrittenArticles
               validates :a_id, uniqueness: { scope: [:b_id, :c_id] }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end
@@ -301,7 +301,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
             class Article
               belongs_to :user
               validates :user, uniqueness: true
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end
@@ -419,7 +419,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
             class Article
               belongs_to :member, foreign_key: :user_id
               validates :member, uniqueness: true
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end
@@ -480,7 +480,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           class User
             self.table_name = 'members'
             validates :account, uniqueness: true
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
           end
         RUBY
       end
@@ -500,7 +500,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           module Admin
             class User
               validates :account, uniqueness: true
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           end
         RUBY
@@ -510,7 +510,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         expect_offense(<<~RUBY)
           class Admin::User
             validates :account, uniqueness: true
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
           end
         RUBY
       end
@@ -550,7 +550,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           expect_offense(<<~RUBY)
             class Email < ApplicationRecord
               validates :address, presence: true, uniqueness: { case_sensitive: false }, email: true
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end
@@ -572,7 +572,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           expect_offense(<<~RUBY)
             class User
               validates :account, uniqueness: true
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
             end
           RUBY
         end


### PR DESCRIPTION
Based on [this StackOverflow question](https://stackoverflow.com/questions/69323472/rubocop-uniqueness-validation-should-be-with-a-unique-index-in-values-that-star), I think the wording can be improved.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
