### PR TITLE
Fix false-positives when constant is used with receiver on `Rails/DurationArithmetic`, `Rails/IndexBy`, `Rails/IndexWIth`, and `Rails/RequireDependency`

### DIFF
--- a/changelog/fix_false_positives_when_constant_is_used_with_receiver.md
+++ b/changelog/fix_false_positives_when_constant_is_used_with_receiver.md
@@ -1,0 +1,1 @@
+* [#866](https://github.com/rubocop/rubocop-rails/pull/866): Fix false-positives when constant is used with receiver on `Rails/DurationArithmetic`, `Rails/IndexBy`, `Rails/IndexWIth`, and `Rails/RequireDependency`. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/duration_arithmetic.rb
+++ b/lib/rubocop/cop/rails/duration_arithmetic.rb
@@ -70,8 +70,8 @@ module RuboCop
         #   @return [Boolean] true if matches
         def_node_matcher :time_current?, <<~PATTERN
           {
-            (send (const _ :Time) :current)
-            (send (send (const _ :Time) :zone) :now)
+            (send (const {nil? cbase} :Time) :current)
+            (send (send (const {nil? cbase} :Time) :zone) :now)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rails/index_by.rb
+++ b/lib/rubocop/cop/rails/index_by.rb
@@ -46,7 +46,7 @@ module RuboCop
 
         def_node_matcher :on_bad_hash_brackets_map, <<~PATTERN
           (send
-            (const _ :Hash)
+            (const {nil? cbase} :Hash)
             :[]
             (block
               (call _ {:map :collect})

--- a/lib/rubocop/cop/rails/index_with.rb
+++ b/lib/rubocop/cop/rails/index_with.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         def_node_matcher :on_bad_hash_brackets_map, <<~PATTERN
           (send
-            (const _ :Hash)
+            (const {nil? cbase} :Hash)
             :[]
             (block
               (call _ {:map :collect})

--- a/lib/rubocop/cop/rails/require_dependency.rb
+++ b/lib/rubocop/cop/rails/require_dependency.rb
@@ -26,7 +26,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[require_dependency].freeze
 
         def_node_matcher :require_dependency_call?, <<~PATTERN
-          (send {nil? (const _ :Kernel)} :require_dependency _)
+          (send {nil? (const {nil? cbase} :Kernel)} :require_dependency _)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/duration_arithmetic_spec.rb
+++ b/spec/rubocop/cop/rails/duration_arithmetic_spec.rb
@@ -97,4 +97,32 @@ RSpec.describe RuboCop::Cop::Rails::DurationArithmetic, :config do
       created_at - 1.minute
     RUBY
   end
+
+  it 'does not register an offense for `Foo::Time.current`' do
+    expect_no_offenses(<<~RUBY)
+      Foo::Time.current + 1.hour
+    RUBY
+  end
+
+  it 'registers and correct an offense for `::Time.current`' do
+    expect_offense(<<~RUBY)
+      ::Time.current + 1.hour
+      ^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1.hour.from_now
+    RUBY
+  end
+
+  it 'registers and correct an offense for `::Time.zone.now`' do
+    expect_offense(<<~RUBY)
+      ::Time.zone.now + 1.hour
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not add or subtract duration.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1.hour.from_now
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -156,6 +156,12 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     RUBY
   end
 
+  it 'does not register an offense for `Foo::Hash[map { ... }]`' do
+    expect_no_offenses(<<~RUBY)
+      Foo::Hash[x.map { |el| [el.to_sym, el] }]
+    RUBY
+  end
+
   context 'when using Ruby 2.6 or newer', :ruby26 do
     it 'registers an offense for `to_h { ... }`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       RUBY
     end
 
+    it 'does not register an offense for `Foo::Hash[map { ... }]`' do
+      expect_no_offenses(<<~RUBY)
+        Foo::Hash[x.map { |el| [el, el.to_sym] }]
+      RUBY
+    end
+
     context 'when using Ruby 2.6 or newer', :ruby26 do
       it 'registers an offense for `to_h { ... }`' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rails/require_dependency_spec.rb
+++ b/spec/rubocop/cop/rails/require_dependency_spec.rb
@@ -19,11 +19,39 @@ RSpec.describe RuboCop::Cop::Rails::RequireDependency, :config do
 
   context 'when require_dependency' do
     context 'when using Rails 6.0 or newer', :rails60 do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          require_dependency 'foo'
-          ^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `require_dependency` with Zeitwerk mode.
-        RUBY
+      context 'without receiver' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            require_dependency 'foo'
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `require_dependency` with Zeitwerk mode.
+          RUBY
+        end
+      end
+
+      context 'with `Kernel` as receiver' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            Kernel.require_dependency 'foo'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `require_dependency` with Zeitwerk mode.
+          RUBY
+        end
+      end
+
+      context 'with `::Kernel` as receiver' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            ::Kernel.require_dependency 'foo'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `require_dependency` with Zeitwerk mode.
+          RUBY
+        end
+      end
+
+      context 'with `Foo::Kernel` as receiver' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Foo::Kernel.require_dependency 'foo'
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
In response to the following comment, I reviewed the use of `const _` and found several similar mistakes in the existing code. 

- https://github.com/rubocop/rubocop-rails/pull/865#discussion_r1021009543

cc: @koic 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
