### PR TITLE
Fix `Rails/HasManyOrHasOneDependent` to correctly handle association methods with receiver

### DIFF
--- a/changelog/fix_has_many_or_has_one_dependent_receiver.md
+++ b/changelog/fix_has_many_or_has_one_dependent_receiver.md
@@ -1,0 +1,1 @@
+* [#687](https://github.com/rubocop/rubocop-rails/issues/687): Fix `Rails/HasManyOrHasOneDependent` to correctly handle association methods with receiver. ([@fatkodima][])

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -41,11 +41,11 @@ module RuboCop
         PATTERN
 
         def_node_matcher :association_without_options?, <<~PATTERN
-          (send nil? {:has_many :has_one} _)
+          (send _ {:has_many :has_one} _)
         PATTERN
 
         def_node_matcher :association_with_options?, <<~PATTERN
-          (send nil? {:has_many :has_one} ... (hash $...))
+          (send _ {:has_many :has_one} ... (hash $...))
         PATTERN
 
         def_node_matcher :dependent_option?, <<~PATTERN

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -241,17 +241,41 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
       RUBY
     end
 
-    it 'registers an offense when using mix-in module that has an association of Active Record' do
-      expect_offense(<<~RUBY)
-        module Foo
-          extend ActiveSupport::Concern
+    context 'mix-in module' do
+      it 'registers an offense when has an association of Active Record' do
+        expect_offense(<<~RUBY)
+          module Foo
+            extend ActiveSupport::Concern
 
-          included do
-            has_many :bazs
-            ^^^^^^^^ Specify a `:dependent` option.
+            included do
+              has_many :bazs
+              ^^^^^^^^ Specify a `:dependent` option.
+            end
           end
-        end
-      RUBY
+        RUBY
+      end
+
+      it 'registers an offense when association method is called on the base class and no `:dependent` strategy' do
+        expect_offense(<<~RUBY)
+          module Foo
+            def self.included(base)
+              base.has_many :bazs
+                   ^^^^^^^^ Specify a `:dependent` option.
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when association method is called on the base class' \
+         'and has `:dependent` strategy' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+            def self.included(base)
+              base.has_many :bazs, dependent: :destroy
+            end
+          end
+        RUBY
+      end
     end
 
     it 'does not register an offense when using associations of Active Resource' do


### PR DESCRIPTION
Fixes #687.