### PR TITLE
Add Rails/ControllerTesting cop

### DIFF
--- a/changelog/new_rails_action_controller_test_case_cop.md
+++ b/changelog/new_rails_action_controller_test_case_cop.md
@@ -1,0 +1,1 @@
+* [#638](https://github.com/rubocop/rubocop-rails/pull/638): Add new `Rails/ActionControllerTestCase` cop. ([@gmcgibbon][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -38,6 +38,16 @@ Lint/NumberConversion:
     - fortnights
     - in_milliseconds
 
+Rails/ActionControllerTestCase:
+  Description: 'Use `ActionDispatch::IntegrationTest` instead of `ActionController::TestCase`.'
+  StyleGuide: 'https://rails.rubystyle.guide/#integration-testing'
+  Reference: 'https://api.rubyonrails.org/classes/ActionController/TestCase.html'
+  Enabled: 'pending'
+  SafeAutocorrect: false
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/test/**/*.rb'
+
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: true

--- a/lib/rubocop/cop/rails/action_controller_test_case.rb
+++ b/lib/rubocop/cop/rails/action_controller_test_case.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Using `ActionController::TestCase`` is discouraged and should be replaced by
+      # `ActionDispatch::IntegrationTest``. Controller tests are too close to the
+      # internals of a controller whereas integration tests mimic the browser/user.
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe because the API of each test case class is different.
+      #   Make sure to update each test of your controller test cases after changing the superclass.
+      #
+      # @example
+      #   # bad
+      #   class MyControllerTest < ActionController::TestCase
+      #   end
+      #
+      #   # good
+      #   class MyControllerTest < ActionDispatch::IntegrationTest
+      #   end
+      #
+      class ActionControllerTestCase < Base
+        extend AutoCorrector
+        extend TargetRailsVersion
+
+        MSG = 'Use `ActionDispatch::IntegrationTest` instead.'
+
+        minimum_target_rails_version 5.0
+
+        def_node_matcher :action_controller_test_case?, <<~PATTERN
+          (class
+            (const nil? _)
+            (const (const {nil? cbase} :ActionController) :TestCase) nil?)
+        PATTERN
+
+        def on_class(node)
+          return unless action_controller_test_case?(node)
+
+          add_offense(node.parent_class) do |corrector|
+            corrector.replace(node.parent_class, 'ActionDispatch::IntegrationTest')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -7,6 +7,7 @@ require_relative 'mixin/index_method'
 require_relative 'mixin/migrations_helper'
 require_relative 'mixin/target_rails_version'
 
+require_relative 'rails/action_controller_test_case'
 require_relative 'rails/action_filter'
 require_relative 'rails/active_record_aliases'
 require_relative 'rails/active_record_callbacks_order'

--- a/spec/rubocop/cop/rails/action_controller_test_case_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_test_case_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::ActionControllerTestCase, :config do
+  context 'Rails 4.2', :rails42 do
+    it 'does not add offense when extending `ActionController::TestCase`' do
+      expect_no_offenses(<<~RUBY)
+        class MyControllerTest < ActionController::TestCase
+        end
+      RUBY
+    end
+  end
+
+  it 'adds offense when extending `ActionController::TestCase`' do
+    expect_offense(<<~RUBY)
+      class MyControllerTest < ActionController::TestCase
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `ActionDispatch::IntegrationTest` instead.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MyControllerTest < ActionDispatch::IntegrationTest
+      end
+    RUBY
+  end
+
+  it 'adds offense when extending `::ActionController::TestCase`' do
+    expect_offense(<<~RUBY)
+      class MyControllerTest < ::ActionController::TestCase
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `ActionDispatch::IntegrationTest` instead.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MyControllerTest < ActionDispatch::IntegrationTest
+      end
+    RUBY
+  end
+
+  it 'does not add offense when extending `ActionDispatch::IntegrationTest`' do
+    expect_no_offenses(<<~RUBY)
+      class MyControllerTest < ActionDispatch::IntegrationTest
+      end
+    RUBY
+  end
+
+  it 'does not add offense when extending custom superclass' do
+    expect_no_offenses(<<~RUBY)
+      class MyControllerTest < SuperControllerTest
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
👋 I wrote a cop recently to list usage of all old controller tests. Essentially, it replaces `ActionController::TestCase` with `ActionDispatch::IntegrationTest`. The actual process of converting between the two test case types is a little more involved, but I think the cop is valuable just to keep track of this tech debt within a codebase. I thought that other developers could possibly benefit from this cop as well. Let me know what you think. Thanks!

Add controller testing cop to discourage use of `ActionController::TestCase`. `ActionDispatch::IntegrationTest` should be used instead to test controllers. See https://api.rubyonrails.org/classes/ActionController/TestCase.html

> Rails discourages the use of functional tests in favor of integration tests (use [ActionDispatch::IntegrationTest](https://api.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html)).

Related issue for updating the style guide: https://github.com/rubocop/rails-style-guide/issues/302.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
