### PR TITLE
Eliminate duplicate check items from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,6 @@ Before submitting the PR make sure the following are checked:
 * [ ] Added tests.
 * [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
 * [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
-* [ ] The PR relates to *only* one subject with a clear title
-  and description in grammatically correct, complete sentences.
 * [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).
 
 [1]: https://chris.beams.io/posts/git-commit/


### PR DESCRIPTION
The current template has duplicated `The PR relates to *only* one subject...`. So I've deleted one of them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [ ] ~Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.~
* [ ] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
* [ ] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
