### PR TITLE
Allow for Gemfile.local

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ gem 'rubocop-rspec', '~> 2.5.0'
 gem 'simplecov'
 gem 'test-queue'
 gem 'yard', '~> 0.9'
+
+local_gemfile = File.expand_path('Gemfile.local', __dir__)
+eval_gemfile local_gemfile if File.exist?(local_gemfile)


### PR DESCRIPTION
This allows adding dev gems e.g. `pry-byebug` without keeping a dirty `Gemfile`.

It's done in RuboCop itself https://github.com/rubocop/rubocop/blob/e919a8c216731fadf12c50d2658f9a67a30c5cc7/Gemfile#L29

Luckily enough, `Gemfile.local` is already in `.gitignore`, so this wasn't needed

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/