### PR TITLE
[Fix #717] Fix an error for `Rails/DeprecatedActiveModelErrorsMethods`

### DIFF
--- a/changelog/fix_an_error_for_rails_deprecated_active_model_errors_methods.md
+++ b/changelog/fix_an_error_for_rails_deprecated_active_model_errors_methods.md
@@ -1,0 +1,1 @@
+* [#717](https://github.com/rubocop/rubocop-rails/issues/717): Fix an error for `Rails/DeprecatedActiveModelErrorsMethods` when root receiver is a variable. ([@koic][])

--- a/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
+++ b/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
@@ -119,7 +119,7 @@ module RuboCop
         def autocorrect(corrector, node)
           receiver = node.receiver
 
-          if receiver.receiver.method?(:messages)
+          if receiver.receiver.send_type? && receiver.receiver.method?(:messages)
             corrector.remove(receiver.receiver.loc.dot)
             corrector.remove(receiver.receiver.loc.selector)
           end

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -37,7 +37,20 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
       end
 
       context 'when using `keys` method' do
-        it 'registers and corrects an offense' do
+        it 'registers and corrects an offense when root receiver is a variable' do
+          expect_offense(<<~RUBY, file_path)
+            user = create_user
+            user.errors.keys
+            ^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user = create_user
+            user.errors.attribute_names
+          RUBY
+        end
+
+        it 'registers and corrects an offense when root receiver is a method' do
           expect_offense(<<~RUBY, file_path)
             user.errors.keys.include?(:name)
             ^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.


### PR DESCRIPTION
Fixes #717.

This PR fixes an error for `Rails/DeprecatedActiveModelErrorsMethods` when root receiver is a variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
