### PR TITLE
[Fix #707] Fix an error when a variable is passed to has_many or has_one with double splat

### DIFF
--- a/changelog/fix_an_error_when_a_variable_is_passed.md
+++ b/changelog/fix_an_error_when_a_variable_is_passed.md
@@ -1,0 +1,1 @@
+* [#707](https://github.com/rubocop/rubocop-rails/issues/707): Fix an error when a variable is passed to has_many or has_one with double splat. ([@nobuyo][])

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -116,7 +116,7 @@ module RuboCop
         def valid_options?(options)
           return false if options.nil?
 
-          options = options.first.children.first.pairs if options.first.kwsplat_type?
+          options = extract_option_if_kwsplat(options)
 
           return true unless options
           return true if options.any? do |o|
@@ -124,6 +124,14 @@ module RuboCop
           end
 
           false
+        end
+
+        def extract_option_if_kwsplat(options)
+          if options.first.kwsplat_type? && options.first.children.first.hash_type?
+            return options.first.children.first.pairs
+          end
+
+          options
         end
 
         def active_resource?(node)

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
+    it 'registers an offense when a variable passed with double splat' do
+      expect_offense(<<~RUBY)
+        class Person < ApplicationRecord
+          has_one :foo, **bar
+          ^^^^^^^ Specify a `:dependent` option.
+        end
+      RUBY
+    end
+
     it 'does not register an offense when specifying default `dependent: nil` strategy' do
       expect_no_offenses(<<~RUBY)
         class Person < ApplicationRecord


### PR DESCRIPTION
Fixes #707.

RuboCop cannot determine whether `dependent` is included if a variable is passed,
but I thought it was fine to leave it as is to register the offense to make people aware of it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
