### PR TITLE
Fix an offense on `Style/RedundantRegexpEscape`

### DIFF
--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -81,7 +81,7 @@ module RuboCop
         def allowed_name?(argument)
           return false unless argument.str_type? || argument.sym_type?
 
-          !/^[a-zA-Z\-][a-zA-Z\-0-9]*$/.match?(argument.value)
+          !/^[a-zA-Z-][a-zA-Z\-0-9]*$/.match?(argument.value)
         end
 
         def correction_range(node)


### PR DESCRIPTION
I created the following Pull Request and CI failed unexpectedly:

- https://github.com/rubocop/rubocop-rails/pull/863

I checked and found that it succeeds with rubocop 1.37, but fails with rubocop 1.38. So, I ran `rubocop --autocorrect` with rubocop 1.38 to fix it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
