### PR TITLE
Update `Rails/Pluck` to be aware of numblocks

### DIFF
--- a/changelog/change_update_railspluck_to_be_aware_of.md
+++ b/changelog/change_update_railspluck_to_be_aware_of.md
@@ -1,0 +1,1 @@
+* [#631](https://github.com/rubocop/rubocop-rails/pull/631): Update `Rails/Pluck` to be aware of numblocks. ([@sammiya][])

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
           RUBY
         end
       end
+
+      context 'when using Ruby 2.7 or newer', :ruby27 do
+        context 'when using numbered parameter' do
+          context "when `#{method}` can be replaced with `pluck`" do
+            it 'registers an offense' do
+              expect_offense(<<~RUBY, method: method)
+                x.%{method} { _1[:foo] }
+                  ^{method}^^^^^^^^^^^^^ Prefer `pluck(:foo)` over `%{method} { _1[:foo] }`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                x.pluck(:foo)
+              RUBY
+            end
+          end
+        end
+      end
     end
 
     context 'when using Rails 4.2 or older', :rails42 do


### PR DESCRIPTION
Fixed `Rails/Pluck` to catch `map { _1[:foo] }`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
