### PR TITLE
Fix autocorrection bug when `::Hash` is used on `Rails/IndexBy` and `Rails/IndexWith`

### DIFF
--- a/changelog/fix_autocorrection_bug_when_hash_is_used_on.md
+++ b/changelog/fix_autocorrection_bug_when_hash_is_used_on.md
@@ -1,0 +1,1 @@
+* [#867](https://github.com/rubocop/rubocop-rails/pull/867): Fix autocorrection bug when `::Hash` is used on `Rails/IndexBy` and `Rails/IndexWith`. ([@r7kamura][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -134,7 +134,7 @@ module RuboCop
         end
 
         def self.from_hash_brackets_map(node, match)
-          new(match, node.children.last, 'Hash['.length, ']'.length)
+          new(match, node.children.last, "#{node.receiver.source}[".length, ']'.length)
         end
 
         def strip_prefix_and_suffix(node, corrector)

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -145,6 +145,17 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     RUBY
   end
 
+  it 'registers an offense for `::Hash[map { ... }]`' do
+    expect_offense(<<~RUBY)
+      ::Hash[x.map { |el| [el.to_sym, el] }]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `Hash[map { ... }]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.index_by { |el| el.to_sym }
+    RUBY
+  end
+
   context 'when using Ruby 2.6 or newer', :ruby26 do
     it 'registers an offense for `to_h { ... }`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -118,6 +118,17 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       RUBY
     end
 
+    it 'registers an offense for `::Hash[map { ... }]`' do
+      expect_offense(<<~RUBY)
+        ::Hash[x.map { |el| [el, el.to_sym] }]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `Hash[map { ... }]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.index_with { |el| el.to_sym }
+      RUBY
+    end
+
     context 'when using Ruby 2.6 or newer', :ruby26 do
       it 'registers an offense for `to_h { ... }`' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
The following 2 cops currently support both `Hash[...] ` and `::Hash[...] `, but the autocorrection for `::Hash[...] ` yields incorrect result. This is because it assumes only `Hash[` and removes the first 5 characters from source code.

- `Rails/IndexBy`
- `Rails/IndexWith`

This problem was originally found at the following Pull Request:

- https://github.com/rubocop/rubocop-rails/pull/866#discussion_r1021050989

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
