### PR TITLE
Fixes for errors in Rails/DeprecatedActiveModelErrorsMethods

### DIFF
--- a/changelog/fix_deprecated_errors_bad_details_autocorrection.md
+++ b/changelog/fix_deprecated_errors_bad_details_autocorrection.md
@@ -1,0 +1,1 @@
+* [#739](https://github.com/rubocop/rubocop-rails/pull/739): Fix a bad autocorrection for `errors.details[:name] << value` in Rails/DeprecatedActiveModelErrorsMethods. ([@BrianHawley][])

--- a/changelog/fix_deprecated_errors_missing_methods.md
+++ b/changelog/fix_deprecated_errors_missing_methods.md
@@ -1,0 +1,1 @@
+* [#739](https://github.com/rubocop/rubocop-rails/pull/739): Rails/DeprecatedActiveModelErrorsMethods was missing the deprecated `values`, `to_h`, and `to_xml` methods. ([@BrianHawley][])

--- a/changelog/fix_deprecated_errors_nil_dereference.md
+++ b/changelog/fix_deprecated_errors_nil_dereference.md
@@ -1,0 +1,1 @@
+* [#739](https://github.com/rubocop/rubocop-rails/pull/739): Fix a NoMethodError on nil for `errors.keys` in a model in Rails/DeprecatedActiveModelErrorsMethods. ([@BrianHawley][])

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config do
   shared_examples 'errors call with explicit receiver' do
-    context 'when modifying errors' do
+    context 'when accessing errors' do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY, file_path)
           user.errors[:name] << 'msg'
@@ -20,6 +20,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             user.errors[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections
         end
       end
 
@@ -36,8 +38,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
         end
       end
 
-      context 'when using `keys` method' do
-        context 'Rails >= 6.1', :rails61 do
+      context 'Rails >= 6.1', :rails61 do
+        context 'when using `keys` method' do
           it 'registers and corrects an offense when root receiver is a variable' do
             expect_offense(<<~RUBY, file_path)
               user = create_user
@@ -63,7 +65,42 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           end
         end
 
-        context 'Rails <= 6.0', :rails60 do
+        context 'when using `values` method' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, file_path)
+              user.errors.values
+              ^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, file_path)
+              user.errors.to_h
+              ^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, file_path)
+              user.errors.to_xml
+              ^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+      end
+
+      context 'Rails <= 6.0', :rails60 do
+        context 'when using `keys` method' do
           it 'does not register an offense when root receiver is a variable' do
             expect_no_offenses(<<~RUBY, file_path)
               user = create_user
@@ -76,6 +113,30 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
               user.errors.keys.include?(:name)
             RUBY
           end
+        end
+      end
+
+      context 'when using `values` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            user.errors.values
+          RUBY
+        end
+      end
+
+      context 'when using `to_h` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            user.errors.to_h
+          RUBY
+        end
+      end
+
+      context 'when using `to_xml` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            user.errors.to_xml
+          RUBY
         end
       end
     end
@@ -98,16 +159,41 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             user.errors.messages[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY, file_path)
+            user.errors.messages[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user.errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when calling non-manipulative methods' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.messages[:name].present?
+          RUBY
         end
       end
     end
 
     context 'when modifying errors.details' do
-      it 'registers an offense' do
+      it 'registers and corrects an offense' do
         expect_offense(<<~RUBY, file_path)
           user.errors.details[:name] << {}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
         RUBY
+
+        expect_no_corrections
       end
 
       context 'when assigning' do
@@ -115,6 +201,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           expect_offense(<<~RUBY, file_path)
             user.errors.details[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY, file_path)
+            user.errors.details[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user.errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when calling non-manipulative methods' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.details[:name].present?
           RUBY
         end
       end
@@ -131,11 +240,23 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
       end
     end
 
-    context 'when modifying errors' do
+    def expect_correction_if_model_file(code, file_path)
+      expect_correction(code) if file_path.include?('/models/')
+    end
+
+    def expect_no_corrections_if_model_file(file_path)
+      expect_no_corrections if file_path.include?('/models/')
+    end
+
+    context 'when accessing errors' do
       it 'registers an offense for model file' do
         expect_offense_if_model_file(<<~RUBY, file_path)
           errors[:name] << 'msg'
           ^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+        RUBY
+
+        expect_correction_if_model_file(<<~RUBY, file_path)
+          errors.add(:name, 'msg')
         RUBY
       end
 
@@ -145,6 +266,103 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             errors[:name] = []
             ^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections_if_model_file(file_path)
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense_if_model_file(<<~RUBY, file_path)
+            errors[:name].clear
+            ^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction_if_model_file(<<~RUBY, file_path)
+            errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'Rails >= 6.1', :rails61 do
+        context 'when using `keys` method' do
+          it 'registers and corrects an offense when root receiver is a variable' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.keys
+              ^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_correction_if_model_file(<<~RUBY, file_path)
+              errors.attribute_names
+            RUBY
+          end
+        end
+
+        context 'when using `values` method' do
+          it 'registers an offense' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.values
+              ^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections_if_model_file(file_path)
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'registers an offense' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.to_h
+              ^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections_if_model_file(file_path)
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'registers an offense' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.to_xml
+              ^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections_if_model_file(file_path)
+          end
+        end
+      end
+
+      context 'Rails <= 6.0', :rails60 do
+        context 'when using `keys` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              errors.keys
+            RUBY
+          end
+        end
+
+        context 'when using `values` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.values
+            RUBY
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.to_h
+            RUBY
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.to_xml
+            RUBY
+          end
         end
       end
 
@@ -163,6 +381,10 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           errors.messages[:name] << 'msg'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
         RUBY
+
+        expect_correction_if_model_file(<<~RUBY, file_path)
+          errors.add(:name, 'msg')
+        RUBY
       end
 
       context 'when assigning' do
@@ -170,6 +392,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           expect_offense_if_model_file(<<~RUBY, file_path)
             errors.messages[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_no_corrections_if_model_file(file_path)
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense_if_model_file(<<~RUBY, file_path)
+            errors.messages[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction_if_model_file(<<~RUBY, file_path)
+            errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when using `keys` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.messages[:name].keys
           RUBY
         end
       end
@@ -189,6 +434,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           errors.details[:name] << {}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
         RUBY
+
+        expect_no_corrections_if_model_file(file_path)
       end
 
       context 'when assigning' do
@@ -196,6 +443,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           expect_offense_if_model_file(<<~RUBY, file_path)
             errors.details[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_no_corrections_if_model_file(file_path)
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense_if_model_file(<<~RUBY, file_path)
+            errors.details[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction_if_model_file(<<~RUBY, file_path)
+            errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when using `keys` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.details[:name].keys
           RUBY
         end
       end


### PR DESCRIPTION
- Fixed a NoMethodError on nil for `errors.keys` in a model.
- Fixed a bad autocorrection of `errors.details[:name] << value`.
  There isn't really a replacement for this one.
- The `values`, `to_h`, and `to_xml` methods are deprecated too.
- Made the range calculation more exact so the replacement is easier.
- Did some refactors prompted by rubocop complaints.
- Fixed a misspelling of autocorrectable.
- Added missing correction assertions to test cases.
- Added missing test cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
