### PR TITLE
Config to ignore old migrations for `Rails/ThreeStateBooleanColumn`

### DIFF
--- a/changelog/change_config_rails_three_state_boolean.md
+++ b/changelog/change_config_rails_three_state_boolean.md
@@ -1,0 +1,1 @@
+* [#985](https://github.com/rubocop/rubocop-rails/pull/985): Add `StartAfter` config for `Rails/ThreeStateBooleanColumn` to ignore old migrations. ([@toydestroyer][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1002,6 +1002,7 @@ Rails/ThreeStateBooleanColumn:
   StyleGuide: 'https://rails.rubystyle.guide/#three-state-boolean'
   Enabled: pending
   VersionAdded: '2.19'
+  StartAfter: 0
   Include:
     - db/**/*.rb
 

--- a/spec/rubocop/cop/rails/three_state_boolean_column_spec.rb
+++ b/spec/rubocop/cop/rails/three_state_boolean_column_spec.rb
@@ -150,4 +150,31 @@ RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
       RUBY
     end
   end
+
+  context 'with StartAfter config' do
+    let(:cop_config) do
+      { 'StartAfter' => '20230415000000' }
+    end
+
+    it 'does not register an offense for old files' do
+      expect_no_offenses(<<~RUBY, 'db/migrate/20230414000000_create_users.rb')
+        class CreateUsers < ActiveRecord::Migration[7.0]
+          create_table(:users) do |t|
+            t.boolean :active
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for new files' do
+      expect_offense(<<~RUBY, 'db/migrate/20230415000000_create_users.rb')
+        class CreateUsers < ActiveRecord::Migration[7.0]
+          create_table(:users) do |t|
+            t.boolean :active
+            ^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Hello, first-time contributor here 👋

I noticed that the `Rails/ThreeStateBooleanColumn` cop reports offenses in old migrations. And as mentioned by @mvz in https://github.com/rubocop/rubocop-rails/discussions/982, fixing these offenses in existing migrations is not practical. Currently, the only way to address this issue is to exclude all offending migrations in the config file, which can add unnecessary noise.

To improve this situation, I propose adding a configuration option for this cop that ignores offenses occurring before a specified migration version. This approach is inspired by the [strong_migrations](https://github.com/ankane/strong_migrations#existing-migrations) gem. The configuration would look like this:

```yml
Rails/ThreeStateBooleanColumn:
  StartAfter: 20230415000000 # 0 by default
```

I'm open to suggestions for a better name for this configuration option. For now, I've used the name from strong_migrations.

Please let me know if you have any feedback or suggestions for improvement. I'm looking forward to your input and would be happy to make any necessary changes.

Thank you!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
