### PR TITLE
[Fix #591] Add `change_column` check to `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## master (unreleased)
 
-### Changes
-
-* [#591](https://github.com/rubocop/rubocop-rails/issues/591): Add `change_column` to `Rails/ReversibleMigration`. ([@mattmccormick][])
-
 ## 2.12.4 (2021-10-16)
 
 ### Bug fixes
@@ -488,4 +484,3 @@
 [@theunraveler]: https://github.com/theunraveler
 [@pirj]: https://github.com/pirj
 [@vitormd]: https://github.com/vitormd
-[@mattmccormick]: https://github.com/mattmccormick

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#591](https://github.com/rubocop/rubocop-rails/issues/591): Add `change_column` to `Rails/ReversibleMigration`. ([@mattmccormick][])
+
 ## 2.12.4 (2021-10-16)
 
 ### Bug fixes
@@ -484,3 +488,4 @@
 [@theunraveler]: https://github.com/theunraveler
 [@pirj]: https://github.com/pirj
 [@vitormd]: https://github.com/vitormd
+[@mattmccormick]: https://github.com/mattmccormick

--- a/changelog/change_add_change_column_check_to_railsreversiblemigration.md
+++ b/changelog/change_add_change_column_check_to_railsreversiblemigration.md
@@ -1,0 +1,1 @@
+* [#591](https://github.com/rubocop/rubocop-rails/issues/591): Add `change_column` check to `Rails/ReversibleMigration`. ([@mattmccormick][])

--- a/changelog/change_add_remove_reference_check_to_railsreversiblemigration.md
+++ b/changelog/change_add_remove_reference_check_to_railsreversiblemigration.md
@@ -1,0 +1,1 @@
+* Add `remove_reference` check to `Rails/ReversibleMigration`. ([@mattmccormick][])

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -179,7 +179,7 @@ module RuboCop
         MSG = '%<action>s is not reversible.'
 
         def_node_matcher :irreversible_schema_statement_call, <<~PATTERN
-          (send nil? ${:execute :remove_belongs_to} ...)
+          (send nil? ${:execute :remove_belongs_to :change_column} ...)
         PATTERN
 
         def_node_matcher :drop_table_call, <<~PATTERN

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -179,7 +179,7 @@ module RuboCop
         MSG = '%<action>s is not reversible.'
 
         def_node_matcher :irreversible_schema_statement_call, <<~PATTERN
-          (send nil? ${:execute :remove_belongs_to :change_column} ...)
+          (send nil? ${:change_column :execute :remove_belongs_to} ...)
         PATTERN
 
         def_node_matcher :drop_table_call, <<~PATTERN

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -179,7 +179,7 @@ module RuboCop
         MSG = '%<action>s is not reversible.'
 
         def_node_matcher :irreversible_schema_statement_call, <<~PATTERN
-          (send nil? ${:change_column :execute :remove_belongs_to} ...)
+          (send nil? ${:change_column :execute :remove_belongs_to :remove_reference} ...)
         PATTERN
 
         def_node_matcher :drop_table_call, <<~PATTERN

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -171,6 +171,20 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
+  context 'remove_belongs_to' do
+    it_behaves_like 'accepts', 'up_only', <<~RUBY
+      up_only { remove_belongs_to(:products, :user, index: false) }
+    RUBY
+
+    it_behaves_like 'offense', 'remove_belongs_to', <<~RUBY
+      remove_belongs_to(:products, :user, index: false)
+    RUBY
+
+    it_behaves_like 'offense', 'remove_belongs_to', <<~RUBY
+      remove_belongs_to(:products, :supplier, polymorphic: true)
+    RUBY
+  end
+
   context 'remove_column' do
     it_behaves_like 'accepts', 'remove_column(with type)', <<~RUBY
       remove_column(:suppliers, :qualification, :string)
@@ -196,6 +210,20 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
 
     it_behaves_like 'offense', 'remove_foreign_key(without table)', <<~RUBY
       remove_foreign_key :accounts, column: :owner_id
+    RUBY
+  end
+
+  context 'remove_reference' do
+    it_behaves_like 'accepts', 'up_only', <<~RUBY
+      up_only { remove_reference(:products, :user, index: false) }
+    RUBY
+
+    it_behaves_like 'offense', 'remove_reference', <<~RUBY
+      remove_reference(:products, :user, index: false)
+    RUBY
+
+    it_behaves_like 'offense', 'remove_reference', <<~RUBY
+      remove_reference(:products, :supplier, polymorphic: true)
     RUBY
   end
 

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
   end
 
   context 'change_column' do
+    it_behaves_like 'accepts', 'up_only', <<~RUBY
+      up_only { change_column(:posts, :state, :string) }
+    RUBY
+
     it_behaves_like 'offense', 'change_column', <<~RUBY
       change_column(:posts, :state, :string)
     RUBY

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
+  context 'change_column' do
+    it_behaves_like 'offense', 'change_column', <<~RUBY
+      change_column(:posts, :state, :string)
+    RUBY
+
+    it_behaves_like 'offense', 'change_column', <<~RUBY
+      change_column(:posts, :state, :string, null: false)
+    RUBY
+  end
+
   context 'change_column_default' do
     it_behaves_like 'accepts',
                     'change_column_default(with :from and :to)', <<-RUBY


### PR DESCRIPTION
#591 

`change_column` is not on the [list of the migration definitions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method) supported by the `change` method. This is easy to miss as there are a couple `change_column_*` methods that are supported.

When trying to rollback a migration that uses `change_column` in the `change` method, the rollback will fail.  This change adds the check to `Rails/ReversibleMigration`.

```
➜  $ rubocop -V
1.23.0 (using Parser 3.0.3.1, rubocop-ast 1.13.0, running on ruby 3.0.3 x86_64-darwin20)
  - rubocop-performance 1.12.0
  - rubocop-rails 2.12.4
  - rubocop-rspec 2.5.0
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
