### PR TITLE
Fix incorrect documentation URLs when using `rubocop --show-docs-url`

### DIFF
--- a/changelog/fix_incorrect_documentation_urls.md
+++ b/changelog/fix_incorrect_documentation_urls.md
@@ -1,0 +1,1 @@
+* [#756](https://github.com/rubocop/rubocop-rails/pull/756): Fix incorrect documentation URLs when using `rubocop --show-docs-url`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -61,6 +61,10 @@ Lint/NumberConversion:
     - fortnights
     - in_milliseconds
 
+Rails:
+  Enabled: true
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails
+
 Rails/ActionControllerTestCase:
   Description: 'Use `ActionDispatch::IntegrationTest` instead of `ActionController::TestCase`.'
   StyleGuide: 'https://rails.rubystyle.guide/#integration-testing'


### PR DESCRIPTION
Added `DocumentationBaseURL` for `rubocop --show-docs-url [COP1,COP2,...]` command to work correctly for rubocop-rails cops.

### Before

```console
$ bundle exec rubocop --show-docs-url Rails/ActionControllerTestCase
https://docs.rubocop.org/rubocop/cops_rails.html#railsactioncontrollertestcase
```

### After

```console
$ bundle exec rubocop --show-docs-url Rails/ActionControllerTestCase
https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactioncontrollertestcase
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
