### PR TITLE
Unmark `AutoCorrect: false` from `Rails/UniqBeforePluck`

### DIFF
--- a/changelog/change_unmark_autocorrect_false_from_rails_uniq_before_pluck.md
+++ b/changelog/change_unmark_autocorrect_false_from_rails_uniq_before_pluck.md
@@ -1,0 +1,1 @@
+* [#580](https://github.com/rubocop/rubocop-rails/pull/580): Unmark `AutoCorrect: false` from `Rails/UniqBeforePluck`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -820,13 +820,12 @@ Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
   VersionAdded: '0.40'
-  VersionChanged: '2.8'
+  VersionChanged: '2.13'
   EnforcedStyle: conservative
   SupportedStyles:
     - conservative
     - aggressive
   SafeAutoCorrect: false
-  AutoCorrect: false
 
 Rails/UniqueValidationWithoutIndex:
   Description: 'Uniqueness validation should have a unique index on the database column.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4875,7 +4875,7 @@ end
 | Yes
 | Yes (Unsafe)
 | 0.40
-| 2.8
+| 2.13
 |===
 
 Prefer the use of distinct, before pluck instead of after.
@@ -4940,10 +4940,6 @@ Model.distinct.pluck(:id)
 | EnforcedStyle
 | `conservative`
 | `conservative`, `aggressive`
-
-| AutoCorrect
-| `false`
-| Boolean
 |===
 
 == Rails/UniqueValidationWithoutIndex


### PR DESCRIPTION
This `AutoCorrect: false` looks like it was set when there was no way to safe autocorrect by `SafeAutocorrect: false`.
Test code for the autocorrection exists. So it can be enabled by default. However, it is still unsafe because `SafeAutocorrect: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
