### PR TITLE
Add SchemaPath configuration option for Rails/UnusedIgnoredColumns

### DIFF
--- a/changelog/new_feat_allow_setting_of_schema_path_for_unused_ignored_columns.md
+++ b/changelog/new_feat_allow_setting_of_schema_path_for_unused_ignored_columns.md
@@ -1,0 +1,1 @@
+* [#946](https://github.com/rubocop/rubocop-rails/pull/946): New cop config option added, SchemaPath, for for `Rails/UnusedIgnoredColumns` to target other schemas. ([@cfurrow][])

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -6318,6 +6318,10 @@ end
 | Include
 | `+app/models/**/*.rb+`
 | Array
+
+| SchemaPath
+| `db/schema.rb`
+| String
 |===
 
 == Rails/Validation

--- a/lib/rubocop/rails/schema_loader.rb
+++ b/lib/rubocop/rails/schema_loader.rb
@@ -7,27 +7,29 @@ module RuboCop
     module SchemaLoader
       extend self
 
-      # It parses `db/schema.rb` and return it.
-      # It returns `nil` if it can't find `db/schema.rb`.
+      # It parses schema file at  and return it.
+      # It returns `nil` if it can't find the schema file.
       # So a cop that uses the loader should handle `nil` properly.
+      # @param target_ruby_version [String] The target Ruby version
+      # @param schema_path [String] The path to the schema file, defaults to `db/schema.rb`
       #
       # @return [Schema, nil]
-      def load(target_ruby_version)
+      def load(target_ruby_version, schema_path = 'db/schema.rb')
         return @load if defined?(@load)
 
+        @schema_path = schema_path
         @load = load!(target_ruby_version)
       end
 
       def reset!
-        return unless instance_variable_defined?(:@load)
-
-        remove_instance_variable(:@load)
+        remove_instance_variable(:@schema_path) if instance_variable_defined?(:@schema_path)
+        remove_instance_variable(:@load) if instance_variable_defined?(:@load)
       end
 
       def db_schema_path
         path = Pathname.pwd
         until path.root?
-          schema_path = path.join('db/schema.rb')
+          schema_path = path.join(@schema_path || 'db/schema.rb')
           return schema_path if schema_path.exist?
 
           path = path.join('../').cleanpath


### PR DESCRIPTION
The current `Rails/UnusedIgnoredColumns` cop will only scan `db/schema.rb`, but some Rails environments may have multiple schema files, and engineers may want to target those schema files as well for this cop. (See [Multiple Databases with Active Record](https://guides.rubyonrails.org/active_record_multiple_databases.html))

Added a cop configuration for `Rails/UnusedIgnoredColumns`, `SchemaPath`, that allows engineers to target specific schema files for this cop.

```yaml
Rails/UnusedIgnoredColumns:
  Enabled: true
  # this will default to db/schema.rb

Rails/UnusedIgnoredColumns:
  Enabled: true
  SchemaPath: db/other_schema.rb
```

I would appreciate guidance, as this is the first time I've inspected the `rubocop-rails` source, so I may have made some critical errors when adding this new feature.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* ~~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
