### PR TITLE
[Fix #646] Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default

### DIFF
--- a/changelog/change_exclude_db_schema_rb_and_db_configuration_namespace_schema_rb_by_default.md
+++ b/changelog/change_exclude_db_schema_rb_and_db_configuration_namespace_schema_rb_by_default.md
@@ -1,0 +1,1 @@
+* [#646](https://github.com/rubocop/rubocop-rails/issues/646): Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,7 +7,9 @@ inherit_mode:
 AllCops:
   Exclude:
     - bin/*
-    - db/schema.rb
+    # Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default.
+    # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application
+    - db/*schema.rb
   # What version of Rails is the inspected code using?  If a value is specified
   # for TargetRailsVersion then it is used.  Acceptable values are specified
   # as a float (i.e. 5.1); the patch version of Rails should not be included.

--- a/spec/rubocop/rails/inject_spec.rb
+++ b/spec/rubocop/rails/inject_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Rails::Inject do
       expect(configuration['AllCops']['Exclude'])
         .to include(
           '/home/foo/project/bin/*',
-          '/home/foo/project/db/schema.rb'
+          '/home/foo/project/db/*schema.rb'
         )
     end
   end


### PR DESCRIPTION
Fixes #646.

This PR excludes db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default.
schema.rb will be the only file matched by `*schema.rb` directly under the db directory. So I don't think there is any concern about false positives for plain Rails application.

See: https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
