### PR TITLE
[Fix #782] Fix an incorrect autocorrect for `Rails/EagerEvaluationLogMessage`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_eager_evaluation_log_message.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_eager_evaluation_log_message.md
@@ -1,0 +1,1 @@
+* [#782](https://github.com/rubocop/rubocop-rails/issues/782): Fix an incorrect autocorrect for `Rails/EagerEvaluationLogMessage` when using `Style/MethodCallWithArgsParentheses`'s autocorrection together. ([@koic][])

--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -14,6 +14,14 @@ RuboCop::Rails::Inject.defaults!
 
 require_relative 'rubocop/cop/rails_cops'
 
+RuboCop::Cop::Style::MethodCallWithArgsParentheses.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::Rails::EagerEvaluationLogMessage)
+    end
+  end
+)
+
 RuboCop::Cop::Style::RedundantSelf.singleton_class.prepend(
   Module.new do
     def autocorrect_incompatible_with

--- a/lib/rubocop/cop/rails/eager_evaluation_log_message.rb
+++ b/lib/rubocop/cop/rails/eager_evaluation_log_message.rb
@@ -37,6 +37,10 @@ module RuboCop
           )
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [Style::MethodCallWithArgsParentheses]
+        end
+
         def on_send(node)
           return if node.parent&.block_type?
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RuboCop::ConfigLoader.default_configuration.for_all_cops['SuggestExtensions'] = false
   end
 
+  it 'corrects `Rails/EagerEvaluationLogMessage,` with `Style/MethodCallWithArgsParentheses`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Rails/SafeNavigation:
+        ConvertTry: true
+    YAML
+
+    create_file('example.rb', <<~'RUBY')
+      Rails.logger.debug "foo#{bar}"
+    RUBY
+
+    expect(cli.run(['-a', '--only', 'Rails/EagerEvaluationLogMessage,Style/MethodCallWithArgsParentheses'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~'RUBY')
+      Rails.logger.debug { "foo#{bar}" }
+    RUBY
+  end
+
   it 'corrects `Rails/SafeNavigation` with `Style/RedundantSelf`' do
     create_file('.rubocop.yml', <<~YAML)
       Rails/SafeNavigation:


### PR DESCRIPTION
Fixes #782.

This PR fixes an incorrect autocorrect for `Rails/EagerEvaluationLogMessage` when using `Style/MethodCallWithArgsParentheses`'s autocorrection together.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
