### PR TITLE
[Fix #628] Fix a false positive for `Rails/CompactBlank`

### DIFF
--- a/lib/rubocop/cop/rails/compact_blank.rb
+++ b/lib/rubocop/cop/rails/compact_blank.rb
@@ -10,25 +10,21 @@ module RuboCop
       #   blank check of block arguments to the receiver object.
       #
       #   For example, `[[1, 2], [3, nil]].reject { |first, second| second.blank? }` and
-      #   `[[1, 2], [3, nil]].compact_blank` are not compatible. The same is true for `empty?`.
+      #   `[[1, 2], [3, nil]].compact_blank` are not compatible. The same is true for `blank?`.
       #   This will work fine when the receiver is a hash object.
       #
       # @example
       #
       #   # bad
       #   collection.reject(&:blank?)
-      #   collection.reject(&:empty?)
       #   collection.reject { |_k, v| v.blank? }
-      #   collection.reject { |_k, v| v.empty? }
       #
       #   # good
       #   collection.compact_blank
       #
       #   # bad
       #   collection.reject!(&:blank?)
-      #   collection.reject!(&:empty?)
       #   collection.reject! { |_k, v| v.blank? }
-      #   collection.reject! { |_k, v| v.empty? }
       #
       #   # good
       #   collection.compact_blank!
@@ -48,13 +44,13 @@ module RuboCop
             (send _ {:reject :reject!})
             $(args ...)
             (send
-              $(lvar _) {:blank? :empty?}))
+              $(lvar _) :blank?))
         PATTERN
 
         def_node_matcher :reject_with_block_pass?, <<~PATTERN
           (send _ {:reject :reject!}
             (block_pass
-              (sym {:blank? :empty?})))
+              (sym :blank?)))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -13,31 +13,9 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `reject { |e| e.empty? }`' do
-      expect_offense(<<~RUBY)
-        collection.reject { |e| e.empty? }
-                   ^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank
-      RUBY
-    end
-
     it 'registers and corrects an offense when using `reject(&:blank?)`' do
       expect_offense(<<~RUBY)
         collection.reject(&:blank?)
-                   ^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank
-      RUBY
-    end
-
-    it 'registers and corrects an offense when using `reject(&:empty?)`' do
-      expect_offense(<<~RUBY)
-        collection.reject(&:empty?)
                    ^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
       RUBY
 
@@ -57,17 +35,6 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `reject! { |e| e.empty? }`' do
-      expect_offense(<<~RUBY)
-        collection.reject! { |e| e.empty? }
-                   ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank!
-      RUBY
-    end
-
     it 'registers and corrects an offense when using `reject!(&:blank?)`' do
       expect_offense(<<~RUBY)
         collection.reject!(&:blank?)
@@ -76,28 +43,6 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
 
       expect_correction(<<~RUBY)
         collection.compact_blank!
-      RUBY
-    end
-
-    it 'registers and corrects an offense when using `reject!(&:empty?)`' do
-      expect_offense(<<~RUBY)
-        collection.reject!(&:empty?)
-                   ^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank!
-      RUBY
-    end
-
-    it 'registers and corrects an offense when using `reject { |k, v| v.empty? }`' do
-      expect_offense(<<~RUBY)
-        collection.reject { |k, v| v.empty? }
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank
       RUBY
     end
 
@@ -113,9 +58,9 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
-    it 'does not register an offense when using `reject { |k, v| k.empty? }`' do
+    it 'does not register an offense when using `reject { |k, v| k.blank? }`' do
       expect_no_offenses(<<~RUBY)
-        collection.reject { |k, v| k.empty? }
+        collection.reject { |k, v| k.blank? }
       RUBY
     end
 
@@ -124,6 +69,12 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
         def foo(arg)
           collection.reject { |_| arg.blank? }
         end
+      RUBY
+    end
+
+    it 'does not register an offense when using `reject { |e| e.empty? }`' do
+      expect_no_offenses(<<~RUBY)
+        collection.reject { |e| e.empty? }
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #628.

This PR fixes a false positive for `Rails/CompactBlank` when using `collection.reject(&:empty?)`.

`compact_blank`'s implementation targets `blank?` only. `empty?` is irrelevant.
https://github.com/rails/rails/blob/v7.0.1/activesupport/lib/active_support/core_ext/enumerable.rb#L205-L220

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
