### PR TITLE
[Fix #792] Fixes a false negative for Rails/RedundantPresenceValidationOnBelongsTo

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_redundant_presence_validation_on_belongs_to.md
+++ b/changelog/fix_a_false_negative_for_rails_redundant_presence_validation_on_belongs_to.md
@@ -1,0 +1,1 @@
+* [#792](https://github.com/rubocop/rubocop-rails/issues/792): Fix a false negative for `Rails/RedundantPresenceValidationOnBelongsTo` when belongs_to at least one block and one hash like `belongs_to :company, -> { where(foo: true) }, inverse_of: :employee`. ([@PedroAugustoRamalhoDuarte][])

--- a/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
+++ b/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
@@ -143,7 +143,7 @@ module RuboCop
         def_node_matcher :belongs_to_without_fk?, <<~PATTERN
           {
             (send nil? :belongs_to (sym %1))        # belongs_to :user
-            (send nil? :belongs_to (sym %1) !hash)  # belongs_to :user, -> { not_deleted }
+            (send nil? :belongs_to (sym %1) !hash ...)  # belongs_to :user, -> { not_deleted }
             (send nil? :belongs_to (sym %1) !(hash <(pair (sym :foreign_key) _) ...>))
           }
         PATTERN

--- a/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
@@ -180,6 +180,14 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
         RUBY
       end
 
+      it 'registers an offense for multiple attributes and options in belongs_to' do
+        expect_offense(<<~RUBY)
+          belongs_to :user, -> { where(foo: true) }, inverse_of: :employee
+          validates :user_id, presence: true
+                              ^^^^^^^^^^^^^^ Remove explicit presence validation for `user_id`.
+        RUBY
+      end
+
       pending 'registers an offense even when the presence option is factored out' do
         expect_offense(<<~RUBY)
           belongs_to :user


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

Fix a false negative for `Rails/RedundantPresenceValidationOnBelongsTo` when belongs_to have one block and one hash like `belongs_to :company, -> { where(foo: true) }, inverse_of: :employee`

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ x Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
