### PR TITLE
[Fix #934] Fix a false negative for `Rails/Output`

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_output.md
+++ b/changelog/fix_a_false_negative_for_rails_output.md
@@ -1,0 +1,1 @@
+* [#934](https://github.com/rubocop/rubocop-rails/issues/934): Fix a false negative for `Rails/Output` when print methods without arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/output.rb
+++ b/lib/rubocop/cop/rails/output.rb
@@ -39,7 +39,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless (output?(node) || io_output?(node)) && node.arguments?
+          return if node.parent&.call_type?
+          return unless output?(node) || io_output?(node)
 
           range = offense_range(node)
 

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -119,13 +119,31 @@ RSpec.describe RuboCop::Cop::Rails::Output, :config do
     RUBY
   end
 
-  it 'does not record an offense for methods without arguments' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense for methods without arguments' do
+    expect_offense(<<~RUBY)
       print
+      ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       pp
+      ^^ Do not write to stdout. Use Rails's logger if you want to log.
       puts
+      ^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       $stdout.write
+      ^^^^^^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       STDERR.write
+      ^^^^^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+  end
+
+  it 'does not register an offense when a method is called to a local variable with the same name as a print method' do
+    expect_no_offenses(<<~RUBY)
+      p.do_something
+    RUBY
+  end
+
+  it 'does not register an offense when a method is ' \
+     'safe navigation called to a local variable with the same name as a print method' do
+    expect_no_offenses(<<~RUBY)
+      p&.do_something
     RUBY
   end
 


### PR DESCRIPTION
Fixes #934.

This PR fixes a false negative for `Rails/Output` when print methods without arguments.

https://github.com/rubocop/rubocop/issues/1184 reported the following problem, but it seems that it was mistakenly updated to allow no argument cases.

```console
expect(p.arity).to be 1
       ^
spec/models/cco/blog_cco2_spec.rb:46:16: C: Do not write to stdout. Use Rails' logger if you want to log.
```

It seems that https://github.com/rubocop/rubocop/pull/6829 has since used that mistake. So this PR steers `Rails/Output` back to its original intent.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
