### PR TITLE
[Fix #800] Make `Rails/TimeZone` aware of timezone offset

### DIFF
--- a/changelog/change_make_rails_time_zone_aware_of_timezone_offset.md
+++ b/changelog/change_make_rails_time_zone_aware_of_timezone_offset.md
@@ -1,0 +1,1 @@
+* [#800](https://github.com/rubocop/rubocop-rails/issues/800): Make `Rails/TimeZone` aware of timezone UTF offset. ([@inkstak][])

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -55,7 +55,7 @@ module RuboCop
 
         ACCEPTED_METHODS = %i[in_time_zone utc getlocal xmlschema iso8601 jisx0301 rfc3339 httpdate to_i to_f].freeze
 
-        TIMEZONE_SPECIFIER = /[A-z]/.freeze
+        TIMEZONE_SPECIFIER = /([A-z]|[+-]\d{2}:?\d{2})\z/.freeze
 
         def on_const(node)
           mod, klass = *node
@@ -126,7 +126,7 @@ module RuboCop
         end
 
         def attach_timezone_specifier?(date)
-          date.respond_to?(:value) && TIMEZONE_SPECIFIER.match?(date.value.to_s[-1])
+          date.respond_to?(:value) && TIMEZONE_SPECIFIER.match?(date.value.to_s)
         end
 
         def build_message(klass, method_name, node)

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -123,6 +123,18 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       RUBY
     end
 
+    it 'does not register an offense when attaching timezone offset' do
+      expect_no_offenses(<<~RUBY)
+        Time.parse("2012-03-02 16:05:37 +0100")
+      RUBY
+    end
+
+    it 'does not register an offense when attaching timezone offset using a colon' do
+      expect_no_offenses(<<~RUBY)
+        Time.parse("2012-03-02 16:05:37 +01:00")
+      RUBY
+    end
+
     it 'registers an offense for Time.at' do
       expect_offense(<<~RUBY)
         Time.at(ts)


### PR DESCRIPTION
Fixes #800

This PR makes `Rails/TimeZone` aware of timezone UTC offset.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
