### PR TITLE
Make `Style/InverseMethods` aware of some Active Support methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,11 @@ Style/FormatStringToken:
   Exclude:
     - spec/**/*
 
+Style/InverseMethods:
+  # This rubocop-rails repository doesn't use Active Support, so it can't replace `include?` with `exclude?`.
+  InverseMethods:
+    :include?: ~
+
 Layout/HashAlignment:
   EnforcedHashRocketStyle:
     - key

--- a/changelog/change_make_style_inverse_methods_aware_of_active_support_methods.md
+++ b/changelog/change_make_style_inverse_methods_aware_of_active_support_methods.md
@@ -1,0 +1,1 @@
+* [#935](https://github.com/rubocop/rubocop-rails/pull/935): Make `Style/InverseMethods` aware of Active Support's `present?`, `blank?`, `include?`, and `exclude?` methods. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1144,6 +1144,14 @@ Style/FormatStringToken:
   AllowedMethods:
     - redirect
 
+Style/InverseMethods:
+  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
+  # The relationship of inverse methods only needs to be defined in one direction.
+  # Keys and values both need to be defined as symbols.
+  InverseMethods:
+    :present?: :blank?
+    :include?: :exclude?
+
 Style/SymbolProc:
   AllowedMethods:
     - define_method

--- a/lib/rubocop/rails.rb
+++ b/lib/rubocop/rails.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Rails
     PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
     CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
-    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read, permitted_classes: [Regexp, Symbol]).freeze
 
     private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
 


### PR DESCRIPTION
This PR makes `Style/InverseMethods` aware of Active Support's `present?`, `blank?`, `include?`, and `exclude?` methods.

These methods are based on the following setting:
https://github.com/rubocop/rubocop/blob/v1.45.0/config/default.yml#L4030-L4033

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
