### PR TITLE
Fix `require_to_s` usage on dstr cases

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -62,7 +62,7 @@ module RuboCop
           return unless last_child_source.start_with?('.') || last_child_source.include?(File::SEPARATOR)
           return if last_child_source.start_with?(':')
 
-          register_offense(node, require_to_s: true)
+          register_offense(node, require_to_s: false)
         end
 
         def on_send(node)
@@ -106,7 +106,6 @@ module RuboCop
         def register_offense(node, require_to_s:)
           line_range = node.loc.column...node.loc.last_column
           source_range = source_range(processed_source.buffer, node.first_line, line_range)
-          require_to_s = false if node.dstr_type?
 
           message = build_message(require_to_s)
 


### PR DESCRIPTION
I noticed that you did not use the argument `require_to_s` passed from `#on_dstr` at https://github.com/rubocop/rubocop-rails/commit/b7ac06bf5675a3209fbbe3ff07ef6cb6f465b323. Wouldn't it be more appropriate to change it this way?