### PR TITLE
[Fix #940] Mark `Rails/ResponseParsedBody` as unsafe

### DIFF
--- a/changelog/change_mark_rails_response_parsed_body_as_unsafe.md
+++ b/changelog/change_mark_rails_response_parsed_body_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#940](https://github.com/rubocop/rubocop-rails/issues/940): Mark `Rails/ResponseParsedBody` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -842,8 +842,9 @@ Rails/RequireDependency:
 Rails/ResponseParsedBody:
   Description: Prefer `response.parsed_body` to `JSON.parse(response.body)`.
   Enabled: pending
-  SafeAutoCorrect: false
+  Safe: false
   VersionAdded: '2.18'
+  VersionChanged: '<<next>>'
   Include:
     - spec/controllers/**/*.rb
     - spec/requests/**/*.rb

--- a/lib/rubocop/cop/rails/response_parsed_body.rb
+++ b/lib/rubocop/cop/rails/response_parsed_body.rb
@@ -6,9 +6,9 @@ module RuboCop
       # Prefer `response.parsed_body` to `JSON.parse(response.body)`.
       #
       # @safety
-      #   This cop's autocorrection is unsafe because Content-Type may not be `application/json`. For example, the
-      #   proprietary Content-Type provided by corporate entities such as `application/vnd.github+json` is not
-      #   supported at `response.parsed_body` by default, so you still have to use `JSON.parse(response.body)` there.
+      #   This cop is unsafe because Content-Type may not be `application/json`. For example, the proprietary
+      #   Content-Type provided by corporate entities such as `application/vnd.github+json` is not supported at
+      #   `response.parsed_body` by default, so you still have to use `JSON.parse(response.body)` there.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Fixes #940.

This PR marks `Rails/ResponseParsedBody` as unsafe because I was misleading below:
https://github.com/rubocop/rubocop-rails/pull/863#discussion_r1024247356

It's actually unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
