### PR TITLE
Make `Rails/RedundantReceiverInWithOptions` and `Rails/ReversibleMigration` aware of numblock

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,9 +14,6 @@ InternalAffairs/NodeDestructuring:
     - 'lib/rubocop/cop/rails/relative_date_constant.rb'
     - 'lib/rubocop/cop/rails/time_zone.rb'
 
-InternalAffairs/NumblockHandler:
-  Enabled: false
-
 # Offense count: 10
 Metrics/AbcSize:
   Max: 17

--- a/changelog/fix_make_redundant_receiver_in_with_options_and_reversible_migration_aware_of_numblock.md
+++ b/changelog/fix_make_redundant_receiver_in_with_options_and_reversible_migration_aware_of_numblock.md
@@ -1,0 +1,1 @@
+* [#754](https://github.com/rubocop/rubocop-rails/pull/754): Make `Rails/RedundantReceiverInWithOptions` and `Rails/ReversibleMigration` cops aware of numbered block parameter. ([@koic][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -6,7 +6,7 @@ module RuboCop
     module IndexMethod # rubocop:disable Metrics/ModuleLength
       RESTRICT_ON_SEND = %i[each_with_object to_h map collect []].freeze
 
-      def on_block(node)
+      def on_block(node) # rubocop:todo InternalAffairs/NumblockHandler
         on_bad_each_with_object(node) do |*match|
           handle_possible_offense(node, match, 'each_with_object')
         end

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -69,7 +69,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = FILTER_METHODS + ACTION_METHODS
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           check_method_node(node.send_node)
         end
 

--- a/lib/rubocop/cop/rails/rake_environment.rb
+++ b/lib/rubocop/cop/rails/rake_environment.rb
@@ -39,7 +39,7 @@ module RuboCop
           (block $(send nil? :task ...) ...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           task_definition?(node) do |task_method|
             return if task_name(task_method) == :default
             return if with_dependencies?(task_method)

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -229,6 +229,8 @@ module RuboCop
           check_change_table_node(node.send_node, node.body)
         end
 
+        alias on_numblock on_block
+
         private
 
         def check_irreversible_schema_statement_node(node)

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -29,6 +29,36 @@ RSpec.describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
     RUBY
   end
 
+  context 'Ruby >= 2.7', :ruby27 do
+    it 'registers an offense and corrects using explicit receiver in `with_options`' do
+      expect_offense(<<~RUBY)
+        class Account < ApplicationRecord
+          with_options dependent: :destroy do
+            _1.has_many :customers
+            ^^ Redundant receiver in `with_options`.
+            _1.has_many :products
+            ^^ Redundant receiver in `with_options`.
+            _1.has_many :invoices
+            ^^ Redundant receiver in `with_options`.
+            _1.has_many :expenses
+            ^^ Redundant receiver in `with_options`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Account < ApplicationRecord
+          with_options dependent: :destroy do
+            has_many :customers
+            has_many :products
+            has_many :invoices
+            has_many :expenses
+          end
+        end
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using implicit receiver in `with_options`' do
     expect_no_offenses(<<~RUBY)
       class Account < ApplicationRecord

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     end
   RUBY
 
+  context 'Ruby >= 2.7', :ruby27 do
+    it_behaves_like 'accepts', 'create_table using numbered parameter', <<~RUBY
+      create_table :users do
+        _1.string :name
+      end
+    RUBY
+  end
+
   it_behaves_like 'offense', 'execute', <<~RUBY
     execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
   RUBY
@@ -226,6 +234,14 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
         t.change_default :authorized, 1
       end
     RUBY
+
+    context 'Ruby >= 2.7', :ruby27 do
+      it_behaves_like 'offense', 'change_table(with change_default)', <<~RUBY
+        change_table :users do
+          _1.change_default :authorized, 1
+        end
+      RUBY
+    end
 
     context 'remove' do
       context 'Rails >= 6.1', :rails61 do


### PR DESCRIPTION
This PR Make `Rails/RedundantReceiverInWithOptions` and `Rails/ReversibleMigration` cops aware of numbered block parameter.

`Rails/ActionFilter` and `Rails/RakeEnvironment` cops have block arguments, so numblock operation is unnecessary.

`Rails/IndexBy` and `Rails/IndexWith` cops is a slightly more complicated operation using multiple block arguments.
It'll take care of it another time using `rubocop:todo` comment because I think it's a really rare case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
