### PR TITLE
[Fix #603] Teach RedundantPresenceValidationOnBelongsTo to work with multi-attribute validations

### DIFF
--- a/changelog/fix_redundant_presence_validation_with_multi_attributes.md
+++ b/changelog/fix_redundant_presence_validation_with_multi_attributes.md
@@ -1,0 +1,1 @@
+* [#603](https://github.com/rubocop/rubocop-rails/issues/603): Fix autocorrection of multiple attributes for `Rails/RedundantPresenceValidationOnBelongsTo` cop. ([@pirj][])

--- a/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
+++ b/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
@@ -59,14 +59,14 @@ module RuboCop
           )
         PATTERN
 
-        # @!method optional_option?(node)
-        #  Match a `belongs_to` association with an optional option in a hash
+        # @!method optional?(node)
+        #   Match a `belongs_to` association with an optional option in a hash
         def_node_matcher :optional?, <<~PATTERN
           (send nil? :belongs_to _ ... #optional_option?)
         PATTERN
 
         # @!method optional_option?(node)
-        #  Match an optional option in a hash
+        #   Match an optional option in a hash
         def_node_matcher :optional_option?, <<~PATTERN
           {
             (hash <(pair (sym :optional) true) ...>)   # optional: true
@@ -124,7 +124,7 @@ module RuboCop
           )
         PATTERN
 
-        # @!method belongs_to_without_fk?(node, fk)
+        # @!method belongs_to_without_fk?(node, key)
         #   Match a matching `belongs_to` association, without an explicit `foreign_key` option
         #
         #   @param node [RuboCop::AST::Node]

--- a/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
@@ -101,6 +101,20 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
         RUBY
       end
 
+      it 'registers an offense for multiple associations' do
+        expect_offense(<<~RUBY)
+          belongs_to :user
+          belongs_to :book
+          validates :user, :book, presence: true
+                                  ^^^^^^^^^^^^^^ Remove explicit presence validation for `user`/`book`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          belongs_to :user
+          belongs_to :book
+        RUBY
+      end
+
       it 'registers an offense for presence with a message' do
         expect_offense(<<~RUBY)
           belongs_to :user

--- a/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
@@ -115,6 +115,64 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
         RUBY
       end
 
+      it 'registers an offense for multiple attributes when not all are associations' do
+        expect_offense(<<~RUBY)
+          belongs_to :user
+          validates :user, :name, presence: true
+                                  ^^^^^^^^^^^^^^ Remove explicit presence validation for `user`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          belongs_to :user
+          validates :name, presence: true
+        RUBY
+      end
+
+      it 'registers an offense for a secondary attribute' do
+        expect_offense(<<~RUBY)
+          belongs_to :user
+          validates :name, :user, presence: true
+                                  ^^^^^^^^^^^^^^ Remove explicit presence validation for `user`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          belongs_to :user
+          validates :name, presence: true
+        RUBY
+      end
+
+      it 'registers an offense for multiple attributes and options' do
+        expect_offense(<<~RUBY)
+          belongs_to :user
+          validates :user, :name, presence: true, uniqueness: true
+                                  ^^^^^^^^^^^^^^ Remove explicit presence validation for `user`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          belongs_to :user
+          validates :name, presence: true, uniqueness: true
+          validates :user, uniqueness: true
+        RUBY
+      end
+
+      it 'preserves indentation for the extracted validation line' do
+        expect_offense(<<~RUBY)
+          class Profile
+            belongs_to :user
+            validates :user, :name, presence: true, uniqueness: true
+                                    ^^^^^^^^^^^^^^ Remove explicit presence validation for `user`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Profile
+            belongs_to :user
+            validates :name, presence: true, uniqueness: true
+            validates :user, uniqueness: true
+          end
+        RUBY
+      end
+
       it 'registers an offense for presence with a message' do
         expect_offense(<<~RUBY)
           belongs_to :user


### PR DESCRIPTION
fixes #603


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/