### PR TITLE
Fix a false positive for `Rails/Pluck`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_pluck.md
+++ b/changelog/fix_a_false_positive_for_rails_pluck.md
@@ -1,0 +1,1 @@
+* [#831](https://github.com/rubocop/rubocop-rails/pull/831): Fix a false positive for `Rails/Pluck` when using block argument in `[]`. ([@koic][])

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
+      context 'when the block argument is used in `[]`' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            x.#{method} { |a| a[foo...a.to_someghing] }
+          RUBY
+        end
+      end
+
       context 'when using Ruby 2.7 or newer', :ruby27 do
         context 'when using numbered parameter' do
           context "when `#{method}` can be replaced with `pluck`" do
@@ -61,6 +69,14 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
 
               expect_correction(<<~RUBY)
                 x.pluck(:foo)
+              RUBY
+            end
+          end
+
+          context 'when the numblock argument is used in `[]`' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<~RUBY)
+                x.#{method} { _1[foo..._1.to_someghing] }
               RUBY
             end
           end


### PR DESCRIPTION
This PR fixes a false positive for `Rails/Pluck`
when using block argument in `[]` to prevent the following incompatible autocorrect.

```diff
-x.collect { |a| a[foo...a.to_someghing] }
+x.pluck(foo...a.to_someghing)
```

The `a` is not defined in the autocorrected code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
