### PR TITLE
Add months and years to `Rails/DurationArithmetic` cop duration method set

### DIFF
--- a/changelog/fix_missing_duration_methods_for_rails_duration_arithmetic.md
+++ b/changelog/fix_missing_duration_methods_for_rails_duration_arithmetic.md
@@ -1,0 +1,1 @@
+* [#622](https://github.com/rubocop/rubocop-rails/pull/622): Add `month(s)` and `year(s)` to `Rails/DurationArithmetic` cop. ([@agrobbin][])

--- a/lib/rubocop/cop/rails/duration_arithmetic.rb
+++ b/lib/rubocop/cop/rails/duration_arithmetic.rb
@@ -26,7 +26,8 @@ module RuboCop
         RESTRICT_ON_SEND = %i[+ -].freeze
 
         DURATIONS = Set[:second, :seconds, :minute, :minutes, :hour, :hours,
-                        :day, :days, :week, :weeks, :fortnight, :fortnights]
+                        :day, :days, :week, :weeks, :fortnight, :fortnights,
+                        :month, :months, :year, :years]
 
         # @!method duration_arithmetic_argument?(node)
         #   Match duration subtraction or addition with current time.

--- a/spec/rubocop/cop/rails/duration_arithmetic_spec.rb
+++ b/spec/rubocop/cop/rails/duration_arithmetic_spec.rb
@@ -1,20 +1,85 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::DurationArithmetic, :config do
-  it 'registers an offense and corrects' do
+  it 'registers an offense and corrects Time.zone.now instances' do
     expect_offense(<<~RUBY)
-      Time.zone.now - 1.minute
+      Time.zone.now - 1.second
       ^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
-      Time.current + 2.days
-      ^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
-      ::Time.current + 1.hour
-      ^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.zone.now - 2.seconds
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.zone.now + 1.second
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.zone.now + 2.seconds
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
     RUBY
 
     expect_correction(<<~RUBY)
-      1.minute.ago
-      2.days.from_now
+      1.second.ago
+      2.seconds.ago
+      1.second.from_now
+      2.seconds.from_now
+    RUBY
+  end
+
+  it 'registers an offense and corrects all duration arithmetic methods' do
+    expect_offense(<<~RUBY)
+      Time.current - 1.second
+      ^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current - 2.seconds
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.second
+      ^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.seconds
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.minute
+      ^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.minutes
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.hour
+      ^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.hours
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.day
+      ^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.days
+      ^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.week
+      ^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.weeks
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.fortnight
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.fortnights
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.month
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.months
+      ^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 1.year
+      ^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+      Time.current + 2.years
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1.second.ago
+      2.seconds.ago
+      1.second.from_now
+      2.seconds.from_now
+      1.minute.from_now
+      2.minutes.from_now
       1.hour.from_now
+      2.hours.from_now
+      1.day.from_now
+      2.days.from_now
+      1.week.from_now
+      2.weeks.from_now
+      1.fortnight.from_now
+      2.fortnights.from_now
+      1.month.from_now
+      2.months.from_now
+      1.year.from_now
+      2.years.from_now
     RUBY
   end
 


### PR DESCRIPTION
`month(s)` and `year(s)` were [inadvertently missed](https://github.com/rubocop/rubocop-rails/pull/571#discussion_r782330604) when implementation `Rails/DurationArithmetic`, so I've added them here! I've also add some additional test coverage to ensure we are accounting for all of these duration arithmetic methods.