### PR TITLE
Ignore redirect method for Style/FormatStringToken by default

### DIFF
--- a/changelog/change_ignore_redirect_method_for_style_format_string_token.md
+++ b/changelog/change_ignore_redirect_method_for_style_format_string_token.md
@@ -1,0 +1,1 @@
+* [#902](https://github.com/rubocop/rubocop-rails/pull/902): Ignore `redirect` method for `Style/FormatStringToken` by default. ([@javierjulio][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1138,6 +1138,13 @@ Rails/WhereNotWithMultipleConditions:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+Style/FormatStringToken:
+  AllowedMethods:
+    - redirect
+  # Deprecated.
+  IgnoredMethods:
+    - redirect
+
 Style/SymbolProc:
   AllowedMethods:
     - define_method


### PR DESCRIPTION
This adds the `redirect` method as a default for the Style/FormatStringToken rule due to the change in https://github.com/rubocop/rubocop/pull/9369 where it was mentioned that it would be added as a default but since it wasn't, I'm contributing the change. I ran into this false positive with a rails route using both rubocop and rubocop-rails. Seems like a good default to have, if still desired.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~~Added tests.~~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
