### PR TITLE
Add autocorrection for `Rails/IgnoredSkipActionFilterOption`

### DIFF
--- a/changelog/new_add_autocorrection_for_rails_ignored_skip_action_filter_option.md
+++ b/changelog/new_add_autocorrection_for_rails_ignored_skip_action_filter_option.md
@@ -1,0 +1,1 @@
+* [#988](https://github.com/rubocop/rubocop-rails/pull/988): Add autocorrection for `Rails/IgnoredSkipActionFilterOption`. ([@r7kamura][])

--- a/spec/rubocop/cop/rails/ignored_skip_action_filter_option_spec.rb
+++ b/spec/rubocop/cop/rails/ignored_skip_action_filter_option_spec.rb
@@ -6,12 +6,20 @@ RSpec.describe RuboCop::Cop::Rails::IgnoredSkipActionFilterOption, :config do
       skip_before_action :login_required, only: :show, if: :trusted_origin?
                                                        ^^^^^^^^^^^^^^^^^^^^ `if` option will be ignored when `only` and `if` are used together.
     RUBY
+
+    expect_correction(<<~RUBY)
+      skip_before_action :login_required, only: :show
+    RUBY
   end
 
   it 'registers an offense when `if` and `except` are used together' do
     expect_offense(<<~RUBY)
       skip_before_action :login_required, except: :admin, if: :trusted_origin?
                                           ^^^^^^^^^^^^^^ `except` option will be ignored when `if` and `except` are used together.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      skip_before_action :login_required, if: :trusted_origin?
     RUBY
   end
 


### PR DESCRIPTION
If what the message says is true, this autocorrection will not change the behavior and is a safe autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
