### PR TITLE
[Fix #45] Make `Rails/Delegate` aware of `self`

### DIFF
--- a/changelog/new_make_rails_delegate_aware_of_self.md
+++ b/changelog/new_make_rails_delegate_aware_of_self.md
@@ -1,0 +1,1 @@
+* [#45](https://github.com/rubocop/rubocop-rails/issues/45): Make `Rails/Delegate` aware of `self`. ([@koic][])

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -2,10 +2,6 @@
 
 RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
   let(:cop_config) { { 'EnforceForPrefixed' => true } }
-  let(:config) do
-    merged = RuboCop::ConfigLoader.default_configuration['Rails/Delegate'].merge(cop_config)
-    RuboCop::Config.new('Rails/Delegate' => merged)
-  end
 
   it 'finds trivial delegate' do
     expect_offense(<<~RUBY)
@@ -33,6 +29,19 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
     RUBY
   end
 
+  it 'finds trivial delegate to `self`' do
+    expect_offense(<<~RUBY)
+      def foo
+      ^^^ Use `delegate` to define delegations.
+        self.foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      delegate :foo, to: self
+    RUBY
+  end
+
   it 'finds trivial delegate with prefix' do
     expect_offense(<<~RUBY)
       def bar_foo
@@ -43,6 +52,19 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
 
     expect_correction(<<~RUBY)
       delegate :foo, to: :bar, prefix: true
+    RUBY
+  end
+
+  it 'finds trivial delegate to `self` when underscored method' do
+    expect_offense(<<~RUBY)
+      def bar_foo
+      ^^^ Use `delegate` to define delegations.
+        self.bar_foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      delegate :bar_foo, to: self
     RUBY
   end
 


### PR DESCRIPTION
Fixes #45.

This PR makes `Rails/Delegate` aware of `self`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
