### PR TITLE
Fix error in `Rails/Presence` when ternary operators are used in multiple lines

### DIFF
--- a/changelog/fix_error_in_rails_presence_when_ternary.md
+++ b/changelog/fix_error_in_rails_presence_when_ternary.md
@@ -1,0 +1,1 @@
+* [#931](https://github.com/rubocop/rubocop-rails/pull/931): Fix error in `Rails/Presence` when ternary operators are used in multiple lines. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -112,10 +112,10 @@ module RuboCop
         end
 
         def current(node)
-          if node.source.include?("\n")
+          if !node.ternary? && node.source.include?("\n")
             "#{node.loc.keyword.with(end_pos: node.condition.loc.selector.end_pos).source} ... end"
           else
-            node.source
+            node.source.gsub(/\n\s*/, ' ')
           end
         end
 

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -233,6 +233,21 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
     RUBY
   end
 
+  context 'when multiline ternary can be replaced' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        a.present? ?
+        ^^^^^^^^^^^^ Use `a.presence` instead of `a.present? ? a : nil`.
+          a :
+          nil
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.presence
+      RUBY
+    end
+  end
+
   context 'when a method argument of `else` branch is enclosed in parentheses' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
When I run rubocop-rails against the following code, I get an error from `Rails/Presence` cop.

```ruby
a.present? ?
  a :
  b
```

After investigation, I have identified the problem and would like to fix it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
