### PR TITLE
[Fix #99] Fix a false positive for `Rails/HttpPositionalArguments`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_http_positional_arguments.md
+++ b/changelog/fix_a_false_positive_for_rails_http_positional_arguments.md
@@ -1,0 +1,1 @@
+* [#99](https://github.com/rubocop/rubocop-rails/issues/99): Fix a false positive for `Rails/HttpPositionalArguments` when using `include Rack::Test::Methods`. ([@koic][])

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -431,5 +431,25 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments, :config do
         end
       RUBY
     end
+
+    context 'when using `include Rack::Test::Methods`' do
+      it 'does not register an offense for get method' do
+        expect_no_offenses(<<~RUBY)
+          include Rack::Test::Methods
+
+          get :create, user_id: @user.id
+        RUBY
+      end
+    end
+
+    context 'when using `include ::Rack::Test::Methods`' do
+      it 'does not register an offense for get method' do
+        expect_no_offenses(<<~RUBY)
+          include ::Rack::Test::Methods
+
+          get :create, user_id: @user.id
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #99.

This PR fixes a false positive for `Rails/HttpPositionalArguments` when using `include Rack::Test::Methods`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
