### PR TITLE
Fix a wrong AllowedPatterns example in `Rails/FindEach`

### DIFF
--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   # good
       #   User.order(:foo).each
       #
-      # @example AllowedPattern: [/order/]
+      # @example AllowedPattern: ['order']
       #   # good
       #   User.order(:foo).each
       class FindEach < Base

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Rails::FindEach, :config do
   end
 
   context 'allowed patterns' do
-    let(:cop_config) { { 'AllowedMethods' => [], 'AllowedPatterns' => [/order/, /lock/], 'IgnoredMethods' => [] } }
+    let(:cop_config) { { 'AllowedMethods' => [], 'AllowedPatterns' => %w[order lock], 'IgnoredMethods' => [] } }
 
     it 'does not register an offense when using order(...) earlier' do
       expect_no_offenses('User.order(:name).each { |u| u.something }')


### PR DESCRIPTION
This PR is fix a wrong AllowedPatterns example in `Rails/FindEach` When specifying in the .rubocop.yml file, it is necessary to specify `AllowedPatterns: ['foo']` instead of `AllowedPatterns: [/foo/]`.

Follow up: https://github.com/rubocop/rubocop-rspec/issues/1395

The test code was also modified to match the actual behavior as mentioned in https://github.com/rubocop/rubocop-rspec/pull/1396#issuecomment-1257026847 .

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
