### PR TITLE
Make `keys` method aware of `Rails/DeprecatedActiveModelErrorsMethods` cop

### DIFF
--- a/changelog/new_make_keys_method_aware_of_rails_deprecated_active_model_errors_methods.md
+++ b/changelog/new_make_keys_method_aware_of_rails_deprecated_active_model_errors_methods.md
@@ -1,0 +1,1 @@
+* [#702](https://github.com/rubocop/rubocop-rails/pull/702): Make `keys` method aware of `Rails/DeprecatedActiveModelErrorsMethods` cop. ([@koic][])

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           RUBY
         end
       end
+
+      context 'when using `keys` method' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY, file_path)
+            user.errors.keys.include?(:name)
+            ^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user.errors.attribute_names.include?(:name)
+          RUBY
+        end
+      end
     end
 
     context 'when modifying errors.messages' do


### PR DESCRIPTION
This PR makes `keys` method aware of `Rails/DeprecatedActiveModelErrorsMethods` cop. It can emulate the following Rails's warning.

```console
DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2.
```

The following is a bad / good example.

```ruby
# bad
user.errors.keys.include?(:attr)

# good
user.errors.attribute_names.include?(:attr)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
