### PR TITLE
[Fix #822] Extends `Rails/HttpStatus` cop to check `routes.rb`

### DIFF
--- a/changelog/change_extends_http_status_to_detect_redirect_routes.md
+++ b/changelog/change_extends_http_status_to_detect_redirect_routes.md
@@ -1,0 +1,1 @@
+* [#822](https://github.com/rubocop/rubocop-rails/issues/822): Extends `Rails/HttpStatus` cop to check `routes.rb`. ([@anthony-robin][])

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -12,6 +12,7 @@ module RuboCop
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
       #   head 200
+      #   get '/foobar', to: redirect('/foobar/baz', status: 301)
       #
       #   # good
       #   render :foo, status: :ok
@@ -19,6 +20,7 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #   head :ok
+      #   get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       #
       # @example EnforcedStyle: numeric
       #   # bad
@@ -27,6 +29,7 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #   head :ok
+      #   get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       #
       #   # good
       #   render :foo, status: 200
@@ -34,18 +37,20 @@ module RuboCop
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
       #   head 200
+      #   get '/foobar', to: redirect('/foobar/baz', status: 301)
       #
       class HttpStatus < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector
 
-        RESTRICT_ON_SEND = %i[render redirect_to head].freeze
+        RESTRICT_ON_SEND = %i[render redirect_to head redirect].freeze
 
         def_node_matcher :http_status, <<~PATTERN
           {
             (send nil? {:render :redirect_to} _ $hash)
             (send nil? {:render :redirect_to} $hash)
             (send nil? :head ${int sym} ...)
+            (send nil? :redirect _ $hash)
           }
         PATTERN
 

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
              ^^^ Prefer `:ok` over `200` to define HTTP status code.
         head 200, location: 'accounts'
              ^^^ Prefer `:ok` over `200` to define HTTP status code.
+        get '/foobar', to: redirect('/foobar/baz', status: 301)
+                                                           ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -36,6 +38,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
         head :ok
         head :ok, location: 'accounts'
+        get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       RUBY
     end
 
@@ -47,6 +50,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: :moved_permanently
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
         head :ok
+        get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       RUBY
     end
 
@@ -58,6 +62,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 550
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 550
         head 550
+        get '/foobar', to: redirect('/foobar/baz', status: 550)
       RUBY
     end
   end
@@ -85,6 +90,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
              ^^^ Prefer `200` over `:ok` to define HTTP status code.
         head :ok, location: 'accounts'
              ^^^ Prefer `200` over `:ok` to define HTTP status code.
+        get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
+                                                           ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -97,6 +104,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
         head 200
         head 200, location: 'accounts'
+        get '/foobar', to: redirect('/foobar/baz', status: 301)
       RUBY
     end
 
@@ -108,6 +116,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 301
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
         head 200
+        get '/foobar', to: redirect('/foobar/baz', status: 301)
       RUBY
     end
 


### PR DESCRIPTION
Fixes #822.

This PR extends [`Rails/HttpStatus`](https://github.com/rubocop/rubocop-rails/blob/master/lib/rubocop/cop/rails/http_status.rb) cop to detects offenses in `routes.rb` on redirections:

```ruby
Rails.application.routes.draw do
  get '/foobar', to: redirect('/foobar/baz', status: 301)
end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
