### PR TITLE
Raise severity of some cops to warning

### DIFF
--- a/changelog/change_raise_severity_of_some_cops_to_warning.md
+++ b/changelog/change_raise_severity_of_some_cops_to_warning.md
@@ -1,0 +1,1 @@
+* [#896](https://github.com/rubocop/rubocop-rails/pull/896): Raise severity of `Rails/ActiveRecordOverride`, `Rails/DeprecatedActiveModelErrorsMethods`, `Rails/DuplicateAssociation`, `Rails/DuplicateScope`, `Rails/TopLevelHashWithIndifferentAccess`, and `Rails/WhereNotWithMultipleConditions` cops to warning. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -135,7 +135,9 @@ Rails/ActiveRecordOverride:
                   Check for overriding Active Record methods instead of using
                   callbacks.
   Enabled: true
+  Severity: warning
   VersionAdded: '0.67'
+  VersionChanged: '<<next>>'
   Include:
     - app/models/**/*.rb
 
@@ -330,9 +332,10 @@ Rails/DelegateAllowBlank:
 Rails/DeprecatedActiveModelErrorsMethods:
   Description: 'Avoid manipulating ActiveModel errors hash directly.'
   Enabled: pending
+  Severity: warning
   Safe: false
   VersionAdded: '2.14'
-  VersionChanged: '2.15'
+  VersionChanged: '<<next>>'
 
 Rails/DotSeparatedKeys:
   Description: 'Enforces the use of dot-separated keys instead of `:scope` options in `I18n` translation methods.'
@@ -343,12 +346,16 @@ Rails/DotSeparatedKeys:
 Rails/DuplicateAssociation:
   Description: "Don't repeat associations in a model."
   Enabled: pending
+  Severity: warning
   VersionAdded: '2.14'
+  VersionChanged: '<<next>>'
 
 Rails/DuplicateScope:
   Description: 'Multiple scopes share this same where clause.'
   Enabled: pending
+  Severity: warning
   VersionAdded: '2.14'
+  VersionChanged: '<<next>>'
 
 Rails/DurationArithmetic:
   Description: 'Do not use duration as arithmetic operand with `Time.current`.'
@@ -1038,7 +1045,9 @@ Rails/TopLevelHashWithIndifferentAccess:
   Description: 'Identifies top-level `HashWithIndifferentAccess`.'
   Reference: 'https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#top-level-hashwithindifferentaccess-is-soft-deprecated'
   Enabled: pending
+  Severity: warning
   VersionAdded: '2.16'
+  VersionChanged: '<<next>>'
 
 Rails/TransactionExitStatement:
   Description: 'Avoid the usage of `return`, `break` and `throw` in transaction blocks.'
@@ -1066,7 +1075,9 @@ Rails/UniqueValidationWithoutIndex:
 Rails/UnknownEnv:
   Description: 'Use correct environment name.'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.51'
+  VersionChanged: '<<next>>'
   Environments:
     - development
     - test
@@ -1121,7 +1132,9 @@ Rails/WhereNot:
 Rails/WhereNotWithMultipleConditions:
   Description: 'Do not use `where.not(...)` with multiple conditions.'
   Enabled: 'pending'
+  Severity: warning
   VersionAdded: '2.17'
+  VersionChanged: '<<next>>'
 
 # Accept `redirect_to(...) and return` and similar cases.
 Style/AndOr:


### PR DESCRIPTION
The cops below belong to linting, not style preference, so make set the severity to warning.

The following emulates warnings for deprecated APIs:

- Rails/DeprecatedActiveModelErrorsMethods
- Rails/TopLevelHashWithIndifferentAccess
- Rails/WhereNotWithMultipleConditions

The following suggests incorrect usage of APIs:

- Rails/ActiveRecordOverride
- Rails/DuplicateAssociation
- Rails/DuplicateScope

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
