### PR TITLE
[Fix #769] Fix a false positive for `Rails/FreezeTime`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_freeze_time.md
+++ b/changelog/fix_a_false_positive_for_rails_freeze_time.md
@@ -1,0 +1,1 @@
+* [#769](https://github.com/rubocop/rubocop-rails/issues/769): Fix a false positive for `Rails/FreezeTime` when using `travel_to` with an argument of `DateTime.new` with arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/freeze_time.rb
+++ b/lib/rubocop/cop/rails/freeze_time.rb
@@ -43,8 +43,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          child_node, method_name = *node.first_argument.children
-          return unless child_node
+          child_node, method_name, time_argument = *node.first_argument.children
+          return if time_argument || !child_node
           return unless current_time?(child_node, method_name) || current_time_with_convert?(child_node, method_name)
 
           add_offense(node) do |corrector|

--- a/spec/rubocop/cop/rails/freeze_time_spec.rb
+++ b/spec/rubocop/cop/rails/freeze_time_spec.rb
@@ -91,4 +91,10 @@ RSpec.describe RuboCop::Cop::Rails::FreezeTime, :config do
       travel_to(current)
     RUBY
   end
+
+  it 'does not register an offense when using `travel_to` with an argument of `DateTime.new` with arguments' do
+    expect_no_offenses(<<~RUBY)
+      travel_to(DateTime.new(2022, 5, 3, 12, 0, 0))
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #769.

This PR fixes a false positive for `Rails/FreezeTime` when using `travel_to` with an argument of `DateTime.new` with arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
