### PR TITLE
[Fix #620] Fix a false positive for `Rails/RedundantPresenceValidationOnBelongsTo`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_redundant_presence_validation_on_belongs_to.md
+++ b/changelog/fix_a_false_positive_for_rails_redundant_presence_validation_on_belongs_to.md
@@ -1,0 +1,1 @@
+* [#620](https://github.com/rubocop/rubocop-rails/issues/620): Fix a false positive for `Rails/RedundantPresenceValidationOnBelongsTo` using presence with a message. ([@koic][])

--- a/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
+++ b/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
@@ -50,9 +50,6 @@ module RuboCop
         #   @example source that matches - by association
         #     validates :name, :user, presence: true
         #
-        #   @example source that matches - with presence options
-        #     validates :user, presence: { message: 'duplicate' }
-        #
         #   @example source that matches - by a foreign key
         #     validates :user_id, presence: true
         #
@@ -66,7 +63,7 @@ module RuboCop
             send nil? :validates
             (sym $_)+
             $[
-              (hash <$(pair (sym :presence) {true hash}) ...>)  # presence: true
+              (hash <$(pair (sym :presence) true) ...>)         # presence: true
               !(hash <$(pair (sym :strict) {true const}) ...>)  # strict: true
             ]
           )

--- a/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
@@ -173,15 +173,10 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
         RUBY
       end
 
-      it 'registers an offense for presence with a message' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense for presence with a message' do
+        expect_no_offenses(<<~RUBY)
           belongs_to :user
           validates :user, presence: { message: 'Must be present' }
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove explicit presence validation for `user`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          belongs_to :user
         RUBY
       end
 


### PR DESCRIPTION
Fixes #620.

This PR fixes a false positive for `Rails/RedundantPresenceValidationOnBelongsTo` using presence with a message ~~and reverts #616 because accept the use case~~.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
