### PR TITLE
Only consider migration classes for `MigrationClassName`

### DIFF
--- a/changelog/fix_only_consider_migration_classes_for_migration_class_name.md
+++ b/changelog/fix_only_consider_migration_classes_for_migration_class_name.md
@@ -1,0 +1,1 @@
+* [#657](https://github.com/rubocop/rubocop-rails/pull/657): Only consider migration classes for `Rails/MigrationClassName`. ([@sunny][])

--- a/lib/rubocop/cop/rails/migration_class_name.rb
+++ b/lib/rubocop/cop/rails/migration_class_name.rb
@@ -20,10 +20,13 @@ module RuboCop
       #
       class MigrationClassName < Base
         extend AutoCorrector
+        include MigrationsHelper
 
         MSG = 'Replace with `%<corrected_class_name>s` that matches the file name.'
 
         def on_class(node)
+          return if in_migration?(node)
+
           snake_class_name = to_snakecase(node.identifier.source)
 
           return if snake_class_name == basename_without_timestamp

--- a/spec/rubocop/cop/rails/migration_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/migration_class_name_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe RuboCop::Cop::Rails::MigrationClassName, :config do
         end
       RUBY
     end
+
+    context 'when defining another class' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, filename)
+          class CreateUsers < ActiveRecord::Migration[7.0]
+            class Article < ActiveRecord::Base
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when the class name does not match its file name' do


### PR DESCRIPTION
Adds a fix to #644 when calling using multiple classes inside a migration.

Currently, when using the pattern of redefining ActiveRecord classes inside the migration in order not to depend on the app’s classes:

```rb
class UpdateLocaleOnArticles < ActiveRecord::Migration[6.1]
  class Article < ActiveRecord::Base
  end

  def up
    Article.update_all(locale: "fr")
  end
end
```

Produces:

```
db/migrate/20211025103032_update_locale_on_articles.rb:4:9: C: [Correctable] Rails/MigrationClassName: Replace with UpdateLocaleOnArticles that matches the file name.
  class Article < ActiveRecord::Base
        ^^^^^^^
```

Which autocorrects to:

```
db/migrate/20211025103032_update_locale_on_articles.rb:4:9: C: [Correctable] Rails/MigrationClassName: Replace with UpdateLocaleOnArticles that matches the file name.
  class UpdateLocaleOnArticles < ActiveRecord::Base
        ^^^^^^^^^^^^^^^^^^^^^^
```

This fix ignores classes included inside the migration.

-----------------

Before submitting the PR make sure the following are checked:

* [x ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
