### PR TITLE
Only apply SquishSQLHeredoc when the SQL has no comments

### DIFF
--- a/changelog/fix_invalid_squish_sql_heredoc.md
+++ b/changelog/fix_invalid_squish_sql_heredoc.md
@@ -1,0 +1,1 @@
+* [#929](https://github.com/rubocop/rubocop-rails/issues/929): Prevent `Rails/SquishedSQLHeredocs` applying when single-line comments are present. ([@john-h-k][])

--- a/spec/rubocop/cop/rails/squished_sql_heredocs_spec.rb
+++ b/spec/rubocop/cop/rails/squished_sql_heredocs_spec.rb
@@ -19,10 +19,39 @@ RSpec.describe RuboCop::Cop::Rails::SquishedSQLHeredocs, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects it with comment-like string and identifiers' do
+      expect_offense(<<~RUBY)
+        <<~SQL
+        ^^^^^^ Use `<<~SQL.squish` instead of `<<~SQL`.
+          SELECT * FROM posts
+            WHERE [--another identifier!] = 1
+            AND "-- this is a name, not a comment" = '-- this is a string, not a comment'
+        SQL
+      RUBY
+
+      expect_correction(<<~RUBY)
+        <<~SQL.squish
+          SELECT * FROM posts
+            WHERE [--another identifier!] = 1
+            AND "-- this is a name, not a comment" = '-- this is a string, not a comment'
+        SQL
+      RUBY
+    end
+
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         <<-SQL.squish
           SELECT * FROM posts
+            WHERE id = 1
+        SQL
+      RUBY
+    end
+
+    it 'does not register an offense due to comments' do
+      expect_no_offenses(<<~RUBY)
+        <<-SQL
+          SELECT * FROM posts
+            -- This is a comment, so squish can't be used
             WHERE id = 1
         SQL
       RUBY
@@ -45,10 +74,33 @@ RSpec.describe RuboCop::Cop::Rails::SquishedSQLHeredocs, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects it with comment-like string and identifiers' do
+      expect_offense(<<~RUBY)
+        <<~SQL
+        ^^^^^^ Use `<<~SQL.squish` instead of `<<~SQL`.
+          SELECT * FROM posts WHERE [--another identifier!] = 1 AND "-- this is a name, not a comment" = '-- this is a string, not a comment';
+        SQL
+      RUBY
+
+      expect_correction(<<~RUBY)
+        <<~SQL.squish
+          SELECT * FROM posts WHERE [--another identifier!] = 1 AND "-- this is a name, not a comment" = '-- this is a string, not a comment';
+        SQL
+      RUBY
+    end
+
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         <<-SQL.squish
           SELECT * FROM posts;
+        SQL
+      RUBY
+    end
+
+    it 'does not register an offense due to comments' do
+      expect_no_offenses(<<~RUBY)
+        <<-SQL
+          -- This is a comment, so squish can't be used
         SQL
       RUBY
     end
@@ -72,10 +124,39 @@ RSpec.describe RuboCop::Cop::Rails::SquishedSQLHeredocs, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects it with comment-like string and identifiers' do
+      expect_offense(<<~RUBY)
+        execute(<<~SQL, "Post Load")
+                ^^^^^^ Use `<<~SQL.squish` instead of `<<~SQL`.
+          SELECT * FROM posts
+            WHERE [--another identifier!] = 1
+            AND "-- this is a name, not a comment" = '-- this is a string, not a comment'
+        SQL
+      RUBY
+
+      expect_correction(<<~RUBY)
+        execute(<<~SQL.squish, "Post Load")
+          SELECT * FROM posts
+            WHERE [--another identifier!] = 1
+            AND "-- this is a name, not a comment" = '-- this is a string, not a comment'
+        SQL
+      RUBY
+    end
+
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         execute(<<~SQL.squish, "Post Load")
           SELECT * FROM posts
+            WHERE post_id = 1
+        SQL
+      RUBY
+    end
+
+    it 'does not register an offense due to comments' do
+      expect_no_offenses(<<~RUBY)
+        execute(<<-SQL, "Post Load")
+          SELECT * FROM posts
+          -- This is a comment, so squish can't be used
             WHERE post_id = 1
         SQL
       RUBY


### PR DESCRIPTION
Removes all strings and identifiers from the SQL and then checks it for single-comment markers, and does not apply the cop if they are present
