### PR TITLE
[Fix #870] Fix an error for `Rails/RootPathnameMethods`

### DIFF
--- a/changelog/fix_an_error_for_rails_root_pathname_methods.md
+++ b/changelog/fix_an_error_for_rails_root_pathname_methods.md
@@ -1,0 +1,1 @@
+* [#870](https://github.com/rubocop/rubocop-rails/issues/870): Fix an error for `Rails/RootPathnameMethods` when using `Rails.env` argument within `Dir.glob`. ([@koic][])

--- a/lib/rubocop/cop/rails/root_pathname_methods.rb
+++ b/lib/rubocop/cop/rails/root_pathname_methods.rb
@@ -214,8 +214,17 @@ module RuboCop
         end
 
         def join_arguments(arguments)
-          quote = include_interpolation?(arguments) ? '"' : "'"
-          joined_arguments = arguments.map(&:value).join('/')
+          use_interpolation = false
+
+          joined_arguments = arguments.map do |arg|
+            if arg.respond_to?(:value)
+              arg.value
+            else
+              use_interpolation = true
+              "\#{#{arg.source}}"
+            end
+          end.join('/')
+          quote = include_interpolation?(arguments) || use_interpolation ? '"' : "'"
 
           "#{quote}#{joined_arguments}#{quote}"
         end

--- a/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
+++ b/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
@@ -101,6 +101,21 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
         Rails.root.glob("**/#{path}/*.rb")
       RUBY
     end
+
+    it 'registers an offense when using `Rails.env` argument within `Dir.glob`' do
+      expect_offense(<<~'RUBY')
+        Dir.glob(Rails.root.join("db", "seeds", Rails.env, "*.rb")).sort.each do |file|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+          load file
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        Rails.root.glob("db/seeds/#{Rails.env}/*.rb").sort.each do |file|
+          load file
+        end
+      RUBY
+    end
   end
 
   # This is handled by `Rails/RootJoinChain`


### PR DESCRIPTION
Fixes #870.

This PR fixes an error for `Rails/RootPathnameMethods` when using `Rails.env` argument within `Dir.glob`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
