### PR TITLE
[Fix #787] Make `Rails/Pluck` aware of all keys

### DIFF
--- a/changelog/change_make_rails_pluck_aware_of_all_keys.md
+++ b/changelog/change_make_rails_pluck_aware_of_all_keys.md
@@ -1,0 +1,1 @@
+* [#787](https://github.com/rubocop/rubocop-rails/issues/787): Make `Rails/Pluck` aware of all keys. ([@koic][])


### PR DESCRIPTION
Fixes #787.

This PR makes `Rails/Pluck` aware of all keys.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
