### PR TITLE
Preserve multiline semantics on `Rails/Presence`

### DIFF
--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -106,7 +106,17 @@ module RuboCop
         end
 
         def message(node, receiver, other)
-          format(MSG, prefer: replacement(receiver, other), current: node.source)
+          prefer = replacement(receiver, other).gsub(/^\s*|\n/, '')
+          current = current(node).gsub(/^\s*|\n/, '')
+          format(MSG, prefer: prefer, current: current)
+        end
+
+        def current(node)
+          if node.source.include?("\n")
+            "#{node.loc.keyword.with(end_pos: node.condition.loc.selector.end_pos).source} ... end"
+          else
+            node.source
+          end
         end
 
         def replacement(receiver, other)


### PR DESCRIPTION
Similar issue: https://github.com/rubocop/rubocop/pull/10784

Before
```diff
if a.present?
+^^^^^^^^^^^^^ Use `a.presence || b.to_f * 12.0` instead of `if a.present?
+  a
+else
+  b
+end`.
  a
else
  b
end
```

After
```diff
if a.present?
+^^^^^^^^^^^^^ Use `a.presence || b` instead of `if a.present? ... end`.
  a
else
  b
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
