### PR TITLE
Fix `Rails/FilePath` to detect offenses from complex string interpolation

### DIFF
--- a/changelog/fix_rails_file_path_to_detect_offenses_from_complex_string_interpolation.md
+++ b/changelog/fix_rails_file_path_to_detect_offenses_from_complex_string_interpolation.md
@@ -1,0 +1,1 @@
+* [#989](https://github.com/rubocop/rubocop-rails/pull/989): Fix `Rails/FilePath` to detect offenses from complex string interpolation. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -56,11 +56,8 @@ module RuboCop
 
         def on_dstr(node)
           return unless rails_root_nodes?(node)
-          return unless node.children.last.str_type?
-
-          last_child_source = node.children.last.source
-          return unless last_child_source.start_with?('.') || last_child_source.include?(File::SEPARATOR)
-          return if last_child_source.start_with?(':')
+          return if dstr_separated_by_colon?(node)
+          return unless dstr_ending_with_file_extension?(node) || dstr_including_file_separator?(node)
 
           register_offense(node, require_to_s: true)
         end
@@ -118,6 +115,22 @@ module RuboCop
           to_s = require_to_s ? '.to_s' : ''
 
           format(message_template, to_s: to_s)
+        end
+
+        def dstr_ending_with_file_extension?(node)
+          node.children.last.str_type? && node.children.last.source.start_with?('.')
+        end
+
+        def dstr_including_file_separator?(node)
+          node.children.any? do |child|
+            child.str_type? && child.source.include?(File::SEPARATOR)
+          end
+        end
+
+        def dstr_separated_by_colon?(node)
+          node.children[1..].any? do |child|
+            child.str_type? && child.source.start_with?(':')
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when using Rails.root called by double quoted string that ends with string interpolation' do
+      it 'registers an offense' do
+        expect_offense(<<~'RUBY')
+          "#{Rails.root}/a/#{b}"
+          ^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to')`.
+        RUBY
+      end
+    end
+
     context 'when concat Rails.root and file separator using string interpolation' do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')


### PR DESCRIPTION
So far, this cop has only detected offenses from dstr nodes that end with str node, but I think there are offenses that would be missed if it did so. Therefore, I have changed the `#on_dstr` implementation to detect offenses even in examples such as the one I have added as a test case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
