### PR TITLE
Fix include value in `Rails/AttributeDefaultBlockValue`

### DIFF
--- a/changelog/fix_include_value_in.md
+++ b/changelog/fix_include_value_in.md
@@ -1,0 +1,1 @@
+* [#723](https://github.com/rubocop/rubocop-rails/pull/723): Fix include value in `Rails/AttributeDefaultBlockValue`. ([@kkitadate][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -160,7 +160,7 @@ Rails/AttributeDefaultBlockValue:
   Enabled: pending
   VersionAdded: '2.9'
   Include:
-    - 'models/**/*'
+    - 'app/models/**/*'
 
 Rails/BelongsTo:
   Description: >-


### PR DESCRIPTION
Include value in AttributeDefaultBlockValue is incorrect, so i fix it. 
(Although it has already been reported on https://github.com/rubocop/rubocop-rails/pull/339#issuecomment-933968162)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
