### PR TITLE
[Fix #888] Make `Style/InverseMethods` aware of `exists?`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1150,6 +1150,10 @@ Style/FormatStringToken:
   AllowedMethods:
     - redirect
 
+Style/InverseMethods:
+  InverseMethods:
+    :exists?: :none?
+
 Style/SymbolProc:
   AllowedMethods:
     - define_method


### PR DESCRIPTION
Fixes #888.

This PR makes `Style/InverseMethods` aware of `exists?`. Probably simpler than implementing a new named cop. And there will be no overlap with existing cop as reported in #941.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
