### PR TITLE
[Fix #626] Fix a false positive for `Rails/CompactBlank`

### DIFF
--- a/changelog/fix_false_positive_for_rails_compact_blank.md
+++ b/changelog/fix_false_positive_for_rails_compact_blank.md
@@ -1,0 +1,1 @@
+* [#626](https://github.com/rubocop/rubocop-rails/issues/626): Fix a false positive for `Rails/CompactBlank` when using the receiver of `blank?` is not a block variable. ([@koic][])

--- a/lib/rubocop/cop/rails/compact_blank.rb
+++ b/lib/rubocop/cop/rails/compact_blank.rb
@@ -73,10 +73,15 @@ module RuboCop
           return true if reject_with_block_pass?(node)
 
           if (arguments, receiver_in_block = reject_with_block?(node.parent))
-            return arguments.length == 1 || use_hash_value_block_argument?(arguments, receiver_in_block)
+            return use_single_value_block_argument?(arguments, receiver_in_block) ||
+                   use_hash_value_block_argument?(arguments, receiver_in_block)
           end
 
           false
+        end
+
+        def use_single_value_block_argument?(arguments, receiver_in_block)
+          arguments.length == 1 && arguments[0].source == receiver_in_block.source
         end
 
         def use_hash_value_block_argument?(arguments, receiver_in_block)

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -118,6 +118,14 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
         collection.reject { |k, v| k.empty? }
       RUBY
     end
+
+    it 'does not register an offense when using the receiver of `blank?` is not a block variable' do
+      expect_no_offenses(<<~RUBY)
+        def foo(arg)
+          collection.reject { |_| arg.blank? }
+        end
+      RUBY
+    end
   end
 
   context 'Rails <= 6.0', :rails60 do


### PR DESCRIPTION
Fixes #626.

Fix a false positive for `Rails/CompactBlank` when using the receiver of `blank?` is not a block variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
