### PR TITLE
[Fix #781] Fix a false positive for `Rails/DynamicFindBy`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_dynamic_find_by.md
+++ b/changelog/fix_a_false_positive_for_rails_dynamic_find_by.md
@@ -1,0 +1,1 @@
+* [#781](https://github.com/rubocop/rubocop-rails/issues/781): Make `Rails/DynamicFindBy` aware of `find_by_token_for`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -348,8 +348,10 @@ Rails/DynamicFindBy:
   # The `Whitelist` has been deprecated, Please use `AllowedMethods` instead.
   Whitelist:
     - find_by_sql
+    - find_by_token_for
   AllowedMethods:
     - find_by_sql
+    - find_by_token_for
   AllowedReceivers:
     - Gem::Specification
 

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -22,12 +22,14 @@ module RuboCop
       #   User.find_by(name: name, email: email)
       #   User.find_by!(email: email)
       #
-      # @example AllowedMethods: ['find_by_sql'] (default)
+      # @example AllowedMethods: ['find_by_sql', 'find_by_token_for'] (default)
       #   # bad
       #   User.find_by_query(users_query)
+      #   User.find_by_token_for(:password_reset, token)
       #
       #   # good
       #   User.find_by_sql(users_sql)
+      #   User.find_by_token_for(:password_reset, token)
       #
       # @example AllowedReceivers: ['Gem::Specification'] (default)
       #   # bad


### PR DESCRIPTION
Fixes #781.

This PR makes `Rails/DynamicFindBy` aware of `find_by_token_for`. This default setting emphasizes suppressing false positive over false negative. `find_by_token_for` is probably rarely named, but it will always exist in Rails in the future.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
