### PR TITLE
Fix UnusedIgnoredColumns detection when using +=

### DIFF
--- a/changelog/fix_unused_ignored_columns_plus_equals.md
+++ b/changelog/fix_unused_ignored_columns_plus_equals.md
@@ -1,0 +1,1 @@
+* [#895](https://github.com/rubocop/rubocop-rails/pull/895): Fix `Rails/UnusedIgnoredColumns` not recognizing columns added via `+=`. ([@lucthev][])

--- a/lib/rubocop/cop/rails/unused_ignored_columns.rb
+++ b/lib/rubocop/cop/rails/unused_ignored_columns.rb
@@ -28,12 +28,16 @@ module RuboCop
           (send self :ignored_columns= $array)
         PATTERN
 
+        def_node_matcher :appended_ignored_columns, <<~PATTERN
+          (op-asgn (send self :ignored_columns) :+ $array)
+        PATTERN
+
         def_node_matcher :column_name, <<~PATTERN
           ({str sym} $_)
         PATTERN
 
         def on_send(node)
-          return unless (columns = ignored_columns(node))
+          return unless (columns = ignored_columns(node) || appended_ignored_columns(node))
           return unless schema
 
           table = table(node)
@@ -43,6 +47,7 @@ module RuboCop
             check_column_existence(column_node, table)
           end
         end
+        alias on_op_asgn on_send
 
         private
 

--- a/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
+++ b/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
@@ -105,6 +105,17 @@ RSpec.describe RuboCop::Cop::Rails::UnusedIgnoredColumns, :config do
         RUBY
       end
     end
+
+    context 'when using addition assignment on ignored_columns' do
+      it 'registers an offense to the nonexistent column' do
+        expect_offense(<<~RUBY)
+          class User < ApplicationRecord
+            self.ignored_columns += ['real_name']
+                                     ^^^^^^^^^^^ Remove `real_name` from `ignored_columns` because the column does not exist.
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with no tables db/schema.rb' do


### PR DESCRIPTION
[`Rails/IgnoredColumnsAssignment`](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsignoredcolumnsassignment) recommends adding to `ignored_columns` via `+=`, rather than simple assignment, but the `+=` syntax isn't recognized by [`Rails/UnusedIgnoredColumns`](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedignoredcolumns).

This PR fixes `Rails/UnusedIgnoredColumns` to work with `+=`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
