### PR TITLE
Fix loading `database.yml` file with aliases

### DIFF
--- a/changelog/fix_loading_database_yml_with_aliases.md
+++ b/changelog/fix_loading_database_yml_with_aliases.md
@@ -1,0 +1,1 @@
+* [#947](https://github.com/rubocop/rubocop-rails/issues/947): Fix loading `database.yml` file with aliases. ([@fatkodima][])

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -192,11 +192,12 @@ module RuboCop
         def database_yaml
           return nil unless File.exist?('config/database.yml')
 
-          yaml = if YAML.respond_to?(:unsafe_load_file)
-                   YAML.unsafe_load_file('config/database.yml')
+          yaml = if YAML.respond_to?(:safe_load_file)
+                   YAML.safe_load_file('config/database.yml', aliases: true)
                  else
                    YAML.load_file('config/database.yml')
                  end
+
           return nil unless yaml.is_a? Hash
 
           config = yaml['development']

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -444,8 +444,9 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
 
     before do
       allow(File).to receive(:exist?).with('config/database.yml').and_return(true)
-      if YAML.respond_to?(:unsafe_load_file)
-        allow(YAML).to receive(:unsafe_load_file).with('config/database.yml').and_return(yaml)
+      if YAML.respond_to?(:safe_load_file)
+        allow(YAML).to receive(:safe_load_file).with('config/database.yml',
+                                                     hash_including(aliases: true)).and_return(yaml)
       else
         allow(YAML).to receive(:load_file).with('config/database.yml').and_return(yaml)
       end


### PR DESCRIPTION
Fixes #947. 
From that issue, it is clear that the error is related to parsing yaml with aliases.

Based on the solution from https://github.com/sidekiq/sidekiq/pull/5141.