### PR TITLE
Fix a false negative for `Rails/TransactionExitStatement`

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_transaction_exit_statement.md
+++ b/changelog/fix_a_false_negative_for_rails_transaction_exit_statement.md
@@ -1,0 +1,1 @@
+* [#696](https://github.com/rubocop/rubocop-rails/pull/696): Fix a false negative for `Rails/TransactionExitStatement` when `return` is used in `rescue`. ([@koic][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -66,7 +66,7 @@ module RuboCop
           return unless parent.block_type? && parent.body
 
           exit_statements(parent.body).each do |statement_node|
-            next if in_rescue?(statement_node) || nested_block?(statement_node)
+            next if statement_node.break_type? && nested_block?(statement_node)
 
             statement = statement(statement_node)
             message = format(MSG, statement: statement)
@@ -87,13 +87,7 @@ module RuboCop
           end
         end
 
-        def in_rescue?(statement_node)
-          statement_node.ancestors.any? { |n| rescue_body_return_node?(n) }
-        end
-
         def nested_block?(statement_node)
-          return false unless statement_node.break_type?
-
           !statement_node.ancestors.find(&:block_type?).method?(:transaction)
         end
       end

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -76,11 +76,12 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
     RUBY
   end
 
-  it 'does not register an offense when `return` is used in `rescue`' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense when `return` is used in `rescue`' do
+    expect_offense(<<~RUBY)
       ApplicationRecord.transaction do
       rescue
         return do_something
+        ^^^^^^^^^^^^^^^^^^^ Exit statement `return` is not allowed. Use `raise` (rollback) or `next` (commit).
       end
     RUBY
   end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-rails/pull/674#issuecomment-1107330877

Revert "[Fix #669] Fix a false positive for `Rails/TransactionExitStatement`"

This reverts commit d9ec02de75d95337e7dc2a8f876ba8a4874276c1 and tweak a spec.

So this PR fixes a false negative for `Rails/TransactionExitStatement` when `return` is used in `rescue`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
