### PR TITLE
Fix false positive in UniquenessValidator with `conditions`

### DIFF
--- a/changelog/fix_support_conditions_option_of.md
+++ b/changelog/fix_support_conditions_option_of.md
@@ -1,0 +1,1 @@
+* [#882](https://github.com/rubocop/rubocop-rails/pull/882): Fix false positive for `Rails/UniqueValidationWithoutIndex` with :conditions option. ([@etiennebarrie][])

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -139,6 +139,15 @@ module RuboCop
           pairs = node.arguments.last
           return unless pairs.hash_type?
 
+          return true if condition_hash_part?(pairs)
+
+          uniqueness_node = uniqueness_part(node)
+          return unless uniqueness_node&.hash_type?
+
+          condition_hash_part?(uniqueness_node)
+        end
+
+        def condition_hash_part?(pairs)
           pairs.each_pair.any? do |pair|
             key = pair.key
             next unless key.sym_type?

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -139,20 +139,20 @@ module RuboCop
           pairs = node.arguments.last
           return unless pairs.hash_type?
 
-          return true if condition_hash_part?(pairs)
+          return true if condition_hash_part?(pairs, keys: %i[if unless])
 
           uniqueness_node = uniqueness_part(node)
           return unless uniqueness_node&.hash_type?
 
-          condition_hash_part?(uniqueness_node)
+          condition_hash_part?(uniqueness_node, keys: %i[if unless conditions])
         end
 
-        def condition_hash_part?(pairs)
+        def condition_hash_part?(pairs, keys:)
           pairs.each_pair.any? do |pair|
             key = pair.key
             next unless key.sym_type?
 
-            key.value == :if || key.value == :unless
+            keys.include?(key.value)
           end
         end
 

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -371,6 +371,16 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
             end
           RUBY
         end
+
+        it 'does not register an offense with a conditions option on the specific validator' do
+          expect_no_offenses(<<~RUBY)
+            class Article
+              belongs_to :user
+              enum :status, [:draft, :published]
+              validates :user, uniqueness: { conditions: -> { published } }
+            end
+          RUBY
+        end
       end
 
       context 'without column definition' do

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         end
       end
 
-      context 'with an if condition on the validation' do
+      context 'without the proper index' do
         let(:schema) { <<~RUBY }
           ActiveRecord::Schema.define(version: 2020_02_02_075409) do
             create_table "articles", force: :cascade do |t|
@@ -336,7 +336,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
 
-        it 'does not register an offense' do
+        it 'does not register an offense with an if condition on validates' do
           expect_no_offenses(<<~RUBY)
             class Article
               belongs_to :user
@@ -344,22 +344,30 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
             end
           RUBY
         end
-      end
 
-      context 'with an unless condition on the validation' do
-        let(:schema) { <<~RUBY }
-          ActiveRecord::Schema.define(version: 2020_02_02_075409) do
-            create_table "articles", force: :cascade do |t|
-              t.bigint "user_id", null: false
-            end
-          end
-        RUBY
-
-        it 'does not register an offense' do
+        it 'does not register an offense with an unless condition on validates' do
           expect_no_offenses(<<~RUBY)
             class Article
               belongs_to :user
               validates :user, uniqueness: true, unless: -> { true }
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with an if condition on the specific validator' do
+          expect_no_offenses(<<~RUBY)
+            class Article
+              belongs_to :user
+              validates :user, uniqueness: { if: -> { false } }
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with an unless condition on the specific validator' do
+          expect_no_offenses(<<~RUBY)
+            class Article
+              belongs_to :user
+              validates :user, uniqueness: { unless: -> { false } }
             end
           RUBY
         end


### PR DESCRIPTION
First, a validation can be defined with options specific to the validator:

```ruby
class Article < ApplicationRecord
  validates :user, uniqueness: { if: -> { false } }
  # equivalent to
  # validates :user, uniqueness: true, if: -> { false }
end
```

And this should not add an offense, like when the `:if` is on the `validates`, because we don't know what the condition is and it could lead to a false positive.

Secondly, there's a `:conditions` option that can't be added on `validates` directly because it's specific to the `UniquenessValidator`, which can also lead to false positives, because it can refer to columns or otherwise reduce the uniqueness in a way that prevents a unique index from covering it in the schema.

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
