### PR TITLE
[Fix #719] Fix a false negative for `Rails/FormattedS`

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_to_formatted_s.md
+++ b/changelog/fix_a_false_negative_for_rails_to_formatted_s.md
@@ -1,0 +1,1 @@
+* [#719](https://github.com/rubocop/rubocop-rails/issues/719): Fix a false negative for `Rails/FormattedS` when using safe navigation operator. ([@fatkodima][])

--- a/lib/rubocop/cop/rails/to_formatted_s.rb
+++ b/lib/rubocop/cop/rails/to_formatted_s.rb
@@ -39,6 +39,7 @@ module RuboCop
             corrector.replace(node.loc.selector, style)
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/rails/to_formatted_s_spec.rb
+++ b/spec/rubocop/cop/rails/to_formatted_s_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe RuboCop::Cop::Rails::ToFormattedS, :config do
         RUBY
       end
 
+      it 'registers and corrects an offense when using `to_formatted_s` with safe navigation operator' do
+        expect_offense(<<~RUBY)
+          time&.to_formatted_s(:db)
+                ^^^^^^^^^^^^^^ Use `to_fs` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          time&.to_fs(:db)
+        RUBY
+      end
+
       it 'does not register an offense when using `to_fs`' do
         expect_no_offenses(<<~RUBY)
           time.to_fs(:db)
@@ -34,6 +45,17 @@ RSpec.describe RuboCop::Cop::Rails::ToFormattedS, :config do
 
         expect_correction(<<~RUBY)
           time.to_formatted_s(:db)
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `to_fs` with safe navigation operator' do
+        expect_offense(<<~RUBY)
+          time&.to_fs(:db)
+                ^^^^^ Use `to_formatted_s` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          time&.to_formatted_s(:db)
         RUBY
       end
 


### PR DESCRIPTION
Fixes #719.

This PR fixes a false negative for `Rails/FormattedS` when using safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
