### PR TITLE
Fix default configuration for Rails/I18nLazyLookup

### DIFF
--- a/changelog/fix_i18n_lazy_lookup_configuration.md
+++ b/changelog/fix_i18n_lazy_lookup_configuration.md
@@ -1,0 +1,1 @@
+* [#850](https://github.com/rubocop/rubocop-rails/pull/850): Fix default configuration for `Rails/I18nLazyLookup`. ([@vlad-pisanov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -540,7 +540,7 @@ Rails/I18nLazyLookup:
   Enabled: pending
   VersionAdded: '2.14'
   Include:
-    - 'controllers/**/*'
+    - 'app/controllers/**/*.rb'
 
 Rails/I18nLocaleAssignment:
   Description: 'Prefer the usage of `I18n.with_locale` instead of manually updating `I18n.locale` value.'

--- a/lib/rubocop/cop/rails/i18n_lazy_lookup.rb
+++ b/lib/rubocop/cop/rails/i18n_lazy_lookup.rb
@@ -34,6 +34,8 @@ module RuboCop
 
         MSG = 'Use "lazy" lookup for the text used in controllers.'
 
+        RESTRICT_ON_SEND = %i[translate t].freeze
+
         def_node_matcher :translate_call?, <<~PATTERN
           (send nil? {:translate :t} ${sym_type? str_type?} ...)
         PATTERN


### PR DESCRIPTION
Currently, `Rails/I18nLazyLookup` is a no-op out of the box because its default path is set incorrectly (`controllers` instead of `app/controllers`)

The cop is also missing `RESTRICT_ON_SEND` which makes it inefficient.

This PR fixes these issues.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
