### PR TITLE
Fix a false negative for `Rails/TransactionExitStatement`

### DIFF
--- a/changelog/fix_false_negatives_for_rails_transaction_exit_statement.md
+++ b/changelog/fix_false_negatives_for_rails_transaction_exit_statement.md
@@ -1,0 +1,1 @@
+* [#673](https://github.com/rubocop/rubocop-rails/pull/673): Fix a false negative for `Rails/TransactionExitStatement` when `return` or `throw` is used in a block in transactions. ([@Tietew][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -58,7 +58,7 @@ module RuboCop
           return unless parent.block_type? && parent.body
 
           exit_statements(parent.body).each do |statement_node|
-            next unless statement_node.ancestors.find(&:block_type?).method?(:transaction)
+            next if statement_node.break_type? && nested_block?(statement_node)
 
             statement = statement(statement_node)
             message = format(MSG, statement: statement)
@@ -77,6 +77,10 @@ module RuboCop
           else
             statement_node.method_name
           end
+        end
+
+        def nested_block?(statement_node)
+          !statement_node.ancestors.find(&:block_type?).method?(:transaction)
         end
       end
     end

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -44,6 +44,28 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
     RUBY
   end
 
+  it 'registers an offense when `return` is used in `loop` in transactions' do
+    expect_offense(<<~RUBY)
+      ApplicationRecord.transaction do
+        loop do
+          return if condition
+          ^^^^^^ Exit statement `return` is not allowed. Use `raise` (rollback) or `next` (commit).
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `throw` is used in `loop` in transactions' do
+    expect_offense(<<~RUBY)
+      ApplicationRecord.transaction do
+        loop do
+          throw if condition
+          ^^^^^ Exit statement `throw` is not allowed. Use `raise` (rollback) or `next` (commit).
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when `break` is used in `loop` in transactions' do
     expect_no_offenses(<<~RUBY)
       ApplicationRecord.transaction do


### PR DESCRIPTION
#665 fixed a false positive when `break` is used in a block in transactions.
But it introduced a false negative on `return` or `throw`.

``` ruby
transaction do
  loop do
    break  # allowed
    return # should be detected
    throw  # should be detected
  end
end
```

This PR does not cover following false positive.
It's too complex to detect. And a bad code I believe (should be extracted to method).

``` ruby
transaction do
  catch :foo do
    throw :foo if condition1 # false positive -- just exit catch
    throw :bar if condition2 # true positive
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
