### PR TITLE
[Fix #763] Fix a false positive for `Rails/RootPathnameMethods`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_root_pathname_methods.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_root_pathname_methods.md
@@ -1,0 +1,1 @@
+* [#763](https://github.com/rubocop/rubocop-rails/issues/763): Mark `Rails/RootPathnameMethods` as unsafe and fix an incorrect autocorrect when using `Dir.glob`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -845,6 +845,7 @@ Rails/RootJoinChain:
 Rails/RootPathnameMethods:
   Description: 'Use `Rails.root` IO methods instead of passing it to `File`.'
   Enabled: pending
+  SafeAutocorrect: false
   VersionAdded: '2.16'
 
 Rails/RootPublicPath:


### PR DESCRIPTION
Fixes #763.

This PR fix a false positive for `Rails/RootPathnameMethods` when using `Dir.glob`. And marks unsafe for autocorrection because `Dir`'s methods return string element, but `Pathname`'s methods return `Pathname` element.


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
