### PR TITLE
Require missing `#blank?` from ActiveSupport

### DIFF
--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -3,6 +3,7 @@
 require 'rubocop'
 require 'rack/utils'
 require 'active_support/inflector'
+require 'active_support/core_ext/object/blank'
 
 require_relative 'rubocop/rails'
 require_relative 'rubocop/rails/version'


### PR DESCRIPTION
When running `Rails/SchemaComment` on a project which uses rails `main`, I get:
```
An error occurred while Rails/SchemaComment cop was inspecting example.rb:4:4.
undefined method `present?' for "Comment":String
/Users/fatkodima/Desktop/oss/rubocop-rails/lib/rubocop/cop/rails/schema_comment.rb:57:in `block in comment_present?'
/Users/fatkodima/Desktop/oss/rubocop-rails/lib/rubocop/cop/rails/schema_comment.rb:46:in `times'
/Users/fatkodima/Desktop/oss/rubocop-rails/lib/rubocop/cop/rails/schema_comment.rb:46:in `comment_present?'
/Users/fatkodima/Desktop/oss/rubocop-rails/lib/rubocop/cop/rails/schema_comment.rb:60:in `add_column_with_comment?'
/Users/fatkodima/Desktop/oss/rubocop-rails/lib/rubocop/cop/rails/schema_comment.rb:89:in `add_column_without_comment?'
/Users/fatkodima/Desktop/oss/rubocop-rails/lib/rubocop/cop/rails/schema_comment.rb:75:in `on_send'
``` 

That worked before, because `rubocop-rails` requires inflector https://github.com/rubocop/rubocop-rails/blob/546cfbc9f6369aaeeff4f8e64742f75f6e9c8412/lib/rubocop-rails.rb#L5, which required `active_support/core_ext/object/blank` in the past. But after the recent change (https://github.com/rails/rails/commit/0170745b376acd150fec5f8cc57253cc1ffe0cf2), this is no longer the case. So we need to require it manually.

Don't think this change worth a changelog entry?