### PR TITLE
[Fix #501] Fix a false positive for `Rails/OutputSafety`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_output_safety.md
+++ b/changelog/fix_a_false_positive_for_rails_output_safety.md
@@ -1,0 +1,1 @@
+* [#501](https://github.com/rubocop/rubocop-rails/issues/501): Fix a false positive for `Rails/OutputSafety` when using `html_safe` for `I18n` methods. ([@koic][])

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -66,8 +66,12 @@ module RuboCop
         MSG = 'Tagging a string as html safe may be a security risk.'
         RESTRICT_ON_SEND = %i[html_safe raw safe_concat].freeze
 
+        def_node_search :i18n_method?, <<~PATTERN
+          (send {nil? (const {nil? cbase} :I18n)} {:t :translate :l :localize} ...)
+        PATTERN
+
         def on_send(node)
-          return if non_interpolated_string?(node)
+          return if non_interpolated_string?(node) || i18n_method?(node)
 
           return unless looks_like_rails_html_safe?(node) ||
                         looks_like_rails_raw?(node) ||

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -130,5 +130,57 @@ RSpec.describe RuboCop::Cop::Rails::OutputSafety, :config do
                        ^^^ Tagging a string as html safe may be a security risk.
       RUBY
     end
+
+    it 'does not register an offense when using `html_safe` for `I18n.t` method' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t('foo.bar.baz', scope: [:x, :y, :z]).html_safe
+        ::I18n.t('foo.bar.baz', scope: [:x, :y, :z]).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `I18n.translate` method' do
+      expect_no_offenses(<<~RUBY)
+        I18n.translate('foo.bar.baz', scope: [:x, :y, :z]).html_safe
+        ::I18n.translate('foo.bar.baz', scope: [:x, :y, :z]).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `t` method' do
+      expect_no_offenses(<<~RUBY)
+        t('foo.bar.baz').html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `translate` method' do
+      expect_no_offenses(<<~RUBY)
+        translate('foo.bar.baz').html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `I18n.l` method' do
+      expect_no_offenses(<<~RUBY)
+        I18n.l(Time.now, locale: :de).html_safe
+        ::I18n.l(Time.now, locale: :de).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `I18n.localize` method' do
+      expect_no_offenses(<<~RUBY)
+        I18n.localize(Time.now, locale: :de).html_safe
+        ::I18n.localize(Time.now, locale: :de).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `l` method' do
+      expect_no_offenses(<<~RUBY)
+        l(Time.now).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `html_safe` for `localize` method' do
+      expect_no_offenses(<<~RUBY)
+        localize(Time.now).html_safe
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #501.

This PR fixes a false positive for `Rails/OutputSafety` when using `html_safe` for `I18n` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
