### PR TITLE
Update allowlist of methods to ignore for false positives

### DIFF
--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -24,7 +24,7 @@ module RuboCop
 
         MSG = 'Use keyword arguments instead of positional arguments for http call: `%<verb>s`.'
         KEYWORD_ARGS = %i[method params session body flash xhr as headers env to].freeze
-        ROUTING_METHODS = %i[draw routes].freeze
+        ROUTING_METHODS = %i[draw routes append].freeze
         RESTRICT_ON_SEND = %i[get post put patch delete head].freeze
 
         minimum_target_rails_version 5.0


### PR DESCRIPTION
This PR https://github.com/rubocop/rubocop-rails/commit/732a0dba2c379ffbd30b4015fff25a108c821eea

This issue was reported a while back finding that the HTTP positional arguments cop could give false positives https://github.com/rubocop/rubocop-rails/issues/532

I found another instance of false positives when the `append` method is used instead of `draw` or `routes`. If we add that to the list as well this problem seems to go away.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
