### PR TITLE
[Fix #692] Fix an error for `Rails/UnusedIgnoredColumns`

### DIFF
--- a/changelog/fix_an_error_for_rails_unused_ignored_columns.md
+++ b/changelog/fix_an_error_for_rails_unused_ignored_columns.md
@@ -1,0 +1,1 @@
+* [#692](https://github.com/rubocop/rubocop-rails/issues/692): Fix an error for `Rails/UnusedIgnoredColumns` when using no tables db/schema.rb. ([@koic][])

--- a/lib/rubocop/rails/schema_loader/schema.rb
+++ b/lib/rubocop/rails/schema_loader/schema.rb
@@ -32,6 +32,8 @@ module RuboCop
           raise "Unexpected type: #{ast.type}" unless ast.block_type?
 
           each_table(ast) do |table_def|
+            next unless table_def.method?(:create_table)
+
             @tables << Table.new(table_def)
           end
 
@@ -56,6 +58,7 @@ module RuboCop
 
         def each_add_index(ast)
           ast.body.children.each do |node|
+            next unless node.respond_to?(:send_type?)
             next if !node&.send_type? || !node.method?(:add_index)
 
             yield(node)

--- a/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
+++ b/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
@@ -106,4 +106,25 @@ RSpec.describe RuboCop::Cop::Rails::UnusedIgnoredColumns, :config do
       end
     end
   end
+
+  context 'with no tables db/schema.rb' do
+    include_context 'with SchemaLoader'
+
+    let(:schema) { <<~RUBY }
+      ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+        enable_extension 'plpgsql'
+      end
+    RUBY
+
+    context 'with an unused ignored column as a Symbol' do
+      # NOTE: For example, it is not possible to track externally managed databases.
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class User < ApplicationRecord
+            self.ignored_columns = [:real_name]
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #692.

This PR fixes an error for `Rails/UnusedIgnoredColumns` when using no tables db/schema.rb.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
