### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ workflows:
     jobs:
       - documentation-checks
       - rake_default:
-          name: Ruby 2.5
-          image: cimg/ruby:2.5
-      - rake_default:
           name: Ruby 2.6
           image: cimg/ruby:2.6
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/changelog/change_drop_ruby_2_5_support.md
+++ b/changelog/change_drop_ruby_2_5_support.md
@@ -1,0 +1,1 @@
+* [#697](https://github.com/rubocop/rubocop-rails/pull/697): **(Breaking)** Drop Ruby 2.5 support. ([@koic][])

--- a/lib/rubocop/cop/rails/ignored_skip_action_filter_option.rb
+++ b/lib/rubocop/cop/rails/ignored_skip_action_filter_option.rb
@@ -80,7 +80,7 @@ module RuboCop
         def options_hash(options)
           options.pairs
                  .select { |pair| pair.key.sym_type? }
-                 .map { |pair| [pair.key.value, pair] }.to_h
+                 .to_h { |pair| [pair.key.value, pair] }
         end
 
         def if_and_only?(options)

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -66,7 +66,7 @@ module RuboCop
 
         def autocorrect(corrector, node)
           method_node, *params = *node.arguments
-          method = method_node.source[1..-1]
+          method = method_node.source[1..]
 
           range = if node.receiver
                     range_between(node.loc.dot.begin_pos, node.loc.expression.end_pos)

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-rails'
   s.version = RuboCop::Rails::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<~DESCRIPTION
     Automatic Rails code style checking tool.

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -145,24 +145,14 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     RUBY
   end
 
-  context 'when using Ruby 2.6 or newer', :ruby26 do
-    it 'registers an offense for `to_h { ... }`' do
-      expect_offense(<<~RUBY)
-        x.to_h { |el| [el.to_sym, el] }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `to_h { ... }`.
-      RUBY
+  it 'registers an offense for `to_h { ... }`' do
+    expect_offense(<<~RUBY)
+      x.to_h { |el| [el.to_sym, el] }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `to_h { ... }`.
+    RUBY
 
-      expect_correction(<<~RUBY)
-        x.index_by { |el| el.to_sym }
-      RUBY
-    end
-  end
-
-  context 'when using Ruby 2.5 or older', :ruby25 do
-    it 'does not register an offense for `to_h { ... }`' do
-      expect_no_offenses(<<~RUBY)
-        x.to_h { |el| [el.to_sym, el] }
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      x.index_by { |el| el.to_sym }
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -118,25 +118,15 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       RUBY
     end
 
-    context 'when using Ruby 2.6 or newer', :ruby26 do
-      it 'registers an offense for `to_h { ... }`' do
-        expect_offense(<<~RUBY)
-          x.to_h { |el| [el, el.to_sym] }
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `to_h { ... }`.
-        RUBY
+    it 'registers an offense for `to_h { ... }`' do
+      expect_offense(<<~RUBY)
+        x.to_h { |el| [el, el.to_sym] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `to_h { ... }`.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          x.index_with { |el| el.to_sym }
-        RUBY
-      end
-    end
-
-    context 'when using Ruby 2.5 or older', :ruby25 do
-      it 'does not register an offense for `to_h { ... }`' do
-        expect_no_offenses(<<~RUBY)
-          x.to_h { |el| [el, el.to_sym] }
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        x.index_with { |el| el.to_sym }
+      RUBY
     end
   end
 
@@ -145,10 +135,8 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       expect_no_offenses('x.each_with_object({}) { |el, h| h[el] = foo(el) }')
     end
 
-    context 'when using Ruby 2.6 or newer', :ruby26 do
-      it 'does not register an offense for `to_h { ... }`' do
-        expect_no_offenses('x.to_h { |el| [el, el.to_sym] }')
-      end
+    it 'does not register an offense for `to_h { ... }`' do
+      expect_no_offenses('x.to_h { |el| [el, el.to_sym] }')
     end
 
     it 'does not register an offense for `map { ... }.to_h`' do


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10577.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
