### PR TITLE
Exclude `app/assets/**/*` by default

### DIFF
--- a/changelog/change_exclude_app_assets_by_default.md
+++ b/changelog/change_exclude_app_assets_by_default.md
@@ -1,0 +1,1 @@
+* [#992](https://github.com/rubocop/rubocop-rails/pull/992): Exclude `app/assets/**/*` by default. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ inherit_mode:
 
 AllCops:
   Exclude:
+    - app/assets/**/*
     - bin/*
     # Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default.
     # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application


### PR DESCRIPTION
This change is for the same reason as the following issue:

- https://github.com/rubocop/rubocop-rails/issues/796

In a typical Rails application, this directory often contains a large number of non-ruby files, and I believe this optimization is reasonable for rubocop-rails to speed things up.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
