### PR TITLE
[Fix #556] Fix a false positive for `Rails/ContentTag`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_content_tag.md
+++ b/changelog/fix_a_false_positive_for_rails_content_tag.md
@@ -1,0 +1,1 @@
+* [#556](https://github.com/rubocop/rubocop-rails/issues/556): Fix a false positive for `Rails/ContentTag` when using using the `tag` method with 3 or more arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.receiver.nil?
+          return if node.arguments.count >= 3
 
           first_argument = node.first_argument
           return if !first_argument ||

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -75,14 +75,19 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
       RUBY
     end
 
-    it 'corrects an offense with all arguments' do
-      expect_offense(<<~RUBY)
+    # Prevents `ArgumentError` reported by https://github.com/rubocop/rubocop-rails/issues/556.
+    # See: https://api.rubyonrails.org/v6.1.4/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Legacy+syntax
+    it 'does not register an offense with all arguments' do
+      expect_no_offenses(<<~RUBY)
         tag(:br, {class: ["strong", "highlight"]}, true, false)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag.br` instead of `tag(:br)`.
       RUBY
+    end
 
-      expect_correction(<<~RUBY)
-        tag.br({class: ["strong", "highlight"]}, true, false)
+    # Prevents `ArgumentError` reported by https://github.com/rubocop/rubocop-rails/issues/556.
+    # See: https://api.rubyonrails.org/v6.1.4/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Legacy+syntax
+    it 'does not register an offense with three arguments' do
+      expect_no_offenses(<<~RUBY)
+        tag(:br, {class: ["strong", "highlight"]}, true)
       RUBY
     end
 


### PR DESCRIPTION
Fixes #556.

This PR fixes a false positive for `Rails/ContentTag` when using using the `tag` method with 3 or more arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
