### PR TITLE
Add `Rails/ActionControllerFlashBeforeRender` cop

### DIFF
--- a/changelog/new_add_railsactioncontrollerflashbeforerender.md
+++ b/changelog/new_add_railsactioncontrollerflashbeforerender.md
@@ -1,0 +1,1 @@
+* [#759](https://github.com/rubocop/rubocop-rails/pull/759): Add new `Rails/ActionControllerFlashBeforeRender` cop. ([@americodls][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -65,6 +65,14 @@ Rails:
   Enabled: true
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails
 
+Rails/ActionControllerFlashBeforeRender:
+  Description: 'Use `flash.now` instead of `flash` before `render`.'
+  StyleGuide: 'https://rails.rubystyle.guide/#flash-before-render'
+  Reference: 'https://api.rubyonrails.org/classes/ActionController/FlashBeforeRender.html'
+  Enabled: 'pending'
+  SafeAutocorrect: false
+  VersionAdded: '<<next>>'
+
 Rails/ActionControllerTestCase:
   Description: 'Use `ActionDispatch::IntegrationTest` instead of `ActionController::TestCase`.'
   StyleGuide: 'https://rails.rubystyle.guide/#integration-testing'

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Using `flash` assignment before `render` in Rails controllers will persist the message for too long.
+      # Check https://guides.rubyonrails.org/action_controller_overview.html#flash-now
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe because it replaces `flash` by `flash.now`.
+      #   Even though it is usually a mistake, it might be used intentionally.
+      #
+      # @example
+      #
+      #   # bad
+      #   class HomeController < ApplicationController
+      #     def create
+      #       flash[:alert] = "msg"
+      #       render :index
+      #     end
+      #   end
+      #
+      #   # good
+      #   class HomeController < ApplicationController
+      #     def create
+      #       flash.now[:alert] = "msg"
+      #       render :index
+      #     end
+      #   end
+      #
+      class ActionControllerFlashBeforeRender < Base
+        extend AutoCorrector
+
+        MSG = 'Use `flash.now` before `render`.'
+
+        def_node_search :flash_assignment?, <<~PATTERN
+          ^(send (send nil? :flash) :[]= ...)
+        PATTERN
+
+        def_node_search :render?, <<~PATTERN
+          (send nil? :render ...)
+        PATTERN
+
+        def_node_search :action_controller?, <<~PATTERN
+          {
+            (const nil? :ApplicationController)
+            (const (const nil? :ActionController) :Base)
+          }
+        PATTERN
+
+        RESTRICT_ON_SEND = [:flash].freeze
+
+        def on_send(flash_node)
+          return unless flash_assignment?(flash_node)
+
+          return unless followed_by_render?(flash_node)
+
+          return unless instance_method_or_block?(flash_node)
+
+          return unless inherit_action_controller_base?(flash_node)
+
+          add_offense(flash_node) do |corrector|
+            corrector.replace(flash_node, 'flash.now')
+          end
+        end
+
+        private
+
+        def followed_by_render?(flash_node)
+          flash_assigment_node = find_ancestor(flash_node, type: :send)
+          context = flash_assigment_node.parent
+
+          context.each_child_node.any? do |node|
+            render?(node)
+          end
+        end
+
+        def inherit_action_controller_base?(node)
+          class_node = find_ancestor(node, type: :class)
+          return unless class_node
+
+          action_controller?(class_node)
+        end
+
+        def instance_method_or_block?(node)
+          def_node = find_ancestor(node, type: :def)
+          block_node = find_ancestor(node, type: :block)
+
+          def_node || block_node
+        end
+
+        def find_ancestor(node, type:)
+          node.each_ancestor(type).first
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -8,6 +8,7 @@ require_relative 'mixin/index_method'
 require_relative 'mixin/migrations_helper'
 require_relative 'mixin/target_rails_version'
 
+require_relative 'rails/action_controller_flash_before_render'
 require_relative 'rails/action_controller_test_case'
 require_relative 'rails/action_filter'
 require_relative 'rails/active_record_aliases'

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config do
+  context 'when using `flash` before `render`' do
+    context 'within an instance method' do
+      %w[ActionController::Base ApplicationController].each do |parent_class|
+        context "within a class inherited from #{parent_class}" do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  flash[:alert] = "msg"
+                  ^^^^^ Use `flash.now` before `render`.
+                  render :index
+                end
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  flash.now[:alert] = "msg"
+                  render :index
+                end
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'within a non Rails controller class' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class NonController < ApplicationRecord
+              def create
+                flash[:alert] = "msg"
+                render :index
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'within a block' do
+      %w[ActionController::Base ApplicationController].each do |parent_class|
+        context "within a class inherited from #{parent_class}" do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              class HomeController < #{parent_class}
+                before_action do
+                  flash[:alert] = "msg"
+                  ^^^^^ Use `flash.now` before `render`.
+                  render :index
+                end
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              class HomeController < #{parent_class}
+                before_action do
+                  flash.now[:alert] = "msg"
+                  render :index
+                end
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'within a non Rails controller class' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class NonController < ApplicationRecord
+              before_action do
+                flash[:alert] = "msg"
+                render :index
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'within a class method' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class HomeController < ApplicationController
+            def self.create
+              flash[:alert] = "msg"
+              render :index
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'within a class body' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class HomeController < ApplicationController
+            flash[:alert] = "msg"
+            render :index
+          end
+        RUBY
+      end
+    end
+
+    context 'with no context' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          flash[:alert] = "msg"
+          render :index
+        RUBY
+      end
+    end
+  end
+
+  context 'when using `flash` before `redirect_to`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class HomeController < ApplicationController
+          def create
+            flash[:alert] = "msg"
+            redirect_to "https://www.example.com/"
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This PR suggests a new Cop for detecting `flash` assignment before `render` a page (the correct approach would be to assign a message to `flash.now` ([check on rails guides](https://guides.rubyonrails.org/action_controller_overview.html#flash-now)) .

This is a common mistake in Ruby on Rails, and it is easy to fall into this trap the flash will be rendered on the page. But the flash message still persisted and will show up on the following redirect.

This is an example of that issue: https://github.com/rubygems/rubygems.org/issues/3149

Solved here: https://github.com/rubygems/rubygems.org/pull/3198

This is a very simple version but helped me to find more 6 issues on that project.
I hope I can receive some suggestions on how to improve this solution.


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
