### PR TITLE
Handle ignored_columns from mixins

### DIFF
--- a/changelog/fix_handle_ignored_columns_from_mixins.md
+++ b/changelog/fix_handle_ignored_columns_from_mixins.md
@@ -1,0 +1,1 @@
+* [#601](https://github.com/rubocop/rubocop-rails/pull/601): Handle ignored_columns from mixins for `Rails/UnusedIgnoredColumns` cop. ([@tachyons][])

--- a/lib/rubocop/cop/rails/unused_ignored_columns.rb
+++ b/lib/rubocop/cop/rails/unused_ignored_columns.rb
@@ -61,6 +61,8 @@ module RuboCop
 
         def table(node)
           klass = class_node(node)
+          return unless klass
+
           schema.table_by(name: table_name(klass))
         end
       end

--- a/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
+++ b/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe RuboCop::Cop::Rails::UnusedIgnoredColumns, :config do
       end
     end
 
+    context 'with an used/unused ignored column in a mixin' do
+      it 'does nothing' do
+        expect_no_offenses(<<~RUBY)
+          module Abc
+            self.ignored_columns = [:real_name]
+          end
+        RUBY
+      end
+    end
+
     context 'with an unused ignored column as a String' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Ignored columns can be added from a rails concern. In such cases, Rubocop fails with error as fetching table logic fails.

Before
```
Failure/Error:
       def_node_search :find_belongs_to, <<~PATTERN
         (send nil? :belongs_to {str sym} ...)
       PATTERN

     NoMethodError:
       undefined method `each_node' for nil:NilClass
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
