### PR TITLE
Ignore if number of arguments does not match on `Rails/DynamicFindBy`

### DIFF
--- a/changelog/change_ignore_if_number_of_arguments_does_not_match.md
+++ b/changelog/change_ignore_if_number_of_arguments_does_not_match.md
@@ -1,0 +1,1 @@
+* [#862](https://github.com/rubocop/rubocop-rails/pull/862): Ignore if number of arguments does not match on `Rails/DynamicFindBy`. ([@r7kamura][])

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -105,24 +105,18 @@ RSpec.describe RuboCop::Cop::Rails::DynamicFindBy, :config do
   end
 
   context 'with too much arguments' do
-    it 'registers an offense and no corrects' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
         User.find_by_name_and_email(name, email, token)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email`.
       RUBY
-
-      expect_no_corrections
     end
   end
 
   context 'with too few arguments' do
-    it 'registers an offense and no corrects' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
         User.find_by_name_and_email(name)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email`.
       RUBY
-
-      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
If the number of arguments does not match with its method name, it means that dynamic `find_by` is not used, but a user-defined method is used, so I think it should not be an offense in this case. What do you think?

```ruby
Model.find_by_a_and_b(a)
Model.find_by_x(y, z)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
