### PR TITLE
[Fix #776] Fix an incorrect autocorrect for `Rails/Presence`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_presence.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_presence.md
@@ -1,0 +1,1 @@
+* [#776](https://github.com/rubocop/rubocop-rails/issues/776): Fix an incorrect autocorrect for `Rails/Presence` when using arithmetic operation in `else` branch. ([@koic][])

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -122,18 +122,18 @@ module RuboCop
         end
 
         def build_source_for_or_method(other)
-          if other.parenthesized? || other.method?('[]') || !other.arguments?
+          if other.parenthesized? || other.method?('[]') || other.arithmetic_operation? || !other.arguments?
             " || #{other.source}"
           else
-            method = range_between(
-              other.source_range.begin_pos,
-              other.first_argument.source_range.begin_pos - 1
-            ).source
-
+            method = method_range(other).source
             arguments = other.arguments.map(&:source).join(', ')
 
             " || #{method}(#{arguments})"
           end
+        end
+
+        def method_range(node)
+          range_between(node.source_range.begin_pos, node.first_argument.source_range.begin_pos - 1)
         end
       end
     end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
     end
   RUBY
 
+  it_behaves_like 'offense', <<~RUBY.chomp, 'a.presence || b.to_f + 12.0', 1, 5
+    if a.present?
+      a
+    else
+      b.to_f + 12.0
+    end
+  RUBY
+
+  it_behaves_like 'offense', <<~RUBY.chomp, 'a.presence || b.to_f * 12.0', 1, 5
+    if a.present?
+      a
+    else
+      b.to_f * 12.0
+    end
+  RUBY
+
   it_behaves_like 'offense', 'a if a.present?', 'a.presence', 1, 1
   it_behaves_like 'offense', 'a unless a.blank?', 'a.presence', 1, 1
   it_behaves_like 'offense', <<~RUBY.chomp, <<~FIXED.chomp, 1, 7


### PR DESCRIPTION
Fixes #776.

This PR fixes an incorrect autocorrect for `Rails/Presence` when using arithmetic operation in `else` branch.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
