### PR TITLE
[Fix #778] Fix a false positive for `Rails/DynamicFindBy`

### DIFF
--- a/changelog/fix_false_positive_for_rails_dynamic_find_by.md
+++ b/changelog/fix_false_positive_for_rails_dynamic_find_by.md
@@ -1,0 +1,1 @@
+* [#778](https://github.com/rubocop/rubocop-rails/issues/778): Fix a false positive for `Rails/DynamicFindBy` when using `page.find_by_id` as a Capybara testing API. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -352,6 +352,7 @@ Rails/DynamicFindBy:
     - find_by_sql
   AllowedReceivers:
     - Gem::Specification
+    - page # Prevents a warning for `page.find_by_id`. See: https://github.com/rubocop/rubocop-rails/issues/778
 
 Rails/EagerEvaluationLogMessage:
   Description: 'Checks that blocks are used for interpolated strings passed to `Rails.logger.debug`.'

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -29,12 +29,14 @@ module RuboCop
       #   # good
       #   User.find_by_sql(users_sql)
       #
-      # @example AllowedReceivers: ['Gem::Specification'] (default)
+      # @example AllowedReceivers: ['Gem::Specification', 'page'] (default)
       #   # bad
       #   Specification.find_by_name('backend').gem_dir
+      #   page.find_by_id('a_dom_id').click
       #
       #   # good
       #   Gem::Specification.find_by_name('backend').gem_dir
+      #   page.find_by_id('a_dom_id').click
       class DynamicFindBy < Base
         include ActiveRecordHelper
         extend AutoCorrector


### PR DESCRIPTION
Fixes #778.

This PR fixes a false positive for `Rails/DynamicFindBy` when using `page.find_by_id` as a Capybara testing API. This default setting emphasizes suppressing false positive over false negative.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
