### PR TITLE
[Fix #472] Fix incompatible suggestion message for `Rails/FilePath`

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -3,34 +3,43 @@
 module RuboCop
   module Cop
     module Rails
-      # Identifies usages of file path joining process
-      # to use `Rails.root.join` clause. It is used to add uniformity when
-      # joining paths.
+      # Identifies usages of file path joining process to use `Rails.root.join` clause.
+      # It is used to add uniformity when joining paths.
       #
       # @example EnforcedStyle: slashes (default)
       #   # bad
       #   Rails.root.join('app', 'models', 'goober')
+      #
+      #   # good
+      #   Rails.root.join('app/models/goober')
+      #
+      #   # bad
       #   File.join(Rails.root, 'app/models/goober')
       #   "#{Rails.root}/app/models/goober"
       #
       #   # good
-      #   Rails.root.join('app/models/goober')
+      #   Rails.root.join('app/models/goober').to_s
       #
       # @example EnforcedStyle: arguments
       #   # bad
       #   Rails.root.join('app/models/goober')
+      #
+      #   # good
+      #   Rails.root.join('app', 'models', 'goober')
+      #
+      #   # bad
       #   File.join(Rails.root, 'app/models/goober')
       #   "#{Rails.root}/app/models/goober"
       #
       #   # good
-      #   Rails.root.join('app', 'models', 'goober')
+      #   Rails.root.join('app', 'models', 'goober').to_s
       #
       class FilePath < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
 
-        MSG_SLASHES = 'Prefer `Rails.root.join(\'path/to\')`.'
-        MSG_ARGUMENTS = 'Prefer `Rails.root.join(\'path\', \'to\')`.'
+        MSG_SLASHES = 'Prefer `Rails.root.join(\'path/to\')%<to_s>s`.'
+        MSG_ARGUMENTS = 'Prefer `Rails.root.join(\'path\', \'to\')%<to_s>s`.'
         RESTRICT_ON_SEND = %i[join].freeze
 
         def_node_matcher :file_join_nodes?, <<~PATTERN
@@ -53,7 +62,7 @@ module RuboCop
           return unless last_child_source.start_with?('.') || last_child_source.include?(File::SEPARATOR)
           return if last_child_source.start_with?(':')
 
-          register_offense(node)
+          register_offense(node, require_to_s: true)
         end
 
         def on_send(node)
@@ -68,7 +77,7 @@ module RuboCop
           return unless file_join_nodes?(node)
           return unless node.arguments.any? { |e| rails_root_nodes?(e) }
 
-          register_offense(node)
+          register_offense(node, require_to_s: true)
         end
 
         def check_for_rails_root_join_with_string_arguments(node)
@@ -78,7 +87,7 @@ module RuboCop
           return unless node.arguments.size > 1
           return unless node.arguments.all?(&:str_type?)
 
-          register_offense(node)
+          register_offense(node, require_to_s: false)
         end
 
         def check_for_rails_root_join_with_slash_separated_path(node)
@@ -87,21 +96,26 @@ module RuboCop
           return unless rails_root_join_nodes?(node)
           return unless node.arguments.any? { |arg| string_with_slash?(arg) }
 
-          register_offense(node)
+          register_offense(node, require_to_s: false)
         end
 
         def string_with_slash?(node)
           node.str_type? && node.source.include?('/')
         end
 
-        def register_offense(node)
+        def register_offense(node, require_to_s:)
           line_range = node.loc.column...node.loc.last_column
           source_range = source_range(processed_source.buffer, node.first_line, line_range)
-          add_offense(source_range)
+          message = build_message(require_to_s)
+
+          add_offense(source_range, message: message)
         end
 
-        def message(_range)
-          format(style == :arguments ? MSG_ARGUMENTS : MSG_SLASHES)
+        def build_message(require_to_s)
+          message_template = style == :arguments ? MSG_ARGUMENTS : MSG_SLASHES
+          to_s = require_to_s ? '.to_s' : ''
+
+          format(message_template, to_s: to_s)
         end
       end
     end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, 'app', 'models')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
         RUBY
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           ::File.join(Rails.root, 'app', 'models')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
         RUBY
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
           "#{Rails.root}/app/models/goober"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
         RUBY
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
           system "rm -rf #{Rails.root}/foo/bar"
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
         RUBY
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
           "#{Rails.root.join('tmp', user.id, 'icon')}.png"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
         RUBY
       end
     end
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           foo(bar(File.join(Rails.root, "app", "models")))
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
         RUBY
       end
     end
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, 'app', 'models')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
         RUBY
       end
     end
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
           "#{Rails.root}/app/models/goober"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
         RUBY
       end
     end
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
           system "rm -rf #{Rails.root}/foo/bar"
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to')`.
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
         RUBY
       end
     end
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
           "#{Rails.root.join('tmp', user.id, 'icon')}.png"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to')`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
         RUBY
       end
     end
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           foo(bar(File.join(Rails.root, "app", "models")))
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to')`.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #472.

This PR fixes incompatible suggestion message for `Rails/FilePath` when the return type should be `String` instead of `Pathname`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
