### PR TITLE
Allow ignoring scopes for inverse_of cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,3 +519,4 @@
 [@leoarnold]: https://github.com/leoarnold
 [@TonyArra]: https://github.com/TonyArra
 [@tachyons]: https://github.com/tachyons
+[@composerinteralia]: https://github.com/composerinteralia

--- a/changelog/new_allow_ignoring_scopes_for_inverse_of_cop.md
+++ b/changelog/new_allow_ignoring_scopes_for_inverse_of_cop.md
@@ -1,0 +1,1 @@
+* [#614](https://github.com/rubocop/rubocop-rails/pull/614): Add `IgnoreScopes` config option for `Rails/InverseOf` cop. ([@composerinteralia][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -453,6 +453,7 @@ Rails/InverseOf:
   Description: 'Checks for associations where the inverse cannot be determined automatically.'
   Enabled: true
   VersionAdded: '0.52'
+  IgnoreScopes: false
   Include:
     - app/models/**/*.rb
 

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -126,6 +126,18 @@ module RuboCop
       #     has_many :physicians, through: :appointments
       #   end
       #
+      # @example IgnoreScopes: false (default)
+      #   # bad
+      #   class Blog < ApplicationRecord
+      #     has_many :posts, -> { order(published_at: :desc) }
+      #   end
+      #
+      # @example IgnoreScopes: true
+      #   # good
+      #   class Blog < ApplicationRecord
+      #     has_many :posts, -> { order(published_at: :desc) }
+      #   end
+      #
       # @see https://guides.rubyonrails.org/association_basics.html#bi-directional-associations
       # @see https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Setting+Inverses
       class InverseOf < Base
@@ -189,7 +201,7 @@ module RuboCop
         end
 
         def scope?(arguments)
-          arguments.any?(&:block_type?)
+          !ignore_scopes? && arguments.any?(&:block_type?)
         end
 
         def options_requiring_inverse_of?(options)
@@ -235,6 +247,10 @@ module RuboCop
           else
             SPECIFY_MSG
           end
+        end
+
+        def ignore_scopes?
+          cop_config['IgnoreScopes'] == true
         end
       end
     end

--- a/spec/rubocop/cop/rails/inverse_of_spec.rb
+++ b/spec/rubocop/cop/rails/inverse_of_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe RuboCop::Cop::Rails::InverseOf, :config do
         end
       RUBY
     end
+
+    context 'when `IgnoreScopes: true`' do
+      let(:cop_config) do
+        { 'IgnoreScopes' => true }
+      end
+
+      it 'does not register an offense when not specifying `:inverse_of`' do
+        expect_no_offenses(
+          'has_many :foo, -> () { where(bar: true) }'
+        )
+      end
+    end
   end
 
   context 'with option preventing automatic inverse' do


### PR DESCRIPTION
With https://github.com/rails/rails/pull/43358, Rails can now infer
inverse_of for associations with a scope when
`config.active_record.automatic_scope_inversing = true`.

This commit adds an `IgnoreScopes` option to the inverse_of cop allowing
us to disable the cop for scopes when the new Rails option is set to
`true`.

I considered having the default for `IgnoreScopes` change based on the
Rails version since this is the default for new Rails >= 7.0
applications, but existing applications that upgrade to 7.0 wouldn't
necessarily have the option set and in that case changing the
rubocop-rails default behavior would be a breaking change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
