### PR TITLE
Fix an error for `Rails/NegateInclude` when there is no receiver

### DIFF
--- a/changelog/fix_error_for_negate_include_without_receiver.md
+++ b/changelog/fix_error_for_negate_include_without_receiver.md
@@ -1,0 +1,1 @@
+* [#920](https://github.com/rubocop/rubocop-rails/pull/920): Fix an error for `Rails/NegateInclude` when there is no receiver. ([@fatkodima][])

--- a/lib/rubocop/cop/rails/negate_include.rb
+++ b/lib/rubocop/cop/rails/negate_include.rb
@@ -26,7 +26,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[!].freeze
 
         def_node_matcher :negate_include_call?, <<~PATTERN
-          (send (send $_ :include? $_) :!)
+          (send (send $!nil? :include? $_) :!)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/negate_include_spec.rb
+++ b/spec/rubocop/cop/rails/negate_include_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe RuboCop::Cop::Rails::NegateInclude, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `!include?` without receiver' do
+    expect_no_offenses(<<~RUBY)
+      !include?(2)
+    RUBY
+  end
+
   it 'does not register an offense when using `include?` or `exclude?`' do
     expect_no_offenses(<<~RUBY)
       array.include?(2)


### PR DESCRIPTION
This PR fixes an error when there is no receiver. And handles the case when it is used within `exclude?` method (because correcting would cause infinite recursion).

Example from rails: https://github.com/rails/rails/blob/d75fdd1c2f6002d62e5ecf65dda2942065f071f0/activesupport/lib/active_support/core_ext/string/exclude.rb#L10-L12