### PR TITLE
Don't use FreezeTime cop in Rails <5.2

### DIFF
--- a/changelog/fix_set_minimum_target_rails_version_for_freeze_time.md
+++ b/changelog/fix_set_minimum_target_rails_version_for_freeze_time.md
@@ -1,0 +1,1 @@
+* [#918](https://github.com/rubocop/rubocop-rails/pull/918): Fix `Rails/FreezeTime` running against Rails < 5.2 apps. ([@DRBragg][])

--- a/lib/rubocop/cop/rails/freeze_time.rb
+++ b/lib/rubocop/cop/rails/freeze_time.rb
@@ -26,6 +26,9 @@ module RuboCop
       #
       class FreezeTime < Base
         extend AutoCorrector
+        extend TargetRailsVersion
+
+        minimum_target_rails_version 5.2
 
         MSG = 'Use `freeze_time` instead of `travel_to`.'
         NOW_METHODS = %i[now new current].freeze

--- a/spec/rubocop/cop/rails/freeze_time_spec.rb
+++ b/spec/rubocop/cop/rails/freeze_time_spec.rb
@@ -1,121 +1,155 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::FreezeTime, :config do
-  it 'registers an offense when using `travel_to` with an argument of the current time' do
-    expect_offense(<<~RUBY)
-      travel_to(Time.now)
-      ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(Time.new)
-      ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(DateTime.now)
-      ^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(Time.current)
-      ^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(Time.zone.now)
-      ^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(Time.now.in_time_zone)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(Time.current.to_time)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(::Time.now)
-      ^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(::DateTime.now)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      travel_to(::Time.zone.now)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-    RUBY
+  context 'Rails 5.1', :rails51 do
+    it 'does not register an offense when using `travel_to` with an argument of the current time' do
+      expect_no_offenses('travel_to(Time.now)')
+      expect_no_offenses('travel_to(Time.new)')
+      expect_no_offenses('travel_to(DateTime.now)')
+      expect_no_offenses('travel_to(Time.current)')
+      expect_no_offenses('travel_to(Time.zone.now)')
+    end
 
-    expect_correction(<<~RUBY)
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-      freeze_time
-    RUBY
+    it 'does not register an offense when using `travel_to` with an argument of the current time and `do-end` block' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Time.now) do
+          do_something
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `travel_to` with an argument of the current time and `{}` block' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Time.now) { do_something }
+      RUBY
+    end
+
+    it 'does not register an offense when using `travel_to` with an argument of the current time and proc argument' do
+      expect_no_offenses(<<~RUBY)
+        around do |example|
+          travel_to(Time.current, &example)
+        end
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `travel_to` with an argument of the current time and `do-end` block' do
-    expect_offense(<<~RUBY)
-      travel_to(Time.now) do
-      ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-        do_something
-      end
-    RUBY
+  context 'Rails 5.2', :rails52 do
+    it 'registers an offense when using `travel_to` with an argument of the current time' do
+      expect_offense(<<~RUBY)
+        travel_to(Time.now)
+        ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(Time.new)
+        ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(DateTime.now)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(Time.current)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(Time.zone.now)
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(Time.now.in_time_zone)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(Time.current.to_time)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(::Time.now)
+        ^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(::DateTime.now)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        travel_to(::Time.zone.now)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      freeze_time do
-        do_something
-      end
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+        freeze_time
+      RUBY
+    end
 
-  it 'registers an offense when using `travel_to` with an argument of the current time and `{}` block' do
-    expect_offense(<<~RUBY)
-      travel_to(Time.now) { do_something }
-      ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-    RUBY
+    it 'registers an offense when using `travel_to` with an argument of the current time and `do-end` block' do
+      expect_offense(<<~RUBY)
+        travel_to(Time.now) do
+        ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+          do_something
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      freeze_time { do_something }
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        freeze_time do
+          do_something
+        end
+      RUBY
+    end
 
-  it 'registers an offense when using `travel_to` with an argument of the current time and proc argument' do
-    expect_offense(<<~RUBY)
-      around do |example|
-        travel_to(Time.current, &example)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
-      end
-    RUBY
+    it 'registers an offense when using `travel_to` with an argument of the current time and `{}` block' do
+      expect_offense(<<~RUBY)
+        travel_to(Time.now) { do_something }
+        ^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      around do |example|
-        freeze_time(&example)
-      end
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        freeze_time { do_something }
+      RUBY
+    end
 
-  it 'does not register an offense when using `freeze_time`' do
-    expect_no_offenses(<<~RUBY)
-      freeze_time
-    RUBY
-  end
+    it 'registers an offense when using `travel_to` with an argument of the current time and proc argument' do
+      expect_offense(<<~RUBY)
+        around do |example|
+          travel_to(Time.current, &example)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `freeze_time` instead of `travel_to`.
+        end
+      RUBY
 
-  it 'does not register an offense when using `travel_to` with an argument of the not current time' do
-    expect_no_offenses(<<~RUBY)
-      travel_to(Time.current.yesterday)
-      travel_to(Time.zone.tomorrow)
-      travel_to(DateTime.next_day)
-      travel_to(Time.zone.yesterday.in_time_zone)
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        around do |example|
+          freeze_time(&example)
+        end
+      RUBY
+    end
 
-  it 'does not register an offense when using `travel_to` with an argument of `current` method without receiver' do
-    expect_no_offenses(<<~RUBY)
-      travel_to(current)
-    RUBY
-  end
+    it 'does not register an offense when using `freeze_time`' do
+      expect_no_offenses(<<~RUBY)
+        freeze_time
+      RUBY
+    end
 
-  it 'does not register an offense when using `travel_to` with an argument of `DateTime.new` with arguments' do
-    expect_no_offenses(<<~RUBY)
-      travel_to(DateTime.new(2022, 5, 3, 12, 0, 0))
-    RUBY
-  end
+    it 'does not register an offense when using `travel_to` with an argument of the not current time' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Time.current.yesterday)
+        travel_to(Time.zone.tomorrow)
+        travel_to(DateTime.next_day)
+        travel_to(Time.zone.yesterday.in_time_zone)
+      RUBY
+    end
 
-  it 'does not register an offense when using `travel_to` with an argument of `Time.new(...).in_time_zone`' do
-    expect_no_offenses(<<~RUBY)
-      travel_to(Time.new(2019, 4, 3, 12, 30).in_time_zone)
-    RUBY
-  end
+    it 'does not register an offense when using `travel_to` with an argument of `current` method without receiver' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(current)
+      RUBY
+    end
 
-  it 'does not register an offense when using `travel_to` without argument' do
-    expect_no_offenses(<<~RUBY)
-      travel_to
-    RUBY
+    it 'does not register an offense when using `travel_to` with an argument of `DateTime.new` with arguments' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(DateTime.new(2022, 5, 3, 12, 0, 0))
+      RUBY
+    end
+
+    it 'does not register an offense when using `travel_to` with an argument of `Time.new(...).in_time_zone`' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Time.new(2019, 4, 3, 12, 30).in_time_zone)
+      RUBY
+    end
+
+    it 'does not register an offense when using `travel_to` without argument' do
+      expect_no_offenses(<<~RUBY)
+        travel_to
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
`freeze_time` wasn't added until Rails 5.2, so running this cop against a Rails <= 5.1 app returns inaccurate offenses.

I have:
- Added specs and confirmed failures. 
- Set `minimum_target_rails_version` to `5.2` in  the `Rails/FreezeTime` Cop.
- Reran specs and confirmed no failures.
- Added a changelog entry


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
