### PR TITLE
[Fix #650] Make `Rails/CompactBlank` aware of `delete_if(&:blank)`

### DIFF
--- a/changelog/change_make_rails_compact_blank_aware_of_reject_delete_if.md
+++ b/changelog/change_make_rails_compact_blank_aware_of_reject_delete_if.md
@@ -1,0 +1,1 @@
+* [#650](https://github.com/rubocop/rubocop-rails/issues/650): Make `Rails/CompactBlank` aware of `delete_if(&:blank)`. ([@koic][])

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -24,6 +24,28 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `delete_if { |e| e.blank? }`' do
+      expect_offense(<<~RUBY)
+        collection.delete_if { |e| e.blank? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank!
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `delete_if(&:blank?)`' do
+      expect_offense(<<~RUBY)
+        collection.delete_if(&:blank?)
+                   ^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank!
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `reject! { |e| e.blank? }`' do
       expect_offense(<<~RUBY)
         collection.reject! { |e| e.blank? }


### PR DESCRIPTION
Fixes #650.

This PR makes `Rails/CompactBlank` aware of `delete_if(&:blank)`.

It is unsafe because `compact_blank!` has different implementations for `Array`, `Hash`, and `ActionController::Parameters`.
`Array#compact_blank!`, `Hash#compact_blank!` are equivalent to `delete_if(&:blank?)`.
`ActionController::Parameters#compact_blank!` is equivalent to `reject!(&:blank?)`.
If the cop makes a mistake, auto-corrected code may get unexpected behavior.

This PR also updates unsafe document about it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
