### PR TITLE
[Fix #796] Add several directories to `Exclude`

### DIFF
--- a/changelog/change_add_several_dir_to_exclude_to_prevent_slow_investigation.md
+++ b/changelog/change_add_several_dir_to_exclude_to_prevent_slow_investigation.md
@@ -1,0 +1,1 @@
+* [#796](https://github.com/rubocop/rubocop-rails/issues/796): Add several directories to `Exclude` to prevent slow investigation. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,9 @@ AllCops:
     # Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default.
     # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application
     - db/*schema.rb
+    - log/**/*
+    - public/**/*
+    - storage/**/*
   # Enable checking Active Support extensions.
   # See: https://docs.rubocop.org/rubocop/configuration.html#enable-checking-active-support-extensions
   ActiveSupportExtensionsEnabled: true


### PR DESCRIPTION
Fixes #796.

This PR adds several directories to `Exclude` to prevent slow investigation. These directories (`log`, `public`, and `storage`) provided by `bin/rails` are expected not to contain Ruby code. And `tmp` and `vendor` directories have already been excluded in the RuboCop core.
https://github.com/rubocop/rubocop/blob/v1.36.0/config/default.yml#L65-L66

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
