### PR TITLE
Support auto-correction for `Rails/DeprecatedActiveModelErrorsMethods`

### DIFF
--- a/changelog/new_support_autocorrect_for_rails_deprecated_active_model_errors_methods.md
+++ b/changelog/new_support_autocorrect_for_rails_deprecated_active_model_errors_methods.md
@@ -1,0 +1,1 @@
+* [#688](https://github.com/rubocop/rubocop-rails/pull/688): Support auto-correction for `Rails/DeprecatedActiveModelErrorsMethods`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -271,6 +271,7 @@ Rails/DeprecatedActiveModelErrorsMethods:
   Enabled: pending
   Safe: false
   VersionAdded: '2.14'
+  VersionChanged: '<<next>>'
 
 Rails/DuplicateAssociation:
   Description: "Don't repeat associations in a model."

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config do
   shared_examples 'errors call with explicit receiver' do
     context 'when modifying errors' do
-      it 'registers an offense' do
+      it 'registers and corrects an offense' do
         expect_offense(<<~RUBY, file_path)
           user.errors[:name] << 'msg'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          user.errors.add(:name, 'msg')
         RUBY
       end
 
@@ -18,13 +22,30 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           RUBY
         end
       end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY, file_path)
+            user.errors[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user.errors.delete(:name)
+          RUBY
+        end
+      end
     end
 
     context 'when modifying errors.messages' do
-      it 'registers an offense' do
+      it 'registers and corrects an offense' do
         expect_offense(<<~RUBY, file_path)
           user.errors.messages[:name] << 'msg'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          user.errors.add(:name, 'msg')
         RUBY
       end
 


### PR DESCRIPTION
This PR supports auto-correction for `Rails/DeprecatedActiveModelErrorsMethods`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
