### PR TITLE
Fix false-positives that non Rails formats are offended on `Rails/ToSWithArgument`

### DIFF
--- a/changelog/fix_false_positives_that_non_rails_formats.md
+++ b/changelog/fix_false_positives_that_non_rails_formats.md
@@ -1,0 +1,1 @@
+* [#869](https://github.com/rubocop/rubocop-rails/pull/869): Fix false-positives that non Rails formats are offended on `Rails/ToSWithArgument`. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/to_s_with_argument.rb
+++ b/lib/rubocop/cop/rails/to_s_with_argument.rb
@@ -21,6 +21,37 @@ module RuboCop
         extend AutoCorrector
         extend TargetRailsVersion
 
+        # These types are defined by the following files in ActiveSupport:
+        #   lib/active_support/core_ext/array/conversions.rb
+        #   lib/active_support/core_ext/date/conversions.rb
+        #   lib/active_support/core_ext/date_time/conversions.rb
+        #   lib/active_support/core_ext/numeric/conversions.rb
+        #   lib/active_support/core_ext/range/conversions.rb
+        #   lib/active_support/core_ext/time/conversions.rb
+        #   lib/active_support/time_with_zone.rb
+        EXTENDED_FORMAT_TYPES = Set.new(
+          %i[
+            currency
+            db
+            delimited
+            human
+            human_size
+            inspect
+            iso8601
+            long
+            long_ordinal
+            nsec
+            number
+            percentage
+            phone
+            rfc822
+            rounded
+            short
+            time
+            usec
+          ]
+        )
+
         MSG = 'Use `to_formatted_s` instead.'
 
         RESTRICT_ON_SEND = %i[to_s].freeze
@@ -28,13 +59,19 @@ module RuboCop
         minimum_target_rails_version 7.0
 
         def on_send(node)
-          return if node.arguments.empty?
+          return unless rails_extended_to_s?(node)
 
           add_offense(node.loc.selector) do |corrector|
             corrector.replace(node.loc.selector, 'to_formatted_s')
           end
         end
         alias on_csend on_send
+
+        private
+
+        def rails_extended_to_s?(node)
+          node.first_argument&.sym_type? && EXTENDED_FORMAT_TYPES.include?(node.first_argument.value)
+        end
       end
     end
   end

--- a/spec/rubocop/cop/rails/to_s_with_argument_spec.rb
+++ b/spec/rubocop/cop/rails/to_s_with_argument_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe RuboCop::Cop::Rails::ToSWithArgument, :config, :rails70 do
     end
   end
 
+  context 'with unrelated argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        10.to_s(2)
+      RUBY
+    end
+  end
+
   context 'with argument' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
We had `Rails/ToSWithArgument` Cop to replace `to_s` with `to_fs` where Rails' extended functionality is used, but there are frequent false-positives where `to_s` is used with non Rails extended formats like `value.to_s(2)` (`Integer#to_s`).

To prevent this, it would be better to check its 1st argument so that only cases that appear to use Rails-extended functionality are offended.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
