### PR TITLE
Add Rails/I18nLocaleTexts match for `redirect_back`

### DIFF
--- a/changelog/change_add_i18nlocaletext_match_for_redirect_back.md
+++ b/changelog/change_add_i18nlocaletext_match_for_redirect_back.md
@@ -1,0 +1,1 @@
+* [#880](https://github.com/rubocop/rubocop-rails/pull/880): Add Rails/I18nLocaleTexts match for redirect_back. ([@bensheldon][])

--- a/lib/rubocop/cop/rails/i18n_locale_texts.rb
+++ b/lib/rubocop/cop/rails/i18n_locale_texts.rb
@@ -69,7 +69,7 @@ module RuboCop
       class I18nLocaleTexts < Base
         MSG = 'Move locale texts to the locale files in the `config/locales` directory.'
 
-        RESTRICT_ON_SEND = %i[validates redirect_to []= mail].freeze
+        RESTRICT_ON_SEND = %i[validates redirect_to redirect_back []= mail].freeze
 
         def_node_search :validation_message, <<~PATTERN
           (pair (sym :message) $str)
@@ -94,7 +94,7 @@ module RuboCop
               add_offense(text_node)
             end
             return
-          when :redirect_to
+          when :redirect_to, :redirect_back
             text_node = redirect_to_flash(node).to_a.last
           when :[]=
             text_node = flash_assignment?(node)

--- a/spec/rubocop/cop/rails/i18n_locale_texts_spec.rb
+++ b/spec/rubocop/cop/rails/i18n_locale_texts_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe RuboCop::Cop::Rails::I18nLocaleTexts, :config do
     RUBY
   end
 
+  it 'registers an offense when using `redirect_back` with text flash messages' do
+    expect_offense(<<~RUBY)
+      redirect_back fallback_location: root_path, notice: "Post created!"
+                                                          ^^^^^^^^^^^^^^^ Move locale texts to the locale files in the `config/locales` directory.
+    RUBY
+  end
+
   it 'does not register an offense when using `redirect_to` with localized flash messages' do
     expect_no_offenses(<<~RUBY)
       redirect_to root_path, notice: t(".success")


### PR DESCRIPTION
`Rails/I18nLocaleTexts` was introduced in #643 and matches on `redirect_to`; this PR extends the cop to also match on the similarly behaved `redirect_back` method.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
