### PR TITLE
Fix a NoMethodError for `errors.keys` in a model

### DIFF
--- a/changelog/fix_deprecated_errors_nil_dereference.md
+++ b/changelog/fix_deprecated_errors_nil_dereference.md
@@ -1,0 +1,1 @@
+* [#740](https://github.com/rubocop/rubocop-rails/pull/740): Fix a NoMethodError on nil for `errors.keys` in a model in Rails/DeprecatedActiveModelErrorsMethods. ([@BrianHawley][])

--- a/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
+++ b/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
@@ -121,11 +121,6 @@ module RuboCop
         def autocorrect(corrector, node)
           receiver = node.receiver
 
-          if receiver.receiver.send_type? && receiver.receiver.method?(:messages)
-            corrector.remove(receiver.receiver.loc.dot)
-            corrector.remove(receiver.receiver.loc.selector)
-          end
-
           range = offense_range(node, receiver)
           replacement = replacement(node, receiver)
 
@@ -133,11 +128,12 @@ module RuboCop
         end
 
         def offense_range(node, receiver)
-          range_between(receiver.receiver.source_range.end_pos, node.source_range.end_pos)
+          receiver = receiver.receiver while receiver.send_type? && !receiver.method?(:errors) && receiver.receiver
+          range_between(receiver.source_range.end_pos, node.source_range.end_pos)
         end
 
         def replacement(node, receiver)
-          return '.errors.attribute_names' if node.method?(:keys)
+          return '.attribute_names' if node.method?(:keys)
 
           key = receiver.first_argument.source
 

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config do
   shared_examples 'errors call with explicit receiver' do
-    context 'when modifying errors' do
+    context 'when accessing errors' do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY, file_path)
           user.errors[:name] << 'msg'
@@ -20,6 +20,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             user.errors[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections
         end
       end
 
@@ -36,8 +38,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
         end
       end
 
-      context 'when using `keys` method' do
-        context 'Rails >= 6.1', :rails61 do
+      context 'Rails >= 6.1', :rails61 do
+        context 'when using `keys` method' do
           it 'registers and corrects an offense when root receiver is a variable' do
             expect_offense(<<~RUBY, file_path)
               user = create_user
@@ -62,8 +64,10 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             RUBY
           end
         end
+      end
 
-        context 'Rails <= 6.0', :rails60 do
+      context 'Rails <= 6.0', :rails60 do
+        context 'when using `keys` method' do
           it 'does not register an offense when root receiver is a variable' do
             expect_no_offenses(<<~RUBY, file_path)
               user = create_user
@@ -98,6 +102,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             user.errors.messages[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY, file_path)
+            user.errors.messages[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user.errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when calling non-manipulative methods' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.messages[:name].present?
+          RUBY
         end
       end
     end
@@ -116,6 +143,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             user.errors.details[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY, file_path)
+            user.errors.details[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            user.errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when calling non-manipulative methods' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.details[:name].present?
+          RUBY
         end
       end
     end
@@ -131,11 +181,23 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
       end
     end
 
-    context 'when modifying errors' do
+    def expect_correction_if_model_file(code, file_path)
+      expect_correction(code) if file_path.include?('/models/')
+    end
+
+    def expect_no_corrections_if_model_file(file_path)
+      expect_no_corrections if file_path.include?('/models/')
+    end
+
+    context 'when accessing errors' do
       it 'registers an offense for model file' do
         expect_offense_if_model_file(<<~RUBY, file_path)
           errors[:name] << 'msg'
           ^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+        RUBY
+
+        expect_correction_if_model_file(<<~RUBY, file_path)
+          errors.add(:name, 'msg')
         RUBY
       end
 
@@ -145,6 +207,46 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             errors[:name] = []
             ^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
           RUBY
+
+          expect_no_corrections_if_model_file(file_path)
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense_if_model_file(<<~RUBY, file_path)
+            errors[:name].clear
+            ^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction_if_model_file(<<~RUBY, file_path)
+            errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'Rails >= 6.1', :rails61 do
+        context 'when using `keys` method' do
+          it 'registers and corrects an offense when root receiver is a variable' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.keys
+              ^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_correction_if_model_file(<<~RUBY, file_path)
+              errors.attribute_names
+            RUBY
+          end
+        end
+      end
+
+      context 'Rails <= 6.0', :rails60 do
+        context 'when using `keys` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              errors.keys
+            RUBY
+          end
         end
       end
 
@@ -163,6 +265,10 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           errors.messages[:name] << 'msg'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
         RUBY
+
+        expect_correction_if_model_file(<<~RUBY, file_path)
+          errors.add(:name, 'msg')
+        RUBY
       end
 
       context 'when assigning' do
@@ -170,6 +276,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           expect_offense_if_model_file(<<~RUBY, file_path)
             errors.messages[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_no_corrections_if_model_file(file_path)
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense_if_model_file(<<~RUBY, file_path)
+            errors.messages[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction_if_model_file(<<~RUBY, file_path)
+            errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when using `keys` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.messages[:name].keys
           RUBY
         end
       end
@@ -196,6 +325,29 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           expect_offense_if_model_file(<<~RUBY, file_path)
             errors.details[:name] = []
             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_no_corrections_if_model_file(file_path)
+        end
+      end
+
+      context 'when using `clear` method' do
+        it 'registers and corrects an offense' do
+          expect_offense_if_model_file(<<~RUBY, file_path)
+            errors.details[:name].clear
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+          RUBY
+
+          expect_correction_if_model_file(<<~RUBY, file_path)
+            errors.delete(:name)
+          RUBY
+        end
+      end
+
+      context 'when using `keys` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, file_path)
+            errors.details[:name].keys
           RUBY
         end
       end


### PR DESCRIPTION
Fixes for Rails/DeprecatedActiveModelErrorsMethods:
- Fixed a NoMethodError on nil for `errors.keys` in a model.
- Made the range calculation more exact so the replacement is easier.
- Added missing correction assertions to most test cases.
- Added missing test cases.
- Improved test structure for future changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
