### PR TITLE
[Fix #615] Change Rails/RedundantPresenceValidationOnBelongsTo to SafeAutoCorrect: false

### DIFF
--- a/changelog/change_mark_redundant_presence_validation_on_belongs_to_as_unsafe_autocorrect.md
+++ b/changelog/change_mark_redundant_presence_validation_on_belongs_to_as_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#615](https://github.com/rubocop/rubocop-rails/issues/615): Change `Rails/RedundantPresenceValidationOnBelongsTo` to `SafeAutoCorrect: false`. ([@TonyArra][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -627,7 +627,9 @@ Rails/RedundantForeignKey:
 Rails/RedundantPresenceValidationOnBelongsTo:
   Description: 'Checks for redundant presence validation on belongs_to association.'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '2.13'
+  VersionChanged: '<<next>>'
 
 Rails/RedundantReceiverInWithOptions:
   Description: 'Checks for redundant receiver in `with_options`.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3572,7 +3572,7 @@ end
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 2.13
 | -
 |===

--- a/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
+++ b/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
@@ -8,6 +8,10 @@ module RuboCop
       # explicitly set to `false`. The presence validator is added
       # automatically, and explicit presence validation is redundant.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because it changes the default error message
+      #   from "can't be blank" to "must exist".
+      #
       # @example
       #   # bad
       #   belongs_to :user


### PR DESCRIPTION
Fixes #615

Change `Rails/RedundantPresenceValidationOnBelongsTo` to `SafeAutoCorrect: false`

As discussed in #615, this cop's autocorrect is unsafe because it changes the validation error message from "can't be blank" to "must exist". This can break tests and behavior that rely on the error message (such as localizations).

Basing my changes off of #582, I don't believe this requires any test changes, so I've just updated the documentation here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
