### PR TITLE
Mark the autocorrect for Rails/Delegate unsafe

### DIFF
--- a/changelog/fix_mark_the_autocorrect_for_rails_delegate.md
+++ b/changelog/fix_mark_the_autocorrect_for_rails_delegate.md
@@ -1,0 +1,1 @@
+* [#858](https://github.com/rubocop/rubocop-rails/issues/858): Mark the autocorrect for Rails/Delegate unsafe. ([@j-miyake][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -329,6 +329,7 @@ Rails/Delegate:
   # method name without using the `delegate` method will be a
   # violation. When set to false, this case is legal.
   EnforceForPrefixed: true
+  SafeAutoCorrect: false
 
 Rails/DelegateAllowBlank:
   Description: 'Do not use allow_blank as an option to delegate.'

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -15,6 +15,13 @@ module RuboCop
       # without using the `delegate` method will be a violation.
       # When set to `false`, this case is legal.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe when a refinement defines
+      #   the receiver. Since `delegate` defines the method dynamically
+      #   in a separate source file, the refinement is not applied in
+      #   the context of the method definition. Thus, calling the method
+      #   will result in a NameError because the receiver is not found.
+      #
       # @example
       #   # bad
       #   def bar


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rails/issues/858

The autocorrect for Rails/Delegate is unsafe when a refinement defines the receiver. Since `delegate` defines the method dynamically in a separate source file, the refinement is not applied in the context of the method definition. Thus, calling the method will result in a NameError because the receiver is not found.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
