### PR TITLE
[Fix #623] Skip method shadowing check if attr is not sym or str for ReadWriteAttribute

### DIFF
--- a/changelog/fix_skip_method_shadowing_check_if_attr_is_non_str_or_sym.md
+++ b/changelog/fix_skip_method_shadowing_check_if_attr_is_non_str_or_sym.md
@@ -1,0 +1,1 @@
+* [#623](https://github.com/rubocop/rubocop-rails/issues/623): Fix method shadowing check for `Rails/ReadWriteAttribute` cop. ([@nvasilevski][])

--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -59,12 +59,15 @@ module RuboCop
         private
 
         def within_shadowing_method?(node)
-          node.each_ancestor(:def).any? do |enclosing_method|
-            shadowing_method_name = node.first_argument.value.to_s
-            shadowing_method_name << '=' if node.method?(:write_attribute)
+          first_arg = node.first_argument
+          return false unless first_arg.respond_to?(:value)
 
-            enclosing_method.method_name.to_s == shadowing_method_name
-          end
+          enclosing_method = node.each_ancestor(:def).first
+          return false unless enclosing_method
+
+          shadowing_method_name = first_arg.value.to_s
+          shadowing_method_name << '=' if node.method?(:write_attribute)
+          enclosing_method.method?(shadowing_method_name)
         end
 
         def build_message(node)

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -89,6 +89,42 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'registers no offense with explicit receiver' do
       expect_no_offenses('res = object.read_attribute(:test)')
     end
+
+    context 'when used within a method' do
+      context 'when using variable for the attribute name' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            def do_the_read_from(column)
+              read_attribute(column)
+              ^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[column]`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def do_the_read_from(column)
+              self[column]
+            end
+          RUBY
+        end
+      end
+
+      context 'when using constant for the attribute name' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            def do_the_read
+              read_attribute(ATTR_NAME)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[ATTR_NAME]`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def do_the_read
+              self[ATTR_NAME]
+            end
+          RUBY
+        end
+      end
+    end
   end
 
   context 'write_attribute' do
@@ -102,6 +138,42 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
         expect_correction(<<~RUBY)
           self[:test] = val
         RUBY
+      end
+    end
+
+    context 'when used within a method' do
+      context 'when using variable for the attribute name' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            def do_the_write_to(column)
+              write_attribute(column, 'value')
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[column] = 'value'`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def do_the_write_to(column)
+              self[column] = 'value'
+            end
+          RUBY
+        end
+      end
+
+      context 'when using constant for the attribute name' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            def do_the_write(value)
+              write_attribute(ATTR_NAME, value)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[ATTR_NAME] = value`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def do_the_write(value)
+              self[ATTR_NAME] = value
+            end
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop-rails/issues/623

Fixes rubocop exceptions like:
```
undefined method `value' for s(:lvar, :column):RuboCop::AST::Node
```

for read/write methods used within a method and using non-string or non-symbol argument names 
for example: 

```ruby
def do_the_read
  read_attribute(ATTR_NAME)
end
```

So I decided to skip the "shadowing" check if we can't explicitly know the attribute name.

Later we may want to exclude cases like this because it's also shadowing and should be fairly easy to detect this one. But for now I decided to fix the exception and consider an improvement in a separate PR 

```ruby
    def define_date_column_writer(column, value)
      define_method("#{column}=") do |value|
        # currently a violation
        write_attribute(column, value)
      end
    end
```


Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
