### PR TITLE
Fix `TransactionExitStatement` `in_rescue?` Logic

### DIFF
--- a/changelog/fix_false_negative_for_transaction_exit_with_rescue.md
+++ b/changelog/fix_false_negative_for_transaction_exit_with_rescue.md
@@ -1,0 +1,1 @@
+* [#695](https://github.com/rubocop/rubocop-rails/pull/695): Fixes a false negative where the `in_rescue?` check would bypass situations where the return was inside a transaction but outside of a rescue. ([@dorkrawk][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -53,6 +53,14 @@ module RuboCop
           ({return | break | send nil? :throw} ...)
         PATTERN
 
+        def_node_matcher :rescue_body_return_node?, <<~PATTERN
+          (:resbody ...
+            ...
+            ({return | break | send nil? :throw} ...)
+            ...
+          )
+        PATTERN
+
         def on_send(node)
           return unless (parent = node.parent)
           return unless parent.block_type? && parent.body
@@ -80,7 +88,7 @@ module RuboCop
         end
 
         def in_rescue?(statement_node)
-          statement_node.ancestors.find(&:rescue_type?)
+          statement_node.ancestors.any? { |n| rescue_body_return_node?(n) }
         end
 
         def nested_block?(statement_node)

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
     RUBY
   end
 
+  it 'registers an officense when `return` is used outside of a `rescue`' do
+    expect_offense(<<~RUBY)
+      ApplicationRecord.transaction do
+        return if user.active?
+        ^^^^^^ Exit statement `return` is not allowed. Use `raise` (rollback) or `next` (commit).
+      rescue
+        pass
+      end
+    RUBY
+  end
+
   it 'does not register an offense when transaction block is empty' do
     expect_no_offenses(<<~RUBY)
       ApplicationRecord.transaction do


### PR DESCRIPTION
The old logic for `in_rescue?` in the `TransactionExitStatement` case missed situations where a transaction contained an exit outside of a rescue. For example:

```ruby
ApplicationRecord.transaction do
  return if user.active?
rescue
  pass
end
```

This fix adds a new node matcher to find exit statements within the rescue body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
