### PR TITLE
Handle t.remove with multiple columns in Rails/BulkChangeTable

### DIFF
--- a/changelog/fix_bulk_change_table_remove_multiple_columns.md
+++ b/changelog/fix_bulk_change_table_remove_multiple_columns.md
@@ -1,0 +1,1 @@
+* [#635](https://github.com/rubocop/rubocop-rails/pull/635): Handle `t.remove` with multiple columns in `Rails/BulkChangeTable`. ([@eugeneius][])

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -387,6 +387,48 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
     end
+
+    it 'registers an offense for a single `t.remove` with multiple columns' do
+      expect_offense(<<~RUBY)
+        def change
+          change_table :users do |t|
+          ^^^^^^^^^^^^^^^^^^^ You can combine alter queries using `bulk: true` options.
+            t.remove :name, :metadata
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a single `t.remove` with one column' do
+      expect_no_offenses(<<~RUBY)
+        def change
+          change_table :users do |t|
+            t.remove :name
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a single `t.remove` with multiple columns and options' do
+      expect_offense(<<~RUBY)
+        def change
+          change_table :users do |t|
+          ^^^^^^^^^^^^^^^^^^^ You can combine alter queries using `bulk: true` options.
+            t.remove :name, :metadata, type: :string
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a single `t.remove` with one column and options' do
+      expect_no_offenses(<<~RUBY)
+        def change
+          change_table :users do |t|
+            t.remove :name, type: :string
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when database is PostgreSQL' do


### PR DESCRIPTION
`t.remove` can take multiple columns, so a `change_table` block with a single `t.remove` can still benefit from `bulk: true`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/