### PR TITLE
Fix a false positive for `Rails/TopLevelHashWithIndifferentAccess`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_top_level_hash_with_indifferent_access.md
+++ b/changelog/fix_a_false_positive_for_rails_top_level_hash_with_indifferent_access.md
@@ -1,0 +1,1 @@
+* [#772](https://github.com/rubocop/rubocop-rails/pull/772): Fix a false positive for `Rails/TopLevelHashWithIndifferentAccess` when using `HashWithIndifferentAccess` under namespace module. ([@koic][])

--- a/lib/rubocop/cop/rails/top_level_hash_with_indifferent_access.rb
+++ b/lib/rubocop/cop/rails/top_level_hash_with_indifferent_access.rb
@@ -31,6 +31,7 @@ module RuboCop
         # @param [RuboCop::AST::ConstNode] node
         def on_const(node)
           return unless top_level_hash_with_indifferent_access?(node)
+          return if node.parent&.class_type? && node.parent.ancestors.any?(&:module_type?)
 
           add_offense(node) do |corrector|
             autocorrect(corrector, node)

--- a/spec/rubocop/cop/rails/top_level_hash_with_indifferent_access_spec.rb
+++ b/spec/rubocop/cop/rails/top_level_hash_with_indifferent_access_spec.rb
@@ -27,10 +27,34 @@ RSpec.describe RuboCop::Cop::Rails::TopLevelHashWithIndifferentAccess, :config, 
     end
   end
 
+  context 'with top-level `HashWithIndifferentAccess` without method call' do
+    it 'registers and corrects an offense' do
+      expect_offense(<<~RUBY)
+        HashWithIndifferentAccess
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid top-level `HashWithIndifferentAccess`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ActiveSupport::HashWithIndifferentAccess
+      RUBY
+    end
+  end
+
   context 'with ActiveSupport::HashWithIndifferentAccess' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         ActiveSupport::HashWithIndifferentAccess.new(foo: 'bar')
+      RUBY
+    end
+  end
+
+  context 'with `HashWithIndifferentAccess` under the namespace' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        module CoreExt
+          class HashWithIndifferentAccess
+          end
+        end
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes a false positive for `Rails/TopLevelHashWithIndifferentAccess` when using `HashWithIndifferentAccess` under namespace module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
