### PR TITLE
Fix `Rails/CompactBlank` bug when offense is found in block

### DIFF
--- a/changelog/fix_fix_railscompactblank_bug_when_offense.md
+++ b/changelog/fix_fix_railscompactblank_bug_when_offense.md
@@ -1,0 +1,1 @@
+* [#753](https://github.com/rubocop/rubocop-rails/pull/753): Fix `Rails/CompactBlank` bug when offense is found in block. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/compact_blank.rb
+++ b/lib/rubocop/cop/rails/compact_blank.rb
@@ -93,7 +93,11 @@ module RuboCop
         end
 
         def offense_range(node)
-          end_pos = node.parent&.block_type? ? node.parent.loc.expression.end_pos : node.loc.expression.end_pos
+          end_pos = if node.parent&.block_type? && node.parent&.send_node == node
+                      node.parent.loc.expression.end_pos
+                    else
+                      node.loc.expression.end_pos
+                    end
 
           range_between(node.loc.selector.begin_pos, end_pos)
         end

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `reject(&:blank?)` in block' do
+      expect_offense(<<~RUBY)
+        hash.transform_values { |value| value.reject(&:blank?) }
+                                              ^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash.transform_values { |value| value.compact_blank }
+      RUBY
+    end
+
     it 'does not register an offense when using `compact_blank`' do
       expect_no_offenses(<<~RUBY)
         collection.compact_blank


### PR DESCRIPTION
I ran autocorrection of `Rails/CompactBlank` to my code and confirmed that the code is converted as follows:

```diff
-hash.transform_values { |value| value.reject(&:blank?) }
+hash.transform_values { |value| value.compact_blank
```

It appears that the offense range is incorrect.

```
hash.transform_values { |value| value.reject(&:blank?) }
                                      ^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
```

Both the `.reject` call within a block and the `.reject` call with a block have a block node in the parent, so I think it's not sufficient to simply check whether the parent is a `block_type?`.

```console
$ cat example.rb 
a { b.reject(&:blank?) }

c.reject! { |d| d.blank? }
$ ruby-parse example.rb 
(begin
  (block
    (send nil :a)
    (args)
    (send
      (send nil :b) :reject
      (block-pass
        (sym :blank?))))
  (block
    (send
      (send nil :c) :reject!)
    (args
      (procarg0
        (arg :d)))
    (send
      (lvar :d) :blank?)))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
