### PR TITLE
Revert "Merge pull request #823 from anthony-robin/http-status-routes"

### DIFF
--- a/changelog/change_revert_merge_pull_request_823_from.md
+++ b/changelog/change_revert_merge_pull_request_823_from.md
@@ -1,0 +1,1 @@
+* [#829](https://github.com/rubocop/rubocop-rails/pull/829): Revert "Extends `Rails/HttpStatus` cop to check `routes.rb`" introduced in 2.17.0. ([@jdufresne][])

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -12,7 +12,6 @@ module RuboCop
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
       #   head 200
-      #   get '/foobar', to: redirect('/foobar/baz', status: 301)
       #
       #   # good
       #   render :foo, status: :ok
@@ -20,7 +19,6 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #   head :ok
-      #   get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       #
       # @example EnforcedStyle: numeric
       #   # bad
@@ -29,7 +27,6 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #   head :ok
-      #   get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       #
       #   # good
       #   render :foo, status: 200
@@ -37,20 +34,18 @@ module RuboCop
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
       #   head 200
-      #   get '/foobar', to: redirect('/foobar/baz', status: 301)
       #
       class HttpStatus < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector
 
-        RESTRICT_ON_SEND = %i[render redirect_to head redirect].freeze
+        RESTRICT_ON_SEND = %i[render redirect_to head].freeze
 
         def_node_matcher :http_status, <<~PATTERN
           {
             (send nil? {:render :redirect_to} _ $hash)
             (send nil? {:render :redirect_to} $hash)
             (send nil? :head ${int sym} ...)
-            (send nil? :redirect _ $hash)
           }
         PATTERN
 

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
              ^^^ Prefer `:ok` over `200` to define HTTP status code.
         head 200, location: 'accounts'
              ^^^ Prefer `:ok` over `200` to define HTTP status code.
-        get '/foobar', to: redirect('/foobar/baz', status: 301)
-                                                           ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -38,7 +36,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
         head :ok
         head :ok, location: 'accounts'
-        get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       RUBY
     end
 
@@ -50,7 +47,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: :moved_permanently
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
         head :ok
-        get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
       RUBY
     end
 
@@ -62,7 +58,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 550
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 550
         head 550
-        get '/foobar', to: redirect('/foobar/baz', status: 550)
       RUBY
     end
   end
@@ -90,8 +85,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
              ^^^ Prefer `200` over `:ok` to define HTTP status code.
         head :ok, location: 'accounts'
              ^^^ Prefer `200` over `:ok` to define HTTP status code.
-        get '/foobar', to: redirect('/foobar/baz', status: :moved_permanently)
-                                                           ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -104,7 +97,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
         head 200
         head 200, location: 'accounts'
-        get '/foobar', to: redirect('/foobar/baz', status: 301)
       RUBY
     end
 
@@ -116,7 +108,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 301
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
         head 200
-        get '/foobar', to: redirect('/foobar/baz', status: 301)
       RUBY
     end
 


### PR DESCRIPTION
This reverts commit e40d8b9e41daba64364b23df469d534383804951, reversing changes made to 6051ed83c97e99c008fa9d5c91ed5955d915c804.

The auto-corrected code is not compatible with Rails/Puma, resulting the error:

    Puma caught this error: undefined method `to_i' for :moved_permanently:Symbol

              status = status.to_i
                             ^^^^^
    Did you mean?  to_s (NoMethodError)
    /.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.5/lib/puma/request.rb:82:in `handle_request'
    /.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.5/lib/puma/server.rb:443:in `process_client'
    /.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.5/lib/puma/thread_pool.rb:147:in `block in spawn_thread'

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
