### PR TITLE
[Fix #825] Fix a false positive for `Rails/ActionControllerFlashBeforeRender`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
+++ b/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#825](https://github.com/rubocop/rubocop-rails/issues/825): Fix a false positive for `Rails/ActionControllerFlashBeforeRender` when using condition before `redirect_to`. ([@koic][])

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
     context 'with a condition' do
       %w[ActionController::Base ApplicationController].each do |parent_class|
         context "within a class inherited from #{parent_class}" do
-          it 'registers an offense and corrects' do
+          it 'registers an offense and corrects when using `flash` before `render`' do
             expect_offense(<<~RUBY)
               class HomeController < #{parent_class}
                 def create
@@ -120,6 +120,34 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
                 def create
                   flash.now[:alert] = "msg" if condition
                   render :index
+                end
+              end
+            RUBY
+          end
+
+          it 'does not register an offense when using `flash` before `redirect_to`' do
+            expect_no_offenses(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  if condition
+                    flash[:alert] = "msg"
+                  end
+
+                  redirect_to :index
+                end
+              end
+            RUBY
+          end
+
+          it 'does not register an offense when using `flash` before `redirect_back`' do
+            expect_no_offenses(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  if condition
+                    flash[:alert] = "msg"
+                  end
+
+                  redirect_back fallback_location: root_path
                 end
               end
             RUBY


### PR DESCRIPTION
Fixes #825.

This PR fixes a false positive for `Rails/ActionControllerFlashBeforeRender` when using condition before `redirect_to`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
