### PR TITLE
[Fix #938] Fix an error for `Rails/WhereNotWithMultipleConditions`

### DIFF
--- a/changelog/fix_an_error_for_rails_where_not_with_multiple_conditions.md
+++ b/changelog/fix_an_error_for_rails_where_not_with_multiple_conditions.md
@@ -1,0 +1,1 @@
+* [#938](https://github.com/rubocop/rubocop-rails/issues/938): Fix an error for `Rails/WhereNotWithMultipleConditions` when using `where.not.lt(condition)` as a Mongoid API'. ([@koic][])

--- a/lib/rubocop/cop/rails/where_not_with_multiple_conditions.rb
+++ b/lib/rubocop/cop/rails/where_not_with_multiple_conditions.rb
@@ -32,7 +32,7 @@ module RuboCop
 
         def on_send(node)
           where_not_call?(node) do |args|
-            next unless args[0].hash_type?
+            next unless args[0]&.hash_type?
             next unless multiple_arguments_hash? args[0]
 
             range = node.receiver.loc.selector.with(end_pos: node.source_range.end_pos)

--- a/spec/rubocop/cop/rails/where_not_with_multiple_conditions_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_with_multiple_conditions_spec.rb
@@ -50,4 +50,10 @@ RSpec.describe RuboCop::Cop::Rails::WhereNotWithMultipleConditions, :config do
       User.where.not(data: {})
     RUBY
   end
+
+  it 'does not register an offense when using `where.not.lt(condition)` as a Mongoid API' do
+    expect_no_offenses(<<~RUBY)
+      User.where.not.lt(condition)
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #938.

This PR fixes an error for `Rails/WhereNotWithMultipleConditions` when using `where.not.lt(condition)` as a Mongoid API'.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
