### PR TITLE
Iron out Rails/UniqBeforePluck

### DIFF
--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4912,27 +4912,25 @@ end
 | 2.13
 |===
 
-Prefer the use of distinct, before pluck instead of after.
+Prefer using `distinct` before `pluck` instead of `uniq` after `pluck`.
 
-The use of distinct before pluck is preferred because it executes within
+The use of distinct before pluck is preferred because it executes by
 the database.
 
 This cop has two different enforcement modes. When the EnforcedStyle
-is conservative (the default) then only calls to pluck on a constant
-(i.e. a model class) before distinct are added as offenses.
+is `conservative` (the default), then only calls to `pluck` on a constant
+(i.e. a model class) before `uniq` are added as offenses.
 
-When the EnforcedStyle is aggressive then all calls to pluck before
+When the EnforcedStyle is `aggressive` then all calls to `pluck` before
 distinct are added as offenses. This may lead to false positives
-as the cop cannot distinguish between calls to pluck on an
+as the cop cannot distinguish between calls to `pluck` on an
 ActiveRecord::Relation vs a call to pluck on an
 ActiveRecord::Associations::CollectionProxy.
 
 === Safety
 
-This cop is unsafe because the behavior may change depending on the
-database collation.
-Autocorrect is disabled by default for this cop since it may generate
-false positives.
+This cop is unsafe for autocorrection because the behavior may change
+depending on the database collation.
 
 === Examples
 
@@ -4940,30 +4938,30 @@ false positives.
 
 [source,ruby]
 ----
-# bad
-Model.pluck(:id).uniq
+# bad - redundantly fetches duplicate values
+Album.pluck(:band_name).uniq
 
 # good
-Model.distinct.pluck(:id)
+Album.distinct.pluck(:band_name)
 ----
 
 ==== EnforcedStyle: aggressive
 
 [source,ruby]
 ----
-# bad
-# this will return a Relation that pluck is called on
-Model.where(cond: true).pluck(:id).uniq
+# bad - redundantly fetches duplicate values
+Album.pluck(:band_name).uniq
 
-# bad
-# an association on an instance will return a CollectionProxy
-instance.assoc.pluck(:id).uniq
+# bad - redundantly fetches duplicate values
+Album.where(year: 1985).pluck(:band_name).uniq
 
-# bad
-Model.pluck(:id).uniq
+# bad - redundantly fetches duplicate values
+customer.favourites.pluck(:color).uniq
 
 # good
-Model.distinct.pluck(:id)
+Album.distinct.pluck(:band_name)
+Album.distinct.where(year: 1985).pluck(:band_name)
+customer.favourites.distinct.pluck(:color)
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -3,48 +3,46 @@
 module RuboCop
   module Cop
     module Rails
-      # Prefer the use of distinct, before pluck instead of after.
+      # Prefer using `distinct` before `pluck` instead of `uniq` after `pluck`.
       #
-      # The use of distinct before pluck is preferred because it executes within
+      # The use of distinct before pluck is preferred because it executes by
       # the database.
       #
       # This cop has two different enforcement modes. When the EnforcedStyle
-      # is conservative (the default) then only calls to pluck on a constant
-      # (i.e. a model class) before distinct are added as offenses.
+      # is `conservative` (the default), then only calls to `pluck` on a constant
+      # (i.e. a model class) before `uniq` are added as offenses.
       #
-      # When the EnforcedStyle is aggressive then all calls to pluck before
+      # When the EnforcedStyle is `aggressive` then all calls to `pluck` before
       # distinct are added as offenses. This may lead to false positives
-      # as the cop cannot distinguish between calls to pluck on an
+      # as the cop cannot distinguish between calls to `pluck` on an
       # ActiveRecord::Relation vs a call to pluck on an
       # ActiveRecord::Associations::CollectionProxy.
       #
       # @safety
-      #   This cop is unsafe because the behavior may change depending on the
-      #   database collation.
-      #   Autocorrect is disabled by default for this cop since it may generate
-      #   false positives.
+      #   This cop is unsafe for autocorrection because the behavior may change
+      #   depending on the database collation.
       #
       # @example EnforcedStyle: conservative (default)
-      #   # bad
-      #   Model.pluck(:id).uniq
+      #   # bad - redundantly fetches duplicate values
+      #   Album.pluck(:band_name).uniq
       #
       #   # good
-      #   Model.distinct.pluck(:id)
+      #   Album.distinct.pluck(:band_name)
       #
       # @example EnforcedStyle: aggressive
-      #   # bad
-      #   # this will return a Relation that pluck is called on
-      #   Model.where(cond: true).pluck(:id).uniq
+      #   # bad - redundantly fetches duplicate values
+      #   Album.pluck(:band_name).uniq
       #
-      #   # bad
-      #   # an association on an instance will return a CollectionProxy
-      #   instance.assoc.pluck(:id).uniq
+      #   # bad - redundantly fetches duplicate values
+      #   Album.where(year: 1985).pluck(:band_name).uniq
       #
-      #   # bad
-      #   Model.pluck(:id).uniq
+      #   # bad - redundantly fetches duplicate values
+      #   customer.favourites.pluck(:color).uniq
       #
       #   # good
-      #   Model.distinct.pluck(:id)
+      #   Album.distinct.pluck(:band_name)
+      #   Album.distinct.where(year: 1985).pluck(:band_name)
+      #   customer.favourites.distinct.pluck(:color)
       #
       class UniqBeforePluck < Base
         include ConfigurableEnforcedStyle
@@ -52,10 +50,9 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use `distinct` before `pluck`.'
-        RESTRICT_ON_SEND = %i[uniq distinct pluck].freeze
+        RESTRICT_ON_SEND = %i[uniq].freeze
         NEWLINE = "\n"
-        PATTERN = '[!^block (send (send %<type>s :pluck ...) ' \
-                  '${:uniq :distinct} ...)]'
+        PATTERN = '[!^block (send (send %<type>s :pluck ...) :uniq ...)]'
 
         def_node_matcher :conservative_node_match,
                          format(PATTERN, type: 'const')
@@ -64,13 +61,13 @@ module RuboCop
                          format(PATTERN, type: '_')
 
         def on_send(node)
-          method = if style == :conservative
-                     conservative_node_match(node)
-                   else
-                     aggressive_node_match(node)
-                   end
+          uniq = if style == :conservative
+                   conservative_node_match(node)
+                 else
+                   aggressive_node_match(node)
+                 end
 
-          return unless method
+          return unless uniq
 
           add_offense(node.loc.selector) do |corrector|
             method = node.method_name
@@ -81,10 +78,6 @@ module RuboCop
         end
 
         private
-
-        def style_parameter_name
-          'EnforcedStyle'
-        end
 
         def dot_method_with_whitespace(method, node)
           range_between(dot_method_begin_pos(method, node),


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop-rails/pull/580#discussion_r744146536

Removed detection of `distinct` after `pluck`:
```ruby
> User.pluck(:email).distinct
(1.3ms)  SELECT "users"."email" FROM "users"
NoMethodError: undefined method `distinct' for ["user@example.com"]:Array
```

Improved examples and reasoning text.

Unfold specs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/