### PR TITLE
[Fix #694] Mark `Rails/FindEach` as unsafe

### DIFF
--- a/changelog/change_mark_rails_find_each_as_unsafe.md
+++ b/changelog/change_mark_rails_find_each_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#694](https://github.com/rubocop/rubocop-rails/issues/694): Mark `Rails/FindEach` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -460,8 +460,9 @@ Rails/FindEach:
   Description: 'Prefer all.find_each over all.each.'
   StyleGuide: 'https://rails.rubystyle.guide#find-each'
   Enabled: true
+  Safe: false
   VersionAdded: '0.30'
-  VersionChanged: '2.9'
+  VersionChanged: '<<next>>'
   Include:
     - app/models/**/*.rb
   AllowedMethods:

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -3,8 +3,12 @@
 module RuboCop
   module Cop
     module Rails
-      # Identifies usages of `all.each` and
-      # change them to use `all.find_each` instead.
+      # Identifies usages of `all.each` and change them to use `all.find_each` instead.
+      #
+      # @safety
+      #   This cop is unsafe if the receiver object is not an Active Record object.
+      #   Also, `all.each` returns an `Array` instance and `all.find_each` returns nil,
+      #   so the return values are different.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Fixes #694 and #397.

This PR marks `Rails/FindEach` as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
