### PR TITLE
[Fix #590] Fix a false positive for `Rails/HelperInstanceVariable`

### DIFF
--- a/changelog/fix_false_positive_for_rails_helper_instance_variable.md
+++ b/changelog/fix_false_positive_for_rails_helper_instance_variable.md
@@ -1,0 +1,1 @@
+* [#590](https://github.com/rubocop/rubocop-rails/issues/590): Fix a false positive for `Rails/HelperInstanceVariable` when open class for `ActionView::Helpers::FormBuilder`. ([@koic][])

--- a/lib/rubocop/cop/rails/helper_instance_variable.rb
+++ b/lib/rubocop/cop/rails/helper_instance_variable.rb
@@ -56,7 +56,7 @@ module RuboCop
 
         def inherit_form_builder?(node)
           node.each_ancestor(:class) do |class_node|
-            return true if form_builder_class?(class_node.parent_class)
+            return true if form_builder_class?(class_node.parent_class) || form_builder_class?(class_node.identifier)
           end
 
           false

--- a/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
+++ b/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable, :config do
     RUBY
   end
 
+  it 'does not register an offense when open class for `ActionView::Helpers::FormBuilder`' do
+    expect_no_offenses(<<~'RUBY')
+      class ActionView::Helpers::FormBuilder
+        def do_something
+          @template
+          @template = do_something
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when a class which inherits `ActionView::Helpers::FormBuilder`' do
     expect_no_offenses(<<~'RUBY')
       class MyFormBuilder < ActionView::Helpers::FormBuilder


### PR DESCRIPTION
Fixes #590.

This PR fixes a false positive for `Rails/HelperInstanceVariable` when open class for `ActionView::Helpers::FormBuilder`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
