### PR TITLE
[Fix #794] Fix an error for `Rails/RedundantReceiverInWithOptions`

### DIFF
--- a/changelog/fix_an_error_for_rails_redundant_receiver_in_with_option.md
+++ b/changelog/fix_an_error_for_rails_redundant_receiver_in_with_option.md
@@ -1,0 +1,1 @@
+* [#794](https://github.com/rubocop/rubocop-rails/issues/794): Fix an error for `Rails/RedundantReceiverInWithOptions` when calling a method with a receiver in `with_options` without block arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
+++ b/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
@@ -98,6 +98,8 @@ module RuboCop
           proc = if node.numblock_type?
                    ->(n) { n.receiver.lvar_type? && n.receiver.source == '_1' }
                  else
+                   return false if node.arguments.empty?
+
                    arg = node.arguments.first
                    ->(n) { same_value?(arg, n.receiver) }
                  end

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -108,6 +108,14 @@ RSpec.describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
     RUBY
   end
 
+  it 'does not register an offense when calling a method with a receiver in `with_options` without block arguments' do
+    expect_no_offenses(<<~RUBY)
+      with_options do
+        obj.do_something
+      end
+    RUBY
+  end
+
   it 'does not register an offense when empty' do
     expect_no_offenses(<<~RUBY)
       with_options options: false do |merger|


### PR DESCRIPTION
Fixes #794.

This PR fixes an error for `Rails/RedundantReceiverInWithOptions` when calling a method with a receiver in `with_options` without block arguments

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
