### PR TITLE
Fix some typos

### DIFF
--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -67,8 +67,8 @@ module RuboCop
         private
 
         def followed_by_render?(flash_node)
-          flash_assigment_node = find_ancestor(flash_node, type: :send)
-          context = flash_assigment_node
+          flash_assignment_node = find_ancestor(flash_node, type: :send)
+          context = flash_assignment_node
           if (node = context.each_ancestor(:if, :rescue).first)
             context = node
           elsif context.right_siblings.empty?

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
   end
 
   shared_examples 'no offense' do
-    it 'does not register an offensewhen including combinable transformations' do
+    it 'does not register an offense when including combinable transformations' do
       expect_no_offenses(<<~RUBY)
         def change
           change_table :users do |t|
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including combinable alter methods' do
+    it 'does not register an offense when including combinable alter methods' do
       expect_no_offenses(<<~RUBY)
         def change
           add_column :users, :name, :string, null: false
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
   end
 
   shared_examples 'no offense for mysql' do
-    it 'does not register an offensewhen including combinable transformations' do
+    it 'does not register an offense when including combinable transformations' do
       expect_no_offenses(<<~RUBY)
         def change
           change_table :users do |t|
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including combinable alter methods' do
+    it 'does not register an offense when including combinable alter methods' do
       expect_no_offenses(<<~RUBY)
         def change
           remove_index :users, :name
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
   end
 
   shared_examples 'no offense for postgresql' do
-    it 'does not register an offensewhen including combinable transformations' do
+    it 'does not register an offense when including combinable transformations' do
       expect_no_offenses(<<~RUBY)
         def change
           change_table :users do |t|
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including combinable alter methods' do
+    it 'does not register an offense when including combinable alter methods' do
       expect_no_offenses(<<~RUBY)
         def change
           change_column_default :users, :name, false
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including combinable transformations with `bulk: true`' do
+    it 'does not register an offense when including combinable transformations with `bulk: true`' do
       expect_no_offenses(<<~RUBY)
         def change
           change_table :users, bulk: true do |t|
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including combinable transformations with `bulk: false`' do
+    it 'does not register an offense when including combinable transformations with `bulk: false`' do
       expect_no_offenses(<<~RUBY)
         def change
           change_table :users, bulk: false do |t|
@@ -215,7 +215,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including a combinable transformation' do
+    it 'does not register an offense when including a combinable transformation' do
       expect_no_offenses(<<~RUBY)
         def change
           change_table :users do |t|
@@ -252,7 +252,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including transformations with block' do
+    it 'does not register an offense when including transformations with block' do
       expect_no_offenses(<<~RUBY)
         def change
           reversible do |dir|
@@ -272,7 +272,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen the target of the alter method is another table' do
+    it 'does not register an offense when the target of the alter method is another table' do
       expect_no_offenses(<<~RUBY)
         def change
           add_reference :users, :team
@@ -282,7 +282,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including non-combinable alter method between' do
+    it 'does not register an offense when including non-combinable alter method between' do
       expect_no_offenses(<<~RUBY)
         def change
           add_column :users, :name, :string, null: false
@@ -304,7 +304,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
-    it 'does not register an offensewhen including a combinable alter method' do
+    it 'does not register an offense when including a combinable alter method' do
       expect_no_offenses(<<~RUBY)
         def change
           add_reference :users, :team

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
-    context 'when concat Rails.root and colon using string interpoloation' do
+    context 'when concat Rails.root and colon using string interpolation' do
       it 'does not register an offense' do
         expect_no_offenses(<<~'RUBY')
           "#{Rails.root}:/foo/bar"
@@ -268,7 +268,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
-    context 'when concat Rails.root and colon using string interpoloation' do
+    context 'when concat Rails.root and colon using string interpolation' do
       it 'does not register an offense' do
         expect_no_offenses(<<~'RUBY')
           "#{Rails.root}:/foo/bar"

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
       context 'when the block argument is used in `[]`' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
-            x.#{method} { |a| a[foo...a.to_someghing] }
+            x.#{method} { |a| a[foo...a.to_something] }
           RUBY
         end
       end
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
           context 'when the numblock argument is used in `[]`' do
             it 'does not register an offense' do
               expect_no_offenses(<<~RUBY)
-                x.#{method} { _1[foo..._1.to_someghing] }
+                x.#{method} { _1[foo..._1.to_something] }
               RUBY
             end
           end

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
     RUBY
   end
 
-  it 'does not register an offense when including block nodein `with_options`' do
+  it 'does not register an offense when including block node in `with_options`' do
     expect_no_offenses(<<~RUBY)
       with_options options: false do |merger|
         merger.invoke


### PR DESCRIPTION
This PR is fix some typos.

- assigment -> assignment
- offensewhen -> offense when
- interpoloation -> interpolation
- someghing -> something
- nodein -> node in

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
