### PR TITLE
Change from `AutoCorrect: false` to `SafeAutoCorrect: false` for `Rails/RelativeDateConstant`

### DIFF
--- a/changelog/change_unmark_autocorrect_false_from_rails_relative_date_constant.md
+++ b/changelog/change_unmark_autocorrect_false_from_rails_relative_date_constant.md
@@ -1,0 +1,1 @@
+* [#582](https://github.com/rubocop/rubocop-rails/pull/582): Unmark `AutoCorrect: false` from `Rails/RelativeDateConstant`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -652,9 +652,9 @@ Rails/RefuteMethods:
 Rails/RelativeDateConstant:
   Description: 'Do not assign relative date to constants.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.48'
-  VersionChanged: '0.59'
-  AutoCorrect: false
+  VersionChanged: '2.13'
 
 Rails/RenderInline:
   Description: 'Prefer using a template over inline rendering.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3728,13 +3728,17 @@ refute_equal true, false
 
 | Enabled
 | Yes
-| Yes
+| Yes (Unsafe)
 | 0.48
-| 0.59
+| 2.13
 |===
 
 This cop checks whether constant value isn't relative date.
 Because the relative date will be evaluated only once.
+
+=== Safety
+
+This cop's autocorrection is unsafe because its dependence on the constant is not corrected.
 
 === Examples
 
@@ -3761,16 +3765,6 @@ class SomeClass
   end
 end
 ----
-
-=== Configurable attributes
-
-|===
-| Name | Default value | Configurable values
-
-| AutoCorrect
-| `false`
-| Boolean
-|===
 
 == Rails/RenderInline
 

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop checks whether constant value isn't relative date.
       # Because the relative date will be evaluated only once.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because its dependence on the constant is not corrected.
+      #
       # @example
       #   # bad
       #   class SomeClass


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/6177.

This `AutoCorrect: false` looks like it was set when there was no way to safe autocorrect by `SafeAutocorrect: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
