### PR TITLE
Fix Rails/RootPathnameMethods autocorrection for Pathname calls without parens

### DIFF
--- a/changelog/fix_railsrootpathnamemethods.md
+++ b/changelog/fix_railsrootpathnamemethods.md
@@ -1,0 +1,1 @@
+* [#855](https://github.com/rubocop/rubocop-rails/pull/855): Fix Rails/RootPathnameMethods autocorrection for Pathname calls without parens. ([@gsamokovarov][])

--- a/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
+++ b/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
@@ -148,4 +148,15 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       files.map { |file| Rails.root.join('db', file).open('wb') }
     RUBY
   end
+
+  it 'registers an offense when using `File.open Rails.root.join ...` without parens' do
+    expect_offense(<<~RUBY)
+      file = File.open Rails.root.join 'docs', 'invoice.pdf'
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#open`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      file = Rails.root.join('docs', 'invoice.pdf').open
+    RUBY
+  end
 end


### PR DESCRIPTION
```ruby
# I run into case where...
file = File.open Rails.root.join 'spec', 'fixtures', 'pdfs', 'read_only.pdf'

# Got autocrrected to... 👇
file = Rails.root.join 'spec', 'fixtures', 'pdfs', 'read_only.pdf'.open
```

This autocorrection is invalid Ruby code. We can avoid it if we parenthesize `Pathname` methods before chaining like so:

```
file = Rails.root.join('spec', 'fixtures', 'pdfs', 'read_only.pdf').open
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
