### PR TITLE
Enable `ActiveSupportExtensionsEnabled` option by default

### DIFF
--- a/changelog/new_enable_global_active_support_extensions_enabled_option.md
+++ b/changelog/new_enable_global_active_support_extensions_enabled_option.md
@@ -1,0 +1,1 @@
+* [#746](https://github.com/rubocop/rubocop-rails/pull/746): Enable `ActiveSupportExtensionsEnabled` option by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,9 @@ AllCops:
     # Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default.
     # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application
     - db/*schema.rb
+  # Enable checking Active Support extensions.
+  # See: https://docs.rubocop.org/rubocop/configuration.html#enable-checking-active-support-extensions
+  ActiveSupportExtensionsEnabled: true
   # What version of Rails is the inspected code using?  If a value is specified
   # for TargetRailsVersion then it is used.  Acceptable values are specified
   # as a float (i.e. 5.1); the patch version of Rails should not be included.


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10699.

`ActiveSupportExtensionsEnabled` option is supported since RuboCop 1.31.0. Please merge #729 first.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
