### PR TITLE
[Fix #725] Fix an incorrect autocorrect for `Rails/DotSeparatedKeys`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_dot_separated_keys.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_dot_separated_keys.md
@@ -1,0 +1,1 @@
+* [#725](https://github.com/rubocop/rubocop-rails/issues/725): Fix an incorrect autocorrect for `Rails/DotSeparatedKeys` when a key starts with dot. ([@koic][])

--- a/lib/rubocop/cop/rails/dot_separated_keys.rb
+++ b/lib/rubocop/cop/rails/dot_separated_keys.rb
@@ -53,7 +53,7 @@ module RuboCop
         end
 
         def new_key(key_node, scope_node)
-          "'#{scopes(scope_node).map(&:value).join('.')}.#{key_node.value}'"
+          "'#{scopes(scope_node).map(&:value).join('.')}.#{key_node.value}'".squeeze('.')
         end
 
         def scopes(scope_node)

--- a/spec/rubocop/cop/rails/dot_separated_keys_spec.rb
+++ b/spec/rubocop/cop/rails/dot_separated_keys_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe RuboCop::Cop::Rails::DotSeparatedKeys, :config do
                     ^^^^^^^^^^^^^^^^^^^ Use the dot-separated keys instead of specifying the `:scope` option.
       I18n.t :key, scope: :one
                    ^^^^^^^^^^^ Use the dot-separated keys instead of specifying the `:scope` option.
+      I18n.t '.key', scope: :one
+                     ^^^^^^^^^^^ Use the dot-separated keys instead of specifying the `:scope` option.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -29,6 +31,7 @@ RSpec.describe RuboCop::Cop::Rails::DotSeparatedKeys, :config do
       t 'one.two.key', default: 'Not here'
       I18n.t 'one.two.key'
       I18n.t 'one.two.key'
+      I18n.t 'one.key'
       I18n.t 'one.key'
     RUBY
   end


### PR DESCRIPTION
Fixes #725.

This PR fixes an incorrect autocorrect for `Rails/DotSeparatedKeys` when a key starts with dot.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
