### PR TITLE
[Fix #909] Fix a false positive for `Rails/ActionControllerFlashBeforeRender`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
+++ b/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#909](https://github.com/rubocop/rubocop-rails/issues/909): Fix a false positive for `Rails/ActionControllerFlashBeforeRender` when using `flash` before `redirect_to` in `if` branch. ([@koic][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -70,6 +70,8 @@ module RuboCop
           flash_assignment_node = find_ancestor(flash_node, type: :send)
           context = flash_assignment_node
           if (node = context.each_ancestor(:if, :rescue).first)
+            return false if use_redirect_to?(context)
+
             context = node
           elsif context.right_siblings.empty?
             return true
@@ -93,6 +95,12 @@ module RuboCop
           block_node = find_ancestor(node, type: :block)
 
           def_node || block_node
+        end
+
+        def use_redirect_to?(context)
+          context.right_siblings.compact.any? do |sibling|
+            sibling.send_type? && sibling.method?(:redirect_to)
+          end
         end
 
         def find_ancestor(node, type:)

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -202,6 +202,23 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
             RUBY
           end
 
+          it 'does not register an offense when using `flash` before `redirect_to` in `if` branch' do
+            expect_no_offenses(<<~RUBY)
+              class HomeController < #{parent_class}
+                def create
+                  if condition
+                    flash[:alert] = "msg"
+                    redirect_to :index
+
+                    return
+                  end
+
+                  render :index
+                end
+              end
+            RUBY
+          end
+
           it 'does not register an offense when using `flash` in multiline `rescue` branch before `redirect_to`' do
             expect_no_offenses(<<~RUBY)
               class HomeController < #{parent_class}


### PR DESCRIPTION
Fixes #909.

This PR fixes a false positive for `Rails/ActionControllerFlashBeforeRender` when using `flash` before `redirect_to` in `if` branch.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
