### PR TITLE
[Fix #757] Fix a false positive for `Rails/ReflectionClassName`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,6 +11,7 @@ InternalAffairs/NodeDestructuring:
   Exclude:
     - 'lib/rubocop/cop/rails/environment_comparison.rb'
     - 'lib/rubocop/cop/rails/exit.rb'
+    - 'lib/rubocop/cop/rails/reflection_class_name.rb'
     - 'lib/rubocop/cop/rails/relative_date_constant.rb'
     - 'lib/rubocop/cop/rails/time_zone.rb'
 

--- a/changelog/fix_a_false_positive_for_rails_reflection_class_name.md
+++ b/changelog/fix_a_false_positive_for_rails_reflection_class_name.md
@@ -1,0 +1,1 @@
+* [#757](https://github.com/rubocop/rubocop-rails/issues/757): Fix a false positive for `Rails/ReflectionClassName` when using Ruby 3.1's hash shorthand syntax. ([@koic][])

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -80,4 +80,52 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
       belongs_to :account, class_name: :Account
     RUBY
   end
+
+  it 'registers an offense when parameter value is a local variable assigned a constant' do
+    expect_offense(<<~RUBY)
+      class_name = Account
+
+      has_many :accounts, class_name: class_name
+                          ^^^^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
+    RUBY
+  end
+
+  it 'does not register an offense when parameter value is a local variable assigned a string' do
+    expect_no_offenses(<<~RUBY)
+      class_name = 'Account'
+
+      has_many :accounts, class_name: class_name
+    RUBY
+  end
+
+  it 'does not register an offense when parameter value is a method call' do
+    expect_no_offenses(<<~RUBY)
+      has_many :accounts, class_name: class_name
+    RUBY
+  end
+
+  context 'Ruby >= 3.1', :ruby31 do
+    it 'registers an offense when shorthand syntax value is a local variable assigned a constant' do
+      expect_offense(<<~RUBY)
+        class_name = Account
+
+        has_many :accounts, class_name:
+                            ^^^^^^^^^^^ Use a string value for `class_name`.
+      RUBY
+    end
+
+    it 'does not register an offense when shorthand syntax value is a local variable assigned a string' do
+      expect_no_offenses(<<~RUBY)
+        class_name = 'Account'
+
+        has_many :accounts, class_name:
+      RUBY
+    end
+
+    it 'does not register an offense when shorthand syntax value is a local variable assigned a method call' do
+      expect_no_offenses(<<~RUBY)
+        has_many :accounts, class_name:
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #757.

This PR fixes a false positive for `Rails/ReflectionClassName` when using Ruby 3.1's hash shorthand syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
