### PR TITLE
[Fix #898] Fix a false positive for `Rails/ActiveRecordAliases`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_active_record_aliases.md
+++ b/changelog/fix_a_false_positive_for_rails_active_record_aliases.md
@@ -1,0 +1,1 @@
+* [#898](https://github.com/rubocop/rubocop-rails/issues/898): Fix a false positive for `Rails/ActiveRecordAliases` when arguments of `update_attributes` is empty. ([@koic][])

--- a/lib/rubocop/cop/rails/active_record_aliases.rb
+++ b/lib/rubocop/cop/rails/active_record_aliases.rb
@@ -26,6 +26,8 @@ module RuboCop
         RESTRICT_ON_SEND = ALIASES.keys.freeze
 
         def on_send(node)
+          return if node.arguments.empty?
+
           method_name = node.method_name
           alias_method = ALIASES[method_name]
 

--- a/spec/rubocop/cop/rails/active_record_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_aliases_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases, :config do
         RUBY
       end
     end
+
+    context 'when arguments of `update_attributes` is empty' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          user.update(update_attributes)
+        RUBY
+      end
+    end
   end
 
   describe '#update_attributes!' do


### PR DESCRIPTION
Fixes #898.

This PR fixes a false positive for `Rails/ActiveRecordAliases` when arguments of `update_attributes` is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
