### PR TITLE
Fix test case in file_path_spec.rb for `Style/RedundantStringEscape`

### DIFF
--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when string contains an interpolation followed by a period' do
       it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
-          puts "test #\{123\}. Hey!"
+        expect_no_offenses(<<~'RUBY')
+          puts "test #{123}. Hey!"
         RUBY
       end
     end
@@ -244,8 +244,8 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when string contains an interpolation followed by a period' do
       it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
-          puts "test #\{123\}. Hey!"
+        expect_no_offenses(<<~'RUBY')
+          puts "test #{123}. Hey!"
         RUBY
       end
     end


### PR DESCRIPTION
CI seems to have failed because rubocop/rubocop#11002 was merged. (e.g. https://github.com/rubocop/rubocop-rails/pull/771/commits/2723be419d88169aee34ca64865411a3b2ab5300)

This commit is for fixing it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
