### PR TITLE
Ignore `InternalAffairs/CreateEmptyFile` in `#create_empty_file`

### DIFF
--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -19,7 +19,9 @@ module FileHelper
     end
   end
 
+  # rubocop:disable InternalAffairs/CreateEmptyFile
   def create_empty_file(file_path)
     create_file(file_path, '')
   end
+  # rubocop:enable InternalAffairs/CreateEmptyFile
 end


### PR DESCRIPTION
This is in response to the following change:

- https://github.com/rubocop/rubocop/pull/11109

This repository refers to rubocop/rubocop on GitHub and does not stage Gemfile.lock in Git index, so if a cop that detects offenses to existing code is added on rubocop gem side,  the CI on rubocop-rails gem side will start to fail from that point on.

https://github.com/rubocop/rubocop-rails/blob/f913bb517e38849e7318055d93bfecbdb6b4db20/Gemfile#L12

I ran into this problem when I created the following Pull Request, so I decided to create this Pull Request too.

- https://github.com/rubocop/rubocop-rails/pull/827
- https://app.circleci.com/pipelines/github/rubocop/rubocop-rails/2069/workflows/84921743-0ec3-45af-aea8-ef00aa7d85e6/jobs/13915

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
