### PR TITLE
Recover Ruby 2.2 code analysis using `TargetRubyVersion: 2.2`

### DIFF
--- a/changelog/changelog/fix_recover_ruby_22_code_analysis.md
+++ b/changelog/changelog/fix_recover_ruby_22_code_analysis.md
@@ -1,0 +1,1 @@
+* [#708](https://github.com/rubocop/rubocop-rails/pull/708): Recover Ruby 2.2 code analysis using `TargetRubyVersion: 2.2`. ([@koic][])

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -4,7 +4,8 @@ module RuboCop
   module Cop
     module Rails
       # Converts usages of `try!` to `&.`. It can also be configured
-      # to convert `try`. It will convert code to use safe navigation.
+      # to convert `try`. It will convert code to use safe navigation
+      # if the target Ruby version is set to 2.3+
       #
       # @example ConvertTry: false (default)
       #   # bad
@@ -39,6 +40,9 @@ module RuboCop
       class SafeNavigation < Base
         include RangeHelp
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
 
         MSG = 'Use safe navigation (`&.`) instead of `%<try>s`.'
         RESTRICT_ON_SEND = %i[try try!].freeze

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -29,29 +29,43 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
     it_behaves_like 'accepts', 'non try! method calls', 'join'
 
-    context 'try!' do
-      it_behaves_like 'offense', 'try! with a single parameter', 'try!',
-                      '(:join)'
-      it_behaves_like 'offense', 'try! with a multiple parameters', 'try!',
-                      '(:join, ",")'
-      it_behaves_like 'offense', 'try! with a block', 'try!',
-                      '(:map) { |e| e.some_method }'
-      it_behaves_like 'offense', 'try! with params and a block', 'try!',
-                      ['(:each_with_object, []) do |e, acc|',
+    context 'target_ruby_version < 2.3', :ruby22 do
+      it_behaves_like 'accepts', 'try! with a single parameter', 'try!(:join)'
+      it_behaves_like 'accepts', 'try! with a multiple parameters',
+                      'try!(:join, ",")'
+      it_behaves_like 'accepts', 'try! with a block',
+                      'try!(:map) { |e| e.some_method }'
+      it_behaves_like 'accepts', 'try! with params and a block',
+                      ['try!(:each_with_object, []) do |e, acc|',
                        '  acc << e.some_method',
                        'end'].join("\n")
-      it_behaves_like 'offense', 'try! with a question method', 'try!',
-                      '(:something?)'
-      it_behaves_like 'offense', 'try! with a bang method', 'try!',
-                      '(:something!)'
+    end
 
-      it_behaves_like 'accepts', 'try! used to call an enumerable accessor',
-                      'foo.try!(:[], :bar)'
-      it_behaves_like 'accepts', 'try! with ==', 'foo.try!(:==, bar)'
-      it_behaves_like 'accepts', 'try! with an operator', 'foo.try!(:+, bar)'
-      it_behaves_like 'accepts', 'try! with a method stored as a variable',
-                      ['bar = :==',
-                       'foo.try!(baz, bar)'].join("\n")
+    context 'target_ruby_version > 2.3', :ruby23 do
+      context 'try!' do
+        it_behaves_like 'offense', 'try! with a single parameter', 'try!',
+                        '(:join)'
+        it_behaves_like 'offense', 'try! with a multiple parameters', 'try!',
+                        '(:join, ",")'
+        it_behaves_like 'offense', 'try! with a block', 'try!',
+                        '(:map) { |e| e.some_method }'
+        it_behaves_like 'offense', 'try! with params and a block', 'try!',
+                        ['(:each_with_object, []) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n")
+        it_behaves_like 'offense', 'try! with a question method', 'try!',
+                        '(:something?)'
+        it_behaves_like 'offense', 'try! with a bang method', 'try!',
+                        '(:something!)'
+
+        it_behaves_like 'accepts', 'try! used to call an enumerable accessor',
+                        'foo.try!(:[], :bar)'
+        it_behaves_like 'accepts', 'try! with ==', 'foo.try!(:==, bar)'
+        it_behaves_like 'accepts', 'try! with an operator', 'foo.try!(:+, bar)'
+        it_behaves_like 'accepts', 'try! with a method stored as a variable',
+                        ['bar = :==',
+                         'foo.try!(baz, bar)'].join("\n")
+      end
     end
 
     context 'try' do
@@ -93,80 +107,94 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
   context 'convert try and try!' do
     let(:cop_config) { { 'ConvertTry' => true } }
 
-    context 'try!' do
-      it_behaves_like 'offense', 'try! with a single parameter', 'try!',
-                      '(:join)'
-      it_behaves_like 'offense', 'try! with a multiple parameters', 'try!',
-                      '(:join, ",")'
-      it_behaves_like 'offense', 'try! with a block', 'try!',
-                      '(:map) { |e| e.some_method }'
-      it_behaves_like 'offense', 'try! with params and a block', 'try!',
-                      ['(:each_with_object, []) do |e, acc|',
-                       '  acc << e.some_method',
-                       'end'].join("\n")
-
-      it_behaves_like 'accepts', 'try! used to call an enumerable accessor',
-                      'foo.try!(:[], :bar)'
-
-      it_behaves_like 'autocorrect', 'try! a single parameter',
-                      '[1, 2].try!(:join)', '[1, 2]&.join'
-      it_behaves_like 'autocorrect', 'try! with 2 parameters',
-                      '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
-      it_behaves_like 'autocorrect', 'try! with multiple parameters',
-                      '[1, 2].try!(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
-      it_behaves_like 'autocorrect', 'try! without receiver',
-                      'try!(:join)', 'self&.join'
-      it_behaves_like 'autocorrect', 'try! with a block',
-                      ['[foo, bar].try!(:map) do |e|',
-                       '  e.some_method',
-                       'end'].join("\n"),
-                      ['[foo, bar]&.map do |e|',
-                       '  e.some_method',
-                       'end'].join("\n")
-      it_behaves_like 'autocorrect', 'try! with params and a block',
-                      ['[foo, bar].try!(:each_with_object, []) do |e, acc|',
-                       '  acc << e.some_method',
-                       'end'].join("\n"),
-                      ['[foo, bar]&.each_with_object([]) do |e, acc|',
+    context 'target_ruby_version < 2.3', :ruby22 do
+      it_behaves_like 'accepts', 'try! with a single parameter', 'try!(:join)'
+      it_behaves_like 'accepts', 'try! with a multiple parameters',
+                      'try!(:join, ",")'
+      it_behaves_like 'accepts', 'try! with a block',
+                      'try!(:map) { |e| e.some_method }'
+      it_behaves_like 'accepts', 'try! with params and a block',
+                      ['try!(:each_with_object, []) do |e, acc|',
                        '  acc << e.some_method',
                        'end'].join("\n")
     end
 
-    context 'try' do
-      it_behaves_like 'offense', 'try with a single parameter', 'try',
-                      '(:join)'
-      it_behaves_like 'offense', 'try with a multiple parameters', 'try',
-                      '(:join, ",")'
-      it_behaves_like 'offense', 'try with a block', 'try',
-                      '(:map) { |e| e.some_method }'
-      it_behaves_like 'offense', 'try with params and a block', 'try',
-                      ['(:each_with_object, []) do |e, acc|',
-                       '  acc << e.some_method',
-                       'end'].join("\n")
+    context 'target_ruby_version > 2.3', :ruby23 do
+      context 'try!' do
+        it_behaves_like 'offense', 'try! with a single parameter', 'try!',
+                        '(:join)'
+        it_behaves_like 'offense', 'try! with a multiple parameters', 'try!',
+                        '(:join, ",")'
+        it_behaves_like 'offense', 'try! with a block', 'try!',
+                        '(:map) { |e| e.some_method }'
+        it_behaves_like 'offense', 'try! with params and a block', 'try!',
+                        ['(:each_with_object, []) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n")
 
-      it_behaves_like 'accepts', 'try! used to call an enumerable accessor',
-                      'foo.try!(:[], :bar)'
+        it_behaves_like 'accepts', 'try! used to call an enumerable accessor',
+                        'foo.try!(:[], :bar)'
 
-      it_behaves_like 'autocorrect', 'try a single parameter',
-                      '[1, 2].try(:join)', '[1, 2]&.join'
-      it_behaves_like 'autocorrect', 'try with 2 parameters',
-                      '[1, 2].try(:join, ",")', '[1, 2]&.join(",")'
-      it_behaves_like 'autocorrect', 'try with multiple parameters',
-                      '[1, 2].try(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
-      it_behaves_like 'autocorrect', 'try with a block',
-                      ['[foo, bar].try(:map) do |e|',
-                       '  e.some_method',
-                       'end'].join("\n"),
-                      ['[foo, bar]&.map do |e|',
-                       '  e.some_method',
-                       'end'].join("\n")
-      it_behaves_like 'autocorrect', 'try with params and a block',
-                      ['[foo, bar].try(:each_with_object, []) do |e, acc|',
-                       '  acc << e.some_method',
-                       'end'].join("\n"),
-                      ['[foo, bar]&.each_with_object([]) do |e, acc|',
-                       '  acc << e.some_method',
-                       'end'].join("\n")
+        it_behaves_like 'autocorrect', 'try! a single parameter',
+                        '[1, 2].try!(:join)', '[1, 2]&.join'
+        it_behaves_like 'autocorrect', 'try! with 2 parameters',
+                        '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
+        it_behaves_like 'autocorrect', 'try! with multiple parameters',
+                        '[1, 2].try!(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
+        it_behaves_like 'autocorrect', 'try! without receiver',
+                        'try!(:join)', 'self&.join'
+        it_behaves_like 'autocorrect', 'try! with a block',
+                        ['[foo, bar].try!(:map) do |e|',
+                         '  e.some_method',
+                         'end'].join("\n"),
+                        ['[foo, bar]&.map do |e|',
+                         '  e.some_method',
+                         'end'].join("\n")
+        it_behaves_like 'autocorrect', 'try! with params and a block',
+                        ['[foo, bar].try!(:each_with_object, []) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n"),
+                        ['[foo, bar]&.each_with_object([]) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n")
+      end
+
+      context 'try' do
+        it_behaves_like 'offense', 'try with a single parameter', 'try',
+                        '(:join)'
+        it_behaves_like 'offense', 'try with a multiple parameters', 'try',
+                        '(:join, ",")'
+        it_behaves_like 'offense', 'try with a block', 'try',
+                        '(:map) { |e| e.some_method }'
+        it_behaves_like 'offense', 'try with params and a block', 'try',
+                        ['(:each_with_object, []) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n")
+
+        it_behaves_like 'accepts', 'try! used to call an enumerable accessor',
+                        'foo.try!(:[], :bar)'
+
+        it_behaves_like 'autocorrect', 'try a single parameter',
+                        '[1, 2].try(:join)', '[1, 2]&.join'
+        it_behaves_like 'autocorrect', 'try with 2 parameters',
+                        '[1, 2].try(:join, ",")', '[1, 2]&.join(",")'
+        it_behaves_like 'autocorrect', 'try with multiple parameters',
+                        '[1, 2].try(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
+        it_behaves_like 'autocorrect', 'try with a block',
+                        ['[foo, bar].try(:map) do |e|',
+                         '  e.some_method',
+                         'end'].join("\n"),
+                        ['[foo, bar]&.map do |e|',
+                         '  e.some_method',
+                         'end'].join("\n")
+        it_behaves_like 'autocorrect', 'try with params and a block',
+                        ['[foo, bar].try(:each_with_object, []) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n"),
+                        ['[foo, bar]&.each_with_object([]) do |e, acc|',
+                         '  acc << e.some_method',
+                         'end'].join("\n")
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10644.

Reverts part of https://github.com/rubocop/rubocop/pull/7026.

This PR requires https://github.com/rubocop/rubocop/pull/10644 to pass the build.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
