### PR TITLE
[Fix #843] Fix a false positive for `Rails/ActionControllerFlashBeforeRender`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
+++ b/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#843](https://github.com/rubocop/rubocop-rails/issues/843): Fix a false positive for `Rails/ActionControllerFlashBeforeRender` when using `flash` in multiline `if` branch before `redirect_to`. ([@koic][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -69,9 +69,12 @@ module RuboCop
         def followed_by_render?(flash_node)
           flash_assigment_node = find_ancestor(flash_node, type: :send)
           context = flash_assigment_node
-          context = context.parent if context.parent.if_type?
+          if (if_node = context.each_ancestor(:if).first)
+            context = if_node
+          elsif context.right_siblings.empty?
+            return true
+          end
           context = context.right_siblings
-          return true if context.empty?
 
           context.compact.any? do |node|
             render?(node)

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -152,6 +152,50 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
               end
             RUBY
           end
+
+          it 'registers an offense when using `flash` in multiline `if` branch before `render_to`' do
+            expect_offense(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  if condition
+                    do_something
+                    flash[:alert] = "msg"
+                    ^^^^^ Use `flash.now` before `render`.
+                  end
+
+                  render :index
+                end
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  if condition
+                    do_something
+                    flash.now[:alert] = "msg"
+                  end
+
+                  render :index
+                end
+              end
+            RUBY
+          end
+
+          it 'does not register an offense when using `flash` in multiline `if` branch before `redirect_to`' do
+            expect_no_offenses(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  if condition
+                    do_something
+                    flash[:alert] = "msg"
+                  end
+
+                  redirect_to :index
+                end
+              end
+            RUBY
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #843.

This PR fixes a false positive for `Rails/ActionControllerFlashBeforeRender` when using `flash` in multiline `if` branch before `redirect_to`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x]  Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
