### PR TITLE
Fix #803: add ApplicationPolicy cop

### DIFF
--- a/changelog/new_active_policy_cop.md
+++ b/changelog/new_active_policy_cop.md
@@ -1,0 +1,1 @@
+* [#803](https://github.com/rubocop/rubocop-rails/issues/803): Add new `Rails/ActivePolicy` cop. ([@hoshy][])

--- a/lib/rubocop/cop/rails/application_policy.rb
+++ b/lib/rubocop/cop/rails/application_policy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rubocop-rails'
+
+module RuboCop
+  module Cop
+    module Rails
+      # Checks that policies subclass `ApplicationPolicy`.
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe because it may let the logic from `ApplicationPolicy`
+      #   sneak into a policy that is not purposed to inherit logic common among other policies.
+      #
+      # @example
+      #
+      #  # good
+      #  class MyPolicy < ApplicationPolicy
+      #    # ...
+      #  end
+      #
+      #  # bad
+      #  class MyPolicy < ActionPolicy::Base
+      #    # ...
+      #  end
+      class ApplicationPolicy < Base
+        extend AutoCorrector
+
+        include RuboCop::Cop::EnforceSuperclass
+        MSG = 'Policies should subclass `ApplicationPolicy`.'
+        SUPERCLASS = 'ApplicationPolicy'
+        BASE_PATTERN = '(const (const nil? :ActionPolicy) :Base)'
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rails/application_policy.rb
+++ b/spec/rubocop/cop/rails/application_policy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rubocop-rails'
+
+module RuboCop
+  module Cop
+    module Rails
+      # Checks that policies subclass `ApplicationPolicy`.
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe because it may let the logic from `ApplicationPolicy`
+      #   sneak into a policy that is not purposed to inherit logic common among other policies.
+      #
+      # @example
+      #
+      #  # good
+      #  class MyPolicy < ApplicationPolicy
+      #    # ...
+      #  end
+      #
+      #  # bad
+      #  class MyPolicy < ActionPolicy::Base
+      #    # ...
+      #  end
+      class ApplicationPolicy < Base
+        extend AutoCorrector
+
+        include RuboCop::Cop::EnforceSuperclass
+        MSG = 'Policies should subclass `ApplicationPolicy`.'
+        SUPERCLASS = 'ApplicationPolicy'
+        BASE_PATTERN = '(const (const nil? :ActionPolicy) :Base)'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using the active_policy gem you should create an ApplicationPolicy class and inherit your resource policies from it.

Problem
When using the [active_policy](https://github.com/palkan/action_policy) you should create an ApplicationPolicy class and [inherit your resource policies](https://github.com/palkan/action_policy#usage) from it (like you do with the ResourceController and ApplicationController in Rails).

This PR implements a cop thats checks, that policies subclass ApplicationPolicy and may auto-correct findings – similar to the Rails/ApplicationController-Cop.
