### PR TITLE
[Fix #837] Fix incorrect autocorrection of `Rails/ActionOrder` about comments

### DIFF
--- a/changelog/fix_incorrect_autocorrection_of_rails_action_order.md
+++ b/changelog/fix_incorrect_autocorrection_of_rails_action_order.md
@@ -1,0 +1,1 @@
+* [#837](https://github.com/rubocop/rubocop-rails/pull/837): Fix incorrect autocorrection of `Rails/ActionOrder` about comments. ([@r7kamura][])

--- a/spec/rubocop/cop/rails/action_order_spec.rb
+++ b/spec/rubocop/cop/rails/action_order_spec.rb
@@ -187,4 +187,29 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
       RUBY
     end
   end
+
+  context 'when action has some comments' do
+    it 'corrects comments properly' do
+      expect_offense(<<~RUBY)
+        class UserController < ApplicationController
+          # show
+          def show; end
+
+          # index
+          def index; end
+          ^^^^^^^^^^^^^^ Action `index` should appear before `show`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UserController < ApplicationController
+          # index
+          def index; end
+
+          # show
+          def show; end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
## About

This change fixes the following Issue by extending the `Parser::Source::Range` used for replacement to include comment lines.

- Fix #837

## Background

I encountered a problem with `Rails/ActionOrder` Cop autocorrection where comments were not corrected properly.

### Before

```ruby
class FooController < ApplicationController
  # show
  def show; end

  # index
  def index; end
end
```

### Expected

```ruby
class FooController < ApplicationController
  # index
  def index; end

  # show
  def show; end
end
```

### Actual

```ruby
class FooController < ApplicationController
  # show
  def index; end

  # index
  def show; end
end
```

When creating this Pull Request, I confirmed that a similar issue had already been reported, so I decided to tie it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
