### PR TITLE
[Fix #838] Fix an incorrect autocorrect for `Rails/ActionOrder`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_action_order.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_action_order.md
@@ -1,0 +1,1 @@
+* [#838](https://github.com/rubocop/rubocop-rails/issues/838): Fix an incorrect autocorrect for `Rails/ActionOrder` when using unconventional order of actions in conditions. ([@koic][])

--- a/lib/rubocop/cop/rails/action_order.rb
+++ b/lib/rubocop/cop/rails/action_order.rb
@@ -71,9 +71,16 @@ module RuboCop
             current: current.method_name
           )
           add_offense(current, message: message) do |corrector|
+            current = correction_target(current)
+            previous = correction_target(previous)
+
             corrector.replace(current, previous.source)
             corrector.replace(previous, current.source)
           end
+        end
+
+        def correction_target(def_node)
+          def_node.each_ancestor(:if).first || def_node
         end
       end
     end

--- a/spec/rubocop/cop/rails/action_order_spec.rb
+++ b/spec/rubocop/cop/rails/action_order_spec.rb
@@ -115,6 +115,37 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
     RUBY
   end
 
+  it 'detects unconventional order of actions in conditions' do
+    expect_offense(<<~RUBY)
+      class TestController < BaseController
+        unless Rails.env.development?
+          def edit
+          end
+        end
+
+        if Rails.env.development?
+          def index
+          ^^^^^^^^^ Action `index` should appear before `edit`.
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class TestController < BaseController
+        if Rails.env.development?
+          def index
+          end
+        end
+
+        unless Rails.env.development?
+          def edit
+          end
+        end
+      end
+    RUBY
+  end
+
   context 'with custom ordering' do
     it 'enforces custom order' do
       cop_config['ExpectedOrder'] = %w[show index new edit create update destroy]


### PR DESCRIPTION
Fixes #838.

This PR fixes an incorrect autocorrect for `Rails/ActionOrder` when using unconventional order of actions in conditions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
