### PR TITLE
Make `Rails/ExpandedDateRange` aware `beginning_of_week` with an argument

### DIFF
--- a/changelog/fix_false_negative_for_rails_expanded_date_range.md
+++ b/changelog/fix_false_negative_for_rails_expanded_date_range.md
@@ -1,0 +1,1 @@
+* [#737](https://github.com/rubocop/rubocop-rails/pull/737): Make `Rails/ExpandedDateRange` aware `beginning_of_week` with an argument. ([@koic][])

--- a/spec/rubocop/cop/rails/expanded_date_range_spec.rb
+++ b/spec/rubocop/cop/rails/expanded_date_range_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe RuboCop::Cop::Rails::ExpandedDateRange, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `date.beginning_of_week(:sunday)..date.end_of_week(:sunday)`' do
+      expect_offense(<<~RUBY)
+        date.beginning_of_week(:sunday)..date.end_of_week(:sunday)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `date.all_week(:sunday)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        date.all_week(:sunday)
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `date.beginning_of_year..date.end_of_year`' do
       expect_offense(<<~RUBY)
         date.beginning_of_year..date.end_of_year
@@ -108,6 +119,36 @@ RSpec.describe RuboCop::Cop::Rails::ExpandedDateRange, :config do
     it 'does not register an offense when unmapped methods are at the beginning and end of the range' do
       expect_no_offenses(<<~RUBY)
         date.beginning_of_day..date.end_of_year
+      RUBY
+    end
+
+    it 'does not register an offense when `date.beginning_of_week(:sunday)..date.end_of_week(:saturday)`' do
+      expect_no_offenses(<<~RUBY)
+        date.beginning_of_week(:sunday)..date.end_of_week(:saturday)
+      RUBY
+    end
+
+    it 'does not register an offense when `date.beginning_of_day..date.end_of_day` with any argument' do
+      expect_no_offenses(<<~RUBY)
+        date.beginning_of_day(arg)..date.end_of_day(arg)
+      RUBY
+    end
+
+    it 'does not register an offense when `beginning_of_day..end_of_day`' do
+      expect_no_offenses(<<~RUBY)
+        beginning_of_day..end_of_day
+      RUBY
+    end
+
+    it 'does not register an offense when `beginning_of_day..date.end_of_day`' do
+      expect_no_offenses(<<~RUBY)
+        beginning_of_day..date.end_of_day
+      RUBY
+    end
+
+    it 'does not register an offense when `date.beginning_of_day..end_of_day`' do
+      expect_no_offenses(<<~RUBY)
+        date.beginning_of_day..end_of_day
       RUBY
     end
   end


### PR DESCRIPTION
This PR makes `Rails/ExpandedDateRange` aware `beginning_of_week` with an argument.

```ruby
# bad
date.beginning_of_week(:sunday)..date.end_of_week(:sunday)

# good
date.all_week(:sunday)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
