### PR TITLE
[Fix #712] Fixed false negative when visibility modifier is declared in nested class

### DIFF
--- a/changelog/fix_false_negative_when_nested_classes_has_private_or_protected_methods.md
+++ b/changelog/fix_false_negative_when_nested_classes_has_private_or_protected_methods.md
@@ -1,0 +1,1 @@
+* [#712](https://github.com/rubocop/rubocop-rails/issues/712): Fix false negative in `Rails/Delegate` when preceding nested class declares private or protected methods. ([@Darhazer][])

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -54,6 +54,7 @@ module RuboCop
       #   delegate :bar, to: :foo, prefix: true
       class Delegate < Base
         extend AutoCorrector
+        include VisibilityHelp
 
         MSG = 'Use `delegate` to define delegations.'
 
@@ -112,17 +113,11 @@ module RuboCop
         end
 
         def private_or_protected_delegation(node)
-          line = node.first_line
-          private_or_protected_before(line) ||
-            private_or_protected_inline(line)
+          private_or_protected_inline(node) || node_visibility(node) != :public
         end
 
-        def private_or_protected_before(line)
-          (processed_source[0..line].map(&:strip) & %w[private protected]).any?
-        end
-
-        def private_or_protected_inline(line)
-          processed_source[line - 1].strip.match?(/\A(private )|(protected )/)
+        def private_or_protected_inline(node)
+          processed_source[node.first_line - 1].strip.match?(/\A(private )|(protected )/)
         end
       end
     end

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
         bar.fox
       end
 
-        private
+      private
 
       def fox
         bar.fox
@@ -143,6 +143,41 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
 
       def fox
         bar.fox
+      end
+    RUBY
+  end
+
+  it 'works with private methods declared in inner classes' do
+    expect_offense(<<~RUBY)
+      class A
+        class B
+
+          private
+
+          def foo
+            bar.foo
+          end
+        end
+
+        def baz
+        ^^^ Use `delegate` to define delegations.
+          foo.baz
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class A
+        class B
+
+          private
+
+          def foo
+            bar.foo
+          end
+        end
+
+        delegate :baz, to: :foo
       end
     RUBY
   end


### PR DESCRIPTION
Reusing RuboCop's `VisibilityHelp` we no longer check preceding source lines for a visibility modifier, but the preceding nodes. Fixes #712 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
