### PR TITLE
[Fix #731] Fix an incorrect autocorrect for Rails/StripHeredoc

### DIFF
--- a/lib/rubocop/cop/rails/strip_heredoc.rb
+++ b/lib/rubocop/cop/rails/strip_heredoc.rb
@@ -43,7 +43,7 @@ module RuboCop
 
         def register_offense(node, heredoc)
           add_offense(node) do |corrector|
-            squiggly_heredoc = heredoc.source.sub(/\A<<-?/, '<<~')
+            squiggly_heredoc = heredoc.source.sub(/\A<<(-|~)?/, '<<~')
 
             corrector.replace(heredoc, squiggly_heredoc)
             corrector.remove(node.loc.dot)

--- a/spec/rubocop/cop/rails/strip_heredoc_spec.rb
+++ b/spec/rubocop/cop/rails/strip_heredoc_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe RuboCop::Cop::Rails::StripHeredoc, :config do
       RUBY
     end
 
+    it 'registers an offence when squiggly already present' do
+      expect_offense(<<~RUBY)
+        <<~EOS.strip_heredoc
+        ^^^^^^^^^^^^^^^^^^^^ Use squiggly heredoc (`<<~`) instead of `strip_heredoc`.
+          some text
+        EOS
+      RUBY
+
+      expect_correction(<<~RUBY)
+        <<~EOS
+          some text
+        EOS
+      RUBY
+    end
+
     it 'does not register an offense when using squiggly heredoc' do
       expect_no_offenses(<<~RUBY)
         <<~EOS


### PR DESCRIPTION
Fixes #731 

This PR fixes an incorrect autocorrect for Rails/StripHeredoc when squiggly already present

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
