### PR TITLE
Fix typo in `Rails/UniqueValidationWithoutIndex` doc

### DIFF
--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Rails
       # When you define a uniqueness validation in Active Record model,
-      # you also should add a unique index for the column. There are two reasons
+      # you also should add a unique index for the column. There are two reasons.
       # First, duplicated records may occur even if Active Record's validation
       # is defined.
       # Second, it will cause slow queries. The validation executes a `SELECT`


### PR DESCRIPTION
This change adds just a missing period.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
