### PR TITLE
Fix errors that occur when unrelated `tag` is investigated by `Rails/ContentTag`

### DIFF
--- a/changelog/fix_errors_that_occur_when_unrelated_tag.md
+++ b/changelog/fix_errors_that_occur_when_unrelated_tag.md
@@ -1,0 +1,1 @@
+* [#813](https://github.com/rubocop/rubocop-rails/pull/813): Fix errors that occur when unrelated `tag` is investigated by `Rails/ContentTag`. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -56,7 +56,8 @@ module RuboCop
             argument.send_type? ||
             argument.const_type? ||
             argument.splat_type? ||
-            allowed_name?(argument)
+            allowed_name?(argument) ||
+            !argument.respond_to?(:value)
         end
 
         def register_offense(node, message, preferred_method)

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -174,6 +174,14 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
       end
     end
 
+    context 'when the first argument is keyword arguments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          tag(factory: :tag)
+        RUBY
+      end
+    end
+
     context 'when `tag` is not a top-level method (e.g. using intercom-ruby)' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
I encountered a strange error when running rubocop-rails on our Rails app that uses FactoryBot.

The file that caused the problem was, in simplified form, the following code:

```ruby
FactoryBot.define do
  factory :article do
    tag factory: :article_tag
  end
end
```

and the error output was like this:

```
$ bundle exec rubocop spec/factories/articles.rb 
Inspecting 1 file
An error occurred while Rails/ContentTag cop was inspecting /workspace/spec/factories/articles.rb:3:4.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Rails/ContentTag cop was inspecting /workspace/spec/factories/articles.rb:3:4.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.36.0 (using Parser 3.1.2.1, rubocop-ast 1.21.0, running on ruby 2.7.2) [x86_64-linux]
```

This Pull Request has been created to fix this problem.

We could add `{spec,test}/factories/**/*.rb` to `Exclude` section of this cop, but that would not prevent the problem from reoccuring in other places. Since extensive investigation is performed on the generic method name `tag`, I think it should be checked more rigorously in this way.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
