### PR TITLE
[Fix #860] Fix a false positive for `Rails/Pluck`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_pluck.md
+++ b/changelog/fix_a_false_positive_for_rails_pluck.md
@@ -1,0 +1,1 @@
+* [#860](https://github.com/rubocop/rubocop-rails/issues/860): Fix a false positive for `Rails/Pluck` when using regexp literal key for `String#[]`. ([@koic][])

--- a/lib/rubocop/cop/rails/pluck.rb
+++ b/lib/rubocop/cop/rails/pluck.rb
@@ -43,7 +43,7 @@ module RuboCop
 
         def on_block(node)
           pluck_candidate?(node) do |argument, key|
-            next unless use_one_block_argument?(argument)
+            next if key.regexp_type? || !use_one_block_argument?(argument)
 
             match = if node.block_type?
                       block_argument = argument.children.first.source

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
+      context "when `#{method}` with regexp literal key cannot be replaced with `pluck`" do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            x.#{method} { |a| a[/regexp/] }
+          RUBY
+        end
+      end
+
       context 'when using Ruby 2.7 or newer', :ruby27 do
         context 'when using numbered parameter' do
           context "when `#{method}` can be replaced with `pluck`" do


### PR DESCRIPTION
Fixes #860.

This PR fixes a false positive for `Rails/Pluck` when using regexp literal key for `String#[]`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
