### PR TITLE
Fix a false positive for `Rails/NotNullColumn` when adding a `:virtual` column

### DIFF
--- a/changelog/fix_not_null_column_to_accept_virtual_columns.md
+++ b/changelog/fix_not_null_column_to_accept_virtual_columns.md
@@ -1,0 +1,1 @@
+* [#887](https://github.com/rubocop/rubocop-rails/issues/887): Fix a false positive for `Rails/NotNullColumn` when adding a `:virtual` column. ([@fatkodima][])

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
                                              ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
         RUBY
       end
+
+      it 'does not register an offense for virtual columns' do
+        expect_no_offenses(<<~RUBY)
+          add_column :users, :height_in, :virtual, as: "height_cm / 2.54", null: false, default: nil
+          add_column :users, :height_in, 'virtual', as: "height_cm / 2.54", null: false, default: nil
+        RUBY
+      end
     end
 
     context 'with null: true' do


### PR DESCRIPTION
Fixes #887.

From [documentation](https://www.postgresql.org/docs/current/ddl-generated-columns.html):

> Several restrictions apply to the definition of generated columns and tables involving generated columns:
>  - A generated column cannot have a column default or an identity definition.