### PR TITLE
[Fix #790] Make `Style/HashExcept` aware of TargetRubyVersion: 2.x

### DIFF
--- a/changelog/new_make_style_hash_except_aware_of_target_ruby_version_2_x.md
+++ b/changelog/new_make_style_hash_except_aware_of_target_ruby_version_2_x.md
@@ -1,0 +1,1 @@
+* [#790](https://github.com/rubocop/rubocop-rails/issues/790): Make `Style/HashExcept` aware of TargetRubyVersion: 2.x because Rails has `Hash#except`. ([@koic][])

--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -14,6 +14,8 @@ RuboCop::Rails::Inject.defaults!
 
 require_relative 'rubocop/cop/rails_cops'
 
+RuboCop::Cop::Style::HashExcept.minimum_target_ruby_version(2.0)
+
 RuboCop::Cop::Style::MethodCallWithArgsParentheses.singleton_class.prepend(
   Module.new do
     def autocorrect_incompatible_with

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       self&.bar&.baz
     RUBY
   end
+
+  it 'corrects `Style/HashExcept` with `TargetRubyVersion: 2.0`' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 2.0
+    YAML
+
+    create_file('example.rb', <<~RUBY)
+      {foo: 1, bar: 2, baz: 3}.reject {|k, v| k == :bar }
+    RUBY
+
+    expect(cli.run(['-a', '--only', 'Style/HashExcept'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      {foo: 1, bar: 2, baz: 3}.except(:bar)
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #790.

This PR makes `Style/HashExcept` aware of TargetRubyVersion: 2.x because Rails has `Hash#except`. So Ruby version is irrelevant when used in Rails.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
