### PR TITLE
Rails/TransactionExitStatement - Inspect `#with_lock` method too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,3 +589,4 @@
 [@natematykiewicz]: https://github.com/natematykiewicz
 [@lulalala]: https://github.com/lulalala
 [@gmcgibbon]: https://github.com/gmcgibbon
+[@FunnyHector]: https://github.com/FunnyHector

--- a/changelog/change_inspect_with_lock_for_rails_transaction_exit_statement_cop.md
+++ b/changelog/change_inspect_with_lock_for_rails_transaction_exit_statement_cop.md
@@ -1,0 +1,1 @@
+* [#710](https://github.com/rubocop/rubocop-rails/pull/710): Rails/TransactionExitStatement - Inspect `ActiveRecord::Locking::Pessimistic#with_lock` too, as `#with_lock` opens a transaction. ([@FunnyHector][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -29,6 +29,11 @@ module RuboCop
       #     throw if user.active?
       #   end
       #
+      #   # bad, as `with_lock` implicitly opens a transaction too
+      #   user.with_lock do
+      #     throw if user.active?
+      #   end
+      #
       #   # good
       #   ApplicationRecord.transaction do
       #     # Rollback
@@ -47,7 +52,7 @@ module RuboCop
           Exit statement `%<statement>s` is not allowed. Use `raise` (rollback) or `next` (commit).
         MSG
 
-        RESTRICT_ON_SEND = %i[transaction].freeze
+        RESTRICT_ON_SEND = %i[transaction with_lock].freeze
 
         def_node_search :exit_statements, <<~PATTERN
           ({return | break | send nil? :throw} ...)

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
     RUBY
   end
 
+  it 'registers an offense when `return` is used in `with_lock` transactions' do
+    expect_offense(<<~RUBY)
+      user.with_lock do
+        return if user.active?
+        ^^^^^^ Exit statement `return` is not allowed. Use `raise` (rollback) or `next` (commit).
+      end
+    RUBY
+  end
+
   it 'does not register an offense when `next` is used in transactions' do
     expect_no_offenses(<<~RUBY)
       ApplicationRecord.transaction do


### PR DESCRIPTION
`ActiveRecord::Locking::Pessimistic#with_lock` implicitly opens a transaction, so we should inspect this method as well as `ActiveRecord::Transactions#transaction`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
