### PR TITLE
[Fix #979] Fix an error for `Rails/ThreeStateBooleanColumn`

### DIFF
--- a/changelog/fix_an_error_for_rails_three_state_boolean.md
+++ b/changelog/fix_an_error_for_rails_three_state_boolean.md
@@ -1,0 +1,1 @@
+* [#979](https://github.com/rubocop/rubocop-rails/issues/979): Fix an error for `Rails/ThreeStateBooleanColumn` when using `t.boolean` in `drop_table`. ([@koic][])

--- a/lib/rubocop/cop/rails/three_state_boolean_column.rb
+++ b/lib/rubocop/cop/rails/three_state_boolean_column.rb
@@ -46,7 +46,9 @@ module RuboCop
 
             def_node = node.each_ancestor(:def, :defs).first
             table_node = table_node(node)
-            return if def_node && change_column_null?(def_node, table_node.value, column_node.value)
+            if def_node && (table_node.nil? || change_column_null?(def_node, table_node.value, column_node.value))
+              return
+            end
 
             add_offense(node)
           end

--- a/spec/rubocop/cop/rails/three_state_boolean_column_spec.rb
+++ b/spec/rubocop/cop/rails/three_state_boolean_column_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `t.boolean` in `drop_table`' do
+      expect_no_offenses(<<~RUBY)
+        def change
+          drop_table(:users) do |t|
+            t.boolean :active
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using `#change_column_null`' do
       expect_no_offenses(<<~RUBY)
         def change


### PR DESCRIPTION
Fixes #979.

This PR fixes an error for `Rails/ThreeStateBooleanColumn` when using `t.boolean` in `drop_table`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
