### PR TITLE
[Fix #841] Fix an error for `Rails/ActionOrder`

### DIFF
--- a/changelog/fix_an_error_for_rails_action_order.md
+++ b/changelog/fix_an_error_for_rails_action_order.md
@@ -1,0 +1,1 @@
+* [#841](https://github.com/rubocop/rubocop-rails/issues/841): Fix an error for `Rails/ActionOrder` when using unconventional order of multiple actions. ([@koic][])

--- a/lib/rubocop/cop/rails/action_order.rb
+++ b/lib/rubocop/cop/rails/action_order.rb
@@ -6,7 +6,8 @@ module RuboCop
       # Enforces consistent ordering of the standard Rails RESTful controller actions.
       #
       # The cop is configurable and can enforce any ordering of the standard actions.
-      # All other methods are ignored.
+      # All other methods are ignored. So, the actions specified in `ExpectedOrder` should be
+      # defined before actions not specified.
       #
       # [source,yaml]
       # ----
@@ -75,8 +76,7 @@ module RuboCop
             current = correction_target(current)
             previous = correction_target(previous)
 
-            corrector.replace(current, previous.source)
-            corrector.replace(previous, current.source)
+            swap_range(corrector, current, previous)
           end
         end
 
@@ -105,6 +105,11 @@ module RuboCop
 
         def range_with_comments_and_lines(node)
           range_by_whole_lines(range_with_comments(node), include_final_newline: true)
+        end
+
+        def swap_range(corrector, range1, range2)
+          corrector.insert_before(range2, range1.source)
+          corrector.remove(range1)
         end
       end
     end

--- a/spec/rubocop/cop/rails/action_order_spec.rb
+++ b/spec/rubocop/cop/rails/action_order_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
     RUBY
   end
 
+  it 'detects unconventional order of multiple actions' do
+    expect_offense(<<~RUBY)
+      class UserController < ApplicationController
+        def create; end
+        def edit; end
+        ^^^^^^^^^^^^^ Action `edit` should appear before `create`.
+        def show; end
+        ^^^^^^^^^^^^^ Action `show` should appear before `edit`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class UserController < ApplicationController
+        def show; end
+        def edit; end
+        def create; end
+      end
+    RUBY
+  end
+
   it 'supports methods with content' do
     expect_offense(<<~RUBY)
       class UserController < ApplicationController
@@ -33,10 +53,10 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
     expect_correction(<<~RUBY)
       class UserController < ApplicationController
         def index; end
-
         def show
           @user = User.find(params[:id])
         end
+
       end
     RUBY
   end
@@ -137,11 +157,11 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
           def index
           end
         end
-
         unless Rails.env.development?
           def edit
           end
         end
+
       end
     RUBY
   end
@@ -181,8 +201,8 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
       expect_correction(<<~RUBY)
         class UserController < ApplicationController
           def show; end
-          def edit; end
           def index; end
+          def edit; end
         end
       RUBY
     end
@@ -205,9 +225,9 @@ RSpec.describe RuboCop::Cop::Rails::ActionOrder, :config do
         class UserController < ApplicationController
           # index
           def index; end
-
           # show
           def show; end
+
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #841.

This PR fixes an error for `Rails/ActionOrder` when using unconventional order of multiple actions.

With this change, autocorrection blank line positions are not as expected, so they are left to autocorrection of `Layout/EmptyLineBetweenDefs` and `Layout/EmptyLinesAroundClassBody` cops.

This PR aims to fix the error, that it may be a better autocorrection later.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
