### PR TITLE
[Fix #941] Remove redundant config for `Style/InverseMethods`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,11 +66,6 @@ Style/FormatStringToken:
   Exclude:
     - spec/**/*
 
-Style/InverseMethods:
-  # This rubocop-rails repository doesn't use Active Support, so it can't replace `include?` with `exclude?`.
-  InverseMethods:
-    :include?: ~
-
 Layout/HashAlignment:
   EnforcedHashRocketStyle:
     - key

--- a/changelog/fix_remove_redundant_config_for_style_inverse_methods.md
+++ b/changelog/fix_remove_redundant_config_for_style_inverse_methods.md
@@ -1,0 +1,1 @@
+* [#941](https://github.com/rubocop/rubocop-rails/issues/941): Remove redundant config for `Style/InverseMethods`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1142,15 +1142,6 @@ Style/FormatStringToken:
   AllowedMethods:
     - redirect
 
-Style/InverseMethods:
-  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
-  # The relationship of inverse methods only needs to be defined in one direction.
-  # Keys and values both need to be defined as symbols.
-  InverseMethods:
-    :present?: :blank?
-    :include?: :exclude?
-    :valid?: :invalid?
-
 Style/SymbolProc:
   AllowedMethods:
     - define_method


### PR DESCRIPTION
Fixes #941.

This PR removes redundant config for `Style/InverseMethods`. So each invert rule was already supported by the following cops.

- `Rails/Present` cop ... `present?` / `blank?`
- `Rails/NegateInclude` cop ... `include?` / `exclude?`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
