### PR TITLE
[Fix #764] Fix an incorrect autocorrect for `Rails/FreezeTime`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_freeze_time.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_freeze_time.md
@@ -1,0 +1,1 @@
+* [#764](https://github.com/rubocop/rubocop-rails/issues/764): Fix an incorrect autocorrect for `Rails/FreezeTime` when using `travel_to` with an argument of the current time and proc argument. ([@koic][])

--- a/lib/rubocop/cop/rails/freeze_time.rb
+++ b/lib/rubocop/cop/rails/freeze_time.rb
@@ -46,7 +46,11 @@ module RuboCop
           child_node, method_name = *node.first_argument.children
           return unless current_time?(child_node, method_name) || current_time_with_convert?(child_node, method_name)
 
-          add_offense(node) { |corrector| corrector.replace(node, 'freeze_time') }
+          add_offense(node) do |corrector|
+            last_argument = node.last_argument
+            freeze_time_method = last_argument.block_pass_type? ? "freeze_time(#{last_argument.source})" : 'freeze_time'
+            corrector.replace(node, freeze_time_method)
+          end
         end
 
         private

--- a/spec/rubocop/cop/rails/freeze_time_spec.rb
+++ b/spec/rubocop/cop/rails/freeze_time_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe RuboCop::Cop::Rails::FreezeTime, :config do
     RUBY
   end
 
+  it 'registers an offense when using `travel_to` with an argument of the current time and proc argument' do
+    expect_offense(<<~RUBY)
+      around do |example|
+        travel_to(Time.current, &example)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      around do |example|
+        freeze_time(&example)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `freeze_time`' do
     expect_no_offenses(<<~RUBY)
       freeze_time


### PR DESCRIPTION
Fixes #764.

This PR fixes an incorrect autocorrect for `Rails/FreezeTime` when using `travel_to` with an argument of the current time and proc argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
