### PR TITLE
Fix override RuboCop::Cop::Style::RedundantSelf.autocorrect_incompatible_with without breaking designation of future incompatible cop

### DIFF
--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -13,3 +13,11 @@ require_relative 'rubocop/rails/schema_loader/schema'
 RuboCop::Rails::Inject.defaults!
 
 require_relative 'rubocop/cop/rails_cops'
+
+RuboCop::Cop::Style::RedundantSelf.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::Rails::SafeNavigation)
+    end
+  end
+)

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -47,15 +47,6 @@ module RuboCop
           (send _ ${:try :try!} $_ ...)
         PATTERN
 
-        # Monkey patching for `Style/RedundantSelf` of RuboCop core.
-        # rubocop:disable Style/ClassAndModuleChildren
-        class Style::RedundantSelf
-          def self.autocorrect_incompatible_with
-            [Rails::SafeNavigation]
-          end
-        end
-        # rubocop:enable Style/ClassAndModuleChildren
-
         def self.autocorrect_incompatible_with
           [Style::RedundantSelf]
         end


### PR DESCRIPTION
Fixed as not to break future incompatible cop designations.
Reference: https://github.com/rubocop/rubocop-rspec/pull/1252#discussion_r834361929

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
~* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
~* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
