### PR TITLE
No correction for `errors.details[:n] << v`

### DIFF
--- a/changelog/fix_deprecated_errors_bad_details_autocorrection.md
+++ b/changelog/fix_deprecated_errors_bad_details_autocorrection.md
@@ -1,0 +1,1 @@
+* [#741](https://github.com/rubocop/rubocop-rails/pull/741): Fix a bad autocorrection for `errors.details[:name] << value` in Rails/DeprecatedActiveModelErrorsMethods. ([@BrianHawley][])

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -135,6 +135,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           user.errors.details[:name] << {}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
         RUBY
+
+        expect_no_corrections
       end
 
       context 'when assigning' do
@@ -318,6 +320,8 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           errors.details[:name] << {}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
         RUBY
+
+        expect_no_corrections_if_model_file(file_path)
       end
 
       context 'when assigning' do


### PR DESCRIPTION
Fixes for Rails/DeprecatedActiveModelErrorsMethods:
- Fixed a bad autocorrection of `errors.details[:name] << value`.
  There isn't really a correct replacement for this one.
- Did some refactors prompted by rubocop complaints.
- Fixed a misspelling of autocorrectable.
- Added missing correction assertions to test cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
