### PR TITLE
[ReadWriteAttribute] Improve cop message to be more dynamic

### DIFF
--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'registers an offense and corrects a symbol' do
       expect_offense(<<~RUBY)
         res = read_attribute(:test)
-              ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+              ^^^^^^^^^^^^^^^^^^^^^ Prefer `self[:test]`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'register an offense and corrects a string' do
       expect_offense(<<~RUBY)
         res = read_attribute('test')
-              ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+              ^^^^^^^^^^^^^^^^^^^^^^ Prefer `self['test']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
       expect_offense(<<~RUBY)
         def foo
           bar || read_attribute(:baz)
-                 ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+                 ^^^^^^^^^^^^^^^^^^^^ Prefer `self[:baz]`.
         end
       RUBY
 
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'autocorrects without parentheses' do
       expect_offense(<<~RUBY)
         res = read_attribute 'test'
-              ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+              ^^^^^^^^^^^^^^^^^^^^^ Prefer `self['test']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'corrects an expression' do
       expect_offense(<<~RUBY)
         res = read_attribute('test_' + postfix)
-              ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self['test_' + postfix]`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'corrects multiline' do
       expect_offense(<<~RUBY)
         res = read_attribute(
-              ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+              ^^^^^^^^^^^^^^^ Prefer `self[:attr]`.
         (
         'test_' + postfix
         ).to_sym
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           write_attribute(:test, val)
-          ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[:test] = val`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           write_attribute('attr', 'test')
-          ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self['attr'] = 'test'`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'registers an offense and corrects without parentheses' do
       expect_offense(<<~RUBY)
         write_attribute 'attr', 'test'
-        ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self['attr'] = 'test'`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -141,7 +141,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
       expect_offense(<<~RUBY)
         def foo=(value)
           bar(value) || write_attribute(:baz, "baz")
-                        ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[:baz] = "baz"`.
         end
       RUBY
 
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'corrects assignment with chained methods' do
       expect_offense(<<~RUBY)
         write_attribute(:attr, 'test_' + postfix)
-        ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self[:attr] = 'test_' + postfix`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
     it 'autocorrects multiline' do
       expect_offense(<<~RUBY)
         write_attribute(
-        ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+        ^^^^^^^^^^^^^^^^ Prefer `self[:attr] = val`.
         :attr,
         (
         'test_' + postfix


### PR DESCRIPTION
This is almost a cosmetic change but I noticed that the cop has almost everything in place to produce a bit more dynamic violation messages to avoid confusions when possible.

So I changed it to build messages based on actual code instead of hardcoded examples.

The only case when I keep the hardcoded message is when the node is multiline. In this case the message was not really readable so I decided to keep it as is

I wonder if we could omit the `over ... ` part because it essentially duplicates the highlighted code ❓ 

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
