### PR TITLE
Deprecate `IgnoredMethods` option

### DIFF
--- a/changelog/change_deprecate_ignore_methods_parameter.md
+++ b/changelog/change_deprecate_ignore_methods_parameter.md
@@ -1,0 +1,1 @@
+* [#750](https://github.com/rubocop/rubocop-rails/pull/750): Deprecate `IgnoredMethods` option in integrate to `AllowedMethods` and `AllowedPatterns` option. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,24 @@ Lint/NumberConversion:
   # Add Rails' duration methods to the ignore list for `Lint/NumberConversion`
   # so that calling `to_i` on one of these does not register an offense.
   # See: https://github.com/rubocop/rubocop/issues/8950
+  AllowedMethods:
+    - ago
+    - from_now
+    - second
+    - seconds
+    - minute
+    - minutes
+    - hour
+    - hours
+    - day
+    - days
+    - week
+    - weeks
+    - fortnight
+    - fortnights
+    - in_milliseconds
+  AllowedPatterns: []
+  # Deprecated.
   IgnoredMethods:
     - ago
     - from_now
@@ -410,6 +428,14 @@ Rails/FindEach:
   VersionChanged: '2.9'
   Include:
     - app/models/**/*.rb
+  AllowedMethods:
+    # Methods that don't work well with `find_each`.
+    - order
+    - limit
+    - select
+    - lock
+  AllowedPatterns: []
+  # Deprecated.
   IgnoredMethods:
     # Methods that don't work well with `find_each`.
     - order

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -5,3 +5,13 @@
 #
 extracted:
   Rails/*: ~
+
+# Cop parameters that have been changed
+# Can be treated as a warning instead of a failure with `severity: warning`
+changed_parameters:
+  - cops: Rails/FindEach
+    parameters: IgnoredMethods
+    alternatives:
+      - AllowedMethods
+      - AllowedPatterns
+    severity: warning

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -13,11 +13,17 @@ module RuboCop
       #   # good
       #   User.all.find_each
       #
-      # @example IgnoredMethods: ['order']
+      # @example AllowedMethods: ['order']
+      #   # good
+      #   User.order(:foo).each
+      #
+      # @example AllowedPattern: [/order/]
       #   # good
       #   User.order(:foo).each
       class FindEach < Base
         include ActiveRecordHelper
+        include AllowedMethods
+        include AllowedPattern
         extend AutoCorrector
 
         MSG = 'Use `find_each` instead of `each`.'
@@ -47,7 +53,7 @@ module RuboCop
 
           method_chain = node.each_node(:send).map(&:method_name)
 
-          (cop_config['IgnoredMethods'].map(&:to_sym) & method_chain).any?
+          method_chain.any? { |method_name| allowed_method?(method_name) || matches_allowed_pattern?(method_name) }
         end
 
         def active_model_error_where?(node)

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_runtime_dependency 'rack', '>= 1.1'
-  s.add_runtime_dependency 'rubocop', '>= 1.31.0', '< 2.0'
+  s.add_runtime_dependency 'rubocop', '>= 1.33.0', '< 2.0'
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10829.

This PR deprecates `IgnoredMethods` option in integrate to `AllowedMethods` and `AllowedPatterns` option.
It requires RuboCop 1.33.0 or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
