### PR TITLE
Make ReadWriteAttribute cop aware of shadowing methods

### DIFF
--- a/changelog/change_read_write_attribute_to_be_aware_of_shadowed_methods.md
+++ b/changelog/change_read_write_attribute_to_be_aware_of_shadowed_methods.md
@@ -1,0 +1,1 @@
+* [#585](https://github.com/rubocop/rubocop-rails/pull/585): Make `Rails/ReadWriteAttribute` cop aware of shadowing methods. ([@drenmi][])


### PR DESCRIPTION
### Background

Sometimes you might want to put a method "in front of" an attribute. In this case, that method will shadow the attribute name, and using `self[:foo]` within the method will be an infinite loop.

**Example:**

```ruby
class Foo < ApplicationModel
  attribute :foo

  def foo
    bar || self[:foo]
  end

  def bar
    nil
  end
end

foo = Foo.new(foo: 1)
#=> (irb):11:in `foo': stack level too deep (SystemStackError)
```

### What is this change?

This PR makes it so that no offense is registered if `#read_attribute` is used in a method named after that attribute. Same for `#write_attribute` if called inside a writer method (suffix `=`) of the same name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
