### PR TITLE
[Fix #636] Fix a false positive for `Rails/ContentTag`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_content_tag.md
+++ b/changelog/fix_a_false_positive_for_rails_content_tag.md
@@ -1,0 +1,1 @@
+* [#636](https://github.com/rubocop/rubocop-rails/issues/636): Fix a false positive for `Rails/ContentTag` when using `tag` method in config/puma.rb. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -195,9 +195,12 @@ Rails/ContentTag:
   Enabled: true
   VersionAdded: '2.6'
   VersionChanged: '2.12'
-  # This `Exclude` config prevents false positives for `tag` calls to `has_one: tag`. No helpers are used in normal models.
+  # This `Exclude` config prevents false positives for `tag` calls to `has_one: tag` and Puma configuration:
+  # https://puma.io/puma/Puma/DSL.html#tag-instance_method
+  # No helpers are used in normal models and configs.
   Exclude:
     - app/models/**/*.rb
+    - config/**/*.rb
 
 Rails/CreateTableWithTimestamps:
   Description: >-


### PR DESCRIPTION
Fixes #636.

This PR fixes a false positive for `Rails/ContentTag` when using `tag` method in config/puma.rb.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
