### PR TITLE
Fix a false positive for `Rails/WhereMissing` when `left_joins(:foo)`and `where(foos: {id: nil})` separated by `or`, `and`

### DIFF
--- a/changelog/fix_fix_a_false_positive_for_rails_where_missing.md
+++ b/changelog/fix_fix_a_false_positive_for_rails_where_missing.md
@@ -1,0 +1,1 @@
+* [#871](https://github.com/rubocop/rubocop-rails/pull/871): Fix a false positive for `Rails/WhereMissing` when `left_joins(:foo)` and `where(foos: {id: nil})` separated by `or`, `and`. ([@ydah][])


### PR DESCRIPTION
This PR is fix a false positive for `Rails/WhereMissing` when `left_joins(:foo)` and `where(foos: {id: nil})` separated by `or`, `and`.

It is necessary to consider the following cases, which are separated by `or` or `and`.

```ruby
Foo.left_joins(:foo).or(Foo.where(foos: {id: nil}))
Foo.where(foos: {id: nil}).and(Foo.left_joins(:foo))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
