### PR TITLE
[Fix #680] Fix a false positive for `Rails/ReversibleMigrationMethodDefinition`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_reversible_migration_method_definition.md
+++ b/changelog/fix_a_false_positive_for_rails_reversible_migration_method_definition.md
@@ -1,0 +1,1 @@
+* [#680](https://github.com/rubocop/rubocop-rails/issues/680): Fix a false positive for `Rails/ReversibleMigrationMethodDefinition` when using an inner class. ([@koic][])

--- a/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
+++ b/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
@@ -49,15 +49,15 @@ module RuboCop
               'both an `up` and a `down` method.'
 
         def_node_matcher :change_method?, <<~PATTERN
-          [ #migration_class? `(def :change (args) _) ]
+          `(def :change (args) _)
         PATTERN
 
         def_node_matcher :up_and_down_methods?, <<~PATTERN
-          [ #migration_class? `(def :up (args) _) `(def :down (args) _) ]
+          [`(def :up (args) _) `(def :down (args) _)]
         PATTERN
 
         def on_class(node)
-          return if change_method?(node) || up_and_down_methods?(node)
+          return if !migration_class?(node) || change_method?(node) || up_and_down_methods?(node)
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/rails/reversible_migration_method_definition_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_method_definition_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigrationMethodDefinition, :config
     RUBY
   end
 
+  it 'does not register an offense with an inner class' do
+    expect_no_offenses(<<~RUBY)
+      class SomeMigration < ActiveRecord::Migration[6.0]
+        class Foo
+        end
+
+        def change
+          add_column :users, :email, :text, null: false
+        end
+      end
+    RUBY
+  end
+
   it 'registers offenses correctly with any migration class' do
     expect_offense(<<~RUBY)
       class SomeMigration < ActiveRecord::Migration[5.2]


### PR DESCRIPTION
Fixes #680.

This PR fixes a false positive for `Rails/ReversibleMigrationMethodDefinition` when using an inner class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
