### PR TITLE
Support `::Rails` and `::File` on `Rails/FilePath` cop

### DIFF
--- a/changelog/fix_support_rails_and_file_on_rails_file_path.md
+++ b/changelog/fix_support_rails_and_file_on_rails_file_path.md
@@ -1,0 +1,1 @@
+* [#865](https://github.com/rubocop/rubocop-rails/pull/865): Support `::Rails` and `::File` on `Rails/FilePath` cop. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -34,15 +34,15 @@ module RuboCop
         RESTRICT_ON_SEND = %i[join].freeze
 
         def_node_matcher :file_join_nodes?, <<~PATTERN
-          (send (const nil? :File) :join ...)
+          (send (const {nil? cbase} :File) :join ...)
         PATTERN
 
         def_node_search :rails_root_nodes?, <<~PATTERN
-          (send (const nil? :Rails) :root)
+          (send (const {nil? cbase} :Rails) :root)
         PATTERN
 
         def_node_matcher :rails_root_join_nodes?, <<~PATTERN
-          (send (send (const nil? :Rails) :root) :join ...)
+          (send #rails_root_nodes? :join ...)
         PATTERN
 
         def on_dstr(node)

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when using ::Rails.root.join with some path strings' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          ::Rails.root.join('app', 'models', 'user.rb')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+        RUBY
+      end
+    end
+
     context 'when using Rails.root.join in string interpolation of argument' do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
@@ -51,6 +60,15 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
         expect_offense(<<~RUBY)
           File.join(Rails.root, 'app', 'models')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+        RUBY
+      end
+    end
+
+    context 'when using ::File.join with Rails.root' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          ::File.join(Rails.root, 'app', 'models')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
         RUBY
       end
     end


### PR DESCRIPTION
`Rails/FilePath` does not work as intended when `cbase` is used, as in `::Rails.root.join` or `::File.join`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
