### PR TITLE
[Fix #658] Fix a false positive for `Rails/TransactionExitStatement`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_transaction_exit_statement.md
+++ b/changelog/fix_a_false_positive_for_rails_transaction_exit_statement.md
@@ -1,0 +1,1 @@
+* [#658](https://github.com/rubocop/rubocop-rails/issues/658): Fix a false positive for `Rails/TransactionExitStatement` when `break` is used in `loop` in transactions. ([@koic][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -59,16 +59,24 @@ module RuboCop
           return unless parent&.block_type?
 
           exit_statements(parent.body).each do |statement_node|
-            statement = if statement_node.return_type?
-                          'return'
-                        elsif statement_node.break_type?
-                          'break'
-                        else
-                          statement_node.method_name
-                        end
+            next unless statement_node.ancestors.find(&:block_type?).method?(:transaction)
+
+            statement = statement(statement_node)
             message = format(MSG, statement: statement)
 
             add_offense(statement_node, message: message)
+          end
+        end
+
+        private
+
+        def statement(statement_node)
+          if statement_node.return_type?
+            'return'
+          elsif statement_node.break_type?
+            'break'
+          else
+            statement_node.method_name
           end
         end
       end

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when `break` is used in `loop` in transactions' do
+    expect_no_offenses(<<~RUBY)
+      ApplicationRecord.transaction do
+        loop do
+          break if condition
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #658.

This PR fixes a false positive for `Rails/TransactionExitStatement` when `break` is used in `loop` in transactions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
