### PR TITLE
[Fix #34] Allow `CreateTableWithTimestamps` when using `id: false` and not include `timestamps`

### DIFF
--- a/changelog/change_allow_create_table_with_timestamps_for_id_false.md
+++ b/changelog/change_allow_create_table_with_timestamps_for_id_false.md
@@ -1,0 +1,1 @@
+* [#34](https://github.com/rubocop/rubocop-rails/issues/34): Allow `CreateTableWithTimestamps` when using `id: false` and not include `timestamps`. ([@koic][])

--- a/lib/rubocop/cop/rails/create_table_with_timestamps.rb
+++ b/lib/rubocop/cop/rails/create_table_with_timestamps.rb
@@ -3,9 +3,11 @@
 module RuboCop
   module Cop
     module Rails
-      # Checks the migration for which timestamps are not included
-      # when creating a new table.
+      # Checks the migration for which timestamps are not included when creating a new table.
       # In many cases, timestamps are useful information and should be added.
+      #
+      # NOTE: Allow `timestamps` not written when `id: false` because this emphasizes respecting
+      # user's editing intentions.
       #
       # @example
       #   # bad
@@ -40,11 +42,22 @@ module RuboCop
       #
       #     t.datetime :updated_at, default: -> { 'CURRENT_TIMESTAMP' }
       #   end
+      #
+      #   # good
+      #   create_table :users, articles, id: false do |t|
+      #     t.integer :user_id
+      #     t.integer :article_id
+      #   end
+      #
       class CreateTableWithTimestamps < Base
         include ActiveRecordMigrationsHelper
 
         MSG = 'Add timestamps when creating a new table.'
         RESTRICT_ON_SEND = %i[create_table].freeze
+
+        def_node_search :use_id_false_option?, <<~PATTERN
+          (pair (sym :id) (false))
+        PATTERN
 
         def_node_matcher :create_table_with_timestamps_proc?, <<~PATTERN
           (send nil? :create_table (sym _) ... (block-pass (sym :timestamps)))
@@ -61,7 +74,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless node.command?(:create_table)
+          return if !node.command?(:create_table) || use_id_false_option?(node)
 
           parent = node.parent
 

--- a/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
+++ b/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
@@ -108,4 +108,13 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when using `id: false` option and not including `timestamps` in block' do
+    expect_no_offenses(<<~RUBY)
+      create_table :users, :articles, id: false do |t|
+        t.integer :user_id
+        t.integer :article_id
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #34.

This PR allows `CreateTableWithTimestamps` when using `id: false` and not include `timestamps`.

There are design arguments for both allowing and disallowing migration file has `timestamps` when `id: false` (join table) . For the following reasons, allow it when `id: false`:

For example, when running `bin/rails g migration create_articles`, the migration file containing `timestamps` is created by default. Perhaps editing `id: false` and removing `timestamps` will be intentional. On the other hand, if it is not intentionally deleted, it will remain.

So I think that it is possible to allow the behavior that `timestamps` is not written for `id: false`. This emphasizes respecting user's editing intentions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
