### PR TITLE
Fix not auto-corrected for `Rails/DuplicateAssociation`

### DIFF
--- a/changelog/fix_not_autocrrected_for_rails_duplicate_association.md
+++ b/changelog/fix_not_autocrrected_for_rails_duplicate_association.md
@@ -1,0 +1,1 @@
+* [#703](https://github.com/rubocop/rubocop-rails/pull/703): Fix not auto-corrected for `Rails/DuplicateAssociation`. ([@ydah][])

--- a/lib/rubocop/cop/rails/duplicate_association.rb
+++ b/lib/rubocop/cop/rails/duplicate_association.rb
@@ -35,7 +35,7 @@ module RuboCop
           offenses(class_node).each do |name, nodes|
             nodes.each do |node|
               add_offense(node, message: format(MSG, name: name)) do |corrector|
-                next if nodes.last == node
+                next if same_line?(nodes.last, node)
 
                 corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
               end

--- a/spec/rubocop/cop/rails/duplicate_association_spec.rb
+++ b/spec/rubocop/cop/rails/duplicate_association_spec.rb
@@ -8,6 +8,27 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
           belongs_to :foo
           ^^^^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
           belongs_to :bar
+          belongs_to :foo
+          ^^^^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
+          belongs_to :blah
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Post < ApplicationRecord
+          belongs_to :bar
+          belongs_to :foo
+          belongs_to :blah
+        end
+      RUBY
+    end
+
+    it 'registers an offense with scope block' do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          belongs_to :foo
+          ^^^^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
+          belongs_to :bar
           belongs_to :foo, -> { active }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
           belongs_to :blah
@@ -26,6 +47,27 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
   describe 'has_many' do
     it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          has_many :foos
+          ^^^^^^^^^^^^^^ Association `foos` is defined multiple times. Don't repeat associations.
+          has_many :bars
+          has_many :foos
+          ^^^^^^^^^^^^^^ Association `foos` is defined multiple times. Don't repeat associations.
+          has_many :blahs
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Post < ApplicationRecord
+          has_many :bars
+          has_many :foos
+          has_many :blahs
+        end
+      RUBY
+    end
+
+    it 'registers an offense with scope block' do
       expect_offense(<<~RUBY)
         class Post < ApplicationRecord
           has_many :foos
@@ -54,6 +96,27 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
           has_one :foo
           ^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
           has_one :bar
+          has_one :foo
+          ^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
+          has_one :blah
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Post < ApplicationRecord
+          has_one :bar
+          has_one :foo
+          has_one :blah
+        end
+      RUBY
+    end
+
+    it 'registers an offense with scope block' do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          has_one :foo
+          ^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
+          has_one :bar
           has_one :foo, -> { active }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Association `foo` is defined multiple times. Don't repeat associations.
           has_one :blah
@@ -72,6 +135,27 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
   describe 'has_and_belongs_to_many' do
     it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          has_and_belongs_to_many :foos
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Association `foos` is defined multiple times. Don't repeat associations.
+          has_and_belongs_to_many :bars
+          has_and_belongs_to_many :foos
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Association `foos` is defined multiple times. Don't repeat associations.
+          has_and_belongs_to_many :blahs
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Post < ApplicationRecord
+          has_and_belongs_to_many :bars
+          has_and_belongs_to_many :foos
+          has_and_belongs_to_many :blahs
+        end
+      RUBY
+    end
+
+    it 'registers an offense with scope block' do
       expect_offense(<<~RUBY)
         class Post < ApplicationRecord
           has_and_belongs_to_many :foos


### PR DESCRIPTION
This PR is fixed not auto-corrected case for `Rails/DuplicateAssociation`

The following problems that could'nt be corrected automatically
when exactly the same association was defined have been resolved.

```ruby
class Post < ApplicationRecord
  belongs_to :foo
  belongs_to :bar
  belongs_to :foo
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
