### PR TITLE
[Fix #779] Add `mail` to `AllowedMethods` of `Style/SymbolProc`

### DIFF
--- a/changelog/change_add_mail_to_allowed_methods_of_style_symbol_proc.md
+++ b/changelog/change_add_mail_to_allowed_methods_of_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#779](https://github.com/rubocop/rubocop-rails/issues/779): Add `mail` to `AllowedMethods` of `Style/SymbolProc`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1123,3 +1123,9 @@ Rails/WhereNotWithMultipleConditions:
 # Accept `redirect_to(...) and return` and similar cases.
 Style/AndOr:
   EnforcedStyle: conditionals
+
+Style/SymbolProc:
+  AllowedMethods:
+    - define_method
+    - mail
+    - respond_to


### PR DESCRIPTION
Fixes #779.

This PR adds `mail` to `AllowedMethods` of `Style/SymbolProc`. `define_methods` and `respond_to` inherit from RuboCop core.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
