### PR TITLE
Make `Rails/RootPathnameMethods` aware of enforced style of `Style/StringLiterals`

### DIFF
--- a/changelog/fix_make_rails_root_pathname_methods_aware_of_style_string_literals.md
+++ b/changelog/fix_make_rails_root_pathname_methods_aware_of_style_string_literals.md
@@ -1,0 +1,1 @@
+* [#875](https://github.com/rubocop/rubocop-rails/pull/875): Make `Rails/RootPathnameMethods` aware of enforced style of `Style/StringLiterals`. ([@koic][])

--- a/lib/rubocop/cop/rails/root_pathname_methods.rb
+++ b/lib/rubocop/cop/rails/root_pathname_methods.rb
@@ -186,11 +186,7 @@ module RuboCop
         def build_path_glob_replacement(path, method)
           receiver = range_between(path.loc.expression.begin_pos, path.children.first.loc.selector.end_pos).source
 
-          argument = if path.arguments.one?
-                       path.first_argument.source
-                     else
-                       join_arguments(path.arguments)
-                     end
+          argument = path.arguments.one? ? path.first_argument.source : join_arguments(path.arguments)
 
           "#{receiver}.#{method}(#{argument})"
         end
@@ -224,9 +220,17 @@ module RuboCop
               "\#{#{arg.source}}"
             end
           end.join('/')
-          quote = include_interpolation?(arguments) || use_interpolation ? '"' : "'"
+          quote = enforce_double_quotes? || include_interpolation?(arguments) || use_interpolation ? '"' : "'"
 
           "#{quote}#{joined_arguments}#{quote}"
+        end
+
+        def enforce_double_quotes?
+          string_literals_config['EnforcedStyle'] == 'double_quotes'
+        end
+
+        def string_literals_config
+          config.for_cop('Style/StringLiterals')
         end
       end
     end

--- a/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
+++ b/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
@@ -91,6 +91,23 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       RUBY
     end
 
+    context 'when double-quoted string literals are preferred' do
+      let(:other_cops) do
+        super().merge('Style/StringLiterals' => { 'EnforcedStyle' => 'double_quotes' })
+      end
+
+      it "registers an offense when using `Dir.glob(Rails.root.join('**', '*.rb'))`" do
+        expect_offense(<<~RUBY)
+          Dir.glob(Rails.root.join('**', '*.rb'))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.glob("**/*.rb")
+        RUBY
+      end
+    end
+
     it "registers an offense when using `Dir.glob(Rails.root.join('**', \"\#{path}\", '*.rb'))`" do
       expect_offense(<<~'RUBY')
         Dir.glob(Rails.root.join('**', "#{path}", '*.rb'))


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-rails/pull/872#discussion_r1029972604.

This PR makes `Rails/RootPathnameMethods` aware of enforced style of `Style/StringLiterals`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
