### PR TITLE
[Fix #664] Fix a false positive for `Rails/MigrationClassName` cop

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_migration_class_name_cop.md
+++ b/changelog/fix_a_false_positive_for_rails_migration_class_name_cop.md
@@ -1,0 +1,1 @@
+* [#664](https://github.com/rubocop/rubocop-rails/issues/664): Fix a false positive for `Rails/MigrationClassName` when `ActiveSupport::Inflector` is applied to the class name and the case is different. ([@koic][])

--- a/spec/rubocop/cop/rails/migration_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/migration_class_name_spec.rb
@@ -48,4 +48,23 @@ RSpec.describe RuboCop::Cop::Rails::MigrationClassName, :config do
       RUBY
     end
   end
+
+  #
+  # When `OAuth` is applied instead of `Oauth` for `oauth`.
+  #
+  # # config/initializers/inflections.rb
+  # ActiveSupport::Inflector.inflections(:en) do |inflect|
+  #   inflect.acronym 'OAuth'
+  # end
+  #
+  context 'when `ActiveSupport::Inflector` is applied to the class name and the case is different' do
+    let(:filename) { 'db/migrate/20210623095243_remove_unused_oauth_scope_grants.rb' }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, filename)
+        class RemoveUnusedOAuthScopeGrants < ActiveRecord::Migration[7.0]
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #664.

This PR fixes a false positive for `Rails/MigrationClassName` when `ActiveSupport::Inflector` is applied to the class name and the case is different.

Occasionally user want to treat a word like `Oauth` as` OAuth`. This PR is case insensitive for comparisons between migration class name and filename. It's may not a big deal because it's based on filename.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
