### PR TITLE
Update specs to use the expect_correction helper

### DIFF
--- a/spec/rubocop/cop/rails/active_record_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_aliases_spec.rb
@@ -19,13 +19,10 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases, :config do
           book&.update_attributes(author: "Alice")
                 ^^^^^^^^^^^^^^^^^ Use `update` instead of `update_attributes`.
         RUBY
-      end
 
-      it 'is autocorrected' do
-        new_source = autocorrect_source(
-          'book&.update_attributes(author: "Alice")'
-        )
-        expect(new_source).to eq 'book&.update(author: "Alice")'
+        expect_correction(<<~RUBY)
+          book&.update(author: "Alice")
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
         bar.foo
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      delegate :foo, to: :bar
+    RUBY
   end
 
   it 'finds trivial delegate with arguments' do
@@ -24,6 +28,10 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
         bar.foo(baz)
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      delegate :foo, to: :bar
+    RUBY
   end
 
   it 'finds trivial delegate with prefix' do
@@ -32,6 +40,10 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
       ^^^ Use `delegate` to define delegations.
         bar.foo
       end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      delegate :foo, to: :bar, prefix: true
     RUBY
   end
 
@@ -180,57 +192,5 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
         bar&.foo
       end
     RUBY
-  end
-
-  describe '#autocorrect' do
-    context 'trivial delegation' do
-      let(:source) do
-        <<~RUBY
-          def bar
-            foo.bar
-          end
-        RUBY
-      end
-
-      let(:corrected_source) do
-        <<~RUBY
-          delegate :bar, to: :foo
-        RUBY
-      end
-
-      it 'autocorrects' do
-        expect(autocorrect_source(source)).to eq(corrected_source)
-      end
-    end
-
-    context 'trivial delegation with prefix' do
-      let(:source) do
-        <<~RUBY
-          def foo_bar
-            foo.bar
-          end
-        RUBY
-      end
-
-      let(:corrected_source) do
-        <<~RUBY
-          delegate :bar, to: :foo, prefix: true
-        RUBY
-      end
-
-      it 'autocorrects' do
-        expect(autocorrect_source(source)).to eq(corrected_source)
-      end
-
-      context 'with EnforceForPrefixed: false' do
-        let(:cop_config) do
-          { 'EnforceForPrefixed' => false }
-        end
-
-        it 'does not autocorrect' do
-          expect(autocorrect_source(source)).to eq(source)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
While working on a fix for #712 I've noticed that the specs of Rails/Delegate use the old-fashioned auto-correction validation. I've updated everywhere that it doesn't make sense to use `autocorrect_source` (some cops still use it as they have additional specs on the correction and there is little gain in concerting those; and others because of the shared_examples usage)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
* [x] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
