### PR TITLE
[Fix #914] Make `Style/InverseMethods` aware of `valid?` and `invalid?` methods

### DIFF
--- a/changelog/change_make_style_inverse_methods_aware_of_valid_p_and_invalid_p.md
+++ b/changelog/change_make_style_inverse_methods_aware_of_valid_p_and_invalid_p.md
@@ -1,0 +1,1 @@
+* [#914](https://github.com/rubocop/rubocop-rails/issues/914): Make `Style/InverseMethods` aware of `valid?` and `invalid?` methods. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1151,6 +1151,7 @@ Style/InverseMethods:
   InverseMethods:
     :present?: :blank?
     :include?: :exclude?
+    :valid?: :invalid?
 
 Style/SymbolProc:
   AllowedMethods:


### PR DESCRIPTION
Fixes #914.

This commit makes `Style/InverseMethods` aware of `valid?` and `invalid?` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
