### PR TITLE
[Fix #848] Fix a false positive for `Rails/FreezeTime`

### DIFF
--- a/changelog/fix_false_positive_for_rails_freeze_time.md
+++ b/changelog/fix_false_positive_for_rails_freeze_time.md
@@ -1,0 +1,1 @@
+* [#848](https://github.com/rubocop/rubocop-rails/issues/848): Fix a false positive for `Rails/FreezeTime` when using `travel_to` with an argument of `Time.new(...).in_time_zone`. ([@koic][])

--- a/lib/rubocop/cop/rails/freeze_time.rb
+++ b/lib/rubocop/cop/rails/freeze_time.rb
@@ -29,7 +29,7 @@ module RuboCop
 
         MSG = 'Use `freeze_time` instead of `travel_to`.'
         NOW_METHODS = %i[now new current].freeze
-        CONV_METHODS = %i[to_time in_time_zone].freeze
+        CONVERT_METHODS = %i[to_time in_time_zone].freeze
         RESTRICT_ON_SEND = %i[travel_to].freeze
 
         # @!method time_now?(node)
@@ -63,9 +63,11 @@ module RuboCop
         end
 
         def current_time_with_convert?(node, method_name)
-          return false unless CONV_METHODS.include?(method_name)
+          return false unless CONVERT_METHODS.include?(method_name)
 
-          child_node, child_method_name = *node.children
+          child_node, child_method_name, time_argument = *node.children
+          return if time_argument
+
           current_time?(child_node, child_method_name)
         end
       end

--- a/spec/rubocop/cop/rails/freeze_time_spec.rb
+++ b/spec/rubocop/cop/rails/freeze_time_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe RuboCop::Cop::Rails::FreezeTime, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `travel_to` with an argument of `Time.new(...).in_time_zone`' do
+    expect_no_offenses(<<~RUBY)
+      travel_to(Time.new(2019, 4, 3, 12, 30).in_time_zone)
+    RUBY
+  end
+
   it 'does not register an offense when using `travel_to` without argument' do
     expect_no_offenses(<<~RUBY)
       travel_to


### PR DESCRIPTION
Fixes #848.

This PR fixes a false positive for `Rails/FreezeTime` when using `travel_to` with an argument of `Time.new(...).in_time_zone`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
