### PR TITLE
[Fix #786] Fix a false negative for `Rails/ActionControllerTestCase`

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_action_controller_test_case.md
+++ b/changelog/fix_a_false_negative_for_rails_action_controller_test_case.md
@@ -1,0 +1,1 @@
+* [#786](https://github.com/rubocop/rubocop-rails/issues/786): Fix a false negative for `Rails/ActionControllerTestCase` when extending `ActionController::TestCase` and having a method definition. ([@koic][])

--- a/lib/rubocop/cop/rails/action_controller_test_case.rb
+++ b/lib/rubocop/cop/rails/action_controller_test_case.rb
@@ -31,7 +31,7 @@ module RuboCop
         def_node_matcher :action_controller_test_case?, <<~PATTERN
           (class
             (const nil? _)
-            (const (const {nil? cbase} :ActionController) :TestCase) nil?)
+            (const (const {nil? cbase} :ActionController) :TestCase) _)
         PATTERN
 
         def on_class(node)

--- a/spec/rubocop/cop/rails/action_controller_test_case_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_test_case_spec.rb
@@ -36,6 +36,23 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerTestCase, :config do
     RUBY
   end
 
+  it 'adds offense when extending `ActionController::TestCase` and having a method definition' do
+    expect_offense(<<~RUBY)
+      class MyControllerTest < ActionController::TestCase
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `ActionDispatch::IntegrationTest` instead.
+        def test_foo
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MyControllerTest < ActionDispatch::IntegrationTest
+        def test_foo
+        end
+      end
+    RUBY
+  end
+
   it 'does not add offense when extending `ActionDispatch::IntegrationTest`' do
     expect_no_offenses(<<~RUBY)
       class MyControllerTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
Fixes #786.

This PR fixes a false negative for `Rails/ActionControllerTestCase` when extending `ActionController::TestCase` and having a method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
