### PR TITLE
Restrict DuplicateAssociation cop to ActiveRecord

### DIFF
--- a/changelog/change_restrict_duplicate_association_cop_to.md
+++ b/changelog/change_restrict_duplicate_association_cop_to.md
@@ -1,0 +1,1 @@
+* [#994](https://github.com/rubocop/rubocop-rails/pull/994): Restrict DuplicateAssociation cop to ActiveRecord. ([@mjankowski][])

--- a/lib/rubocop/cop/rails/duplicate_association.rb
+++ b/lib/rubocop/cop/rails/duplicate_association.rb
@@ -24,6 +24,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
         include ClassSendNodeHelper
+        include ActiveRecordHelper
 
         MSG = "Association `%<name>s` is defined multiple times. Don't repeat associations."
 
@@ -32,6 +33,8 @@ module RuboCop
         PATTERN
 
         def on_class(class_node)
+          return unless active_record?(class_node.parent_class)
+
           offenses(class_node).each do |name, nodes|
             nodes.each do |node|
               add_offense(node, message: format(MSG, name: name)) do |corrector|

--- a/spec/rubocop/cop/rails/duplicate_association_spec.rb
+++ b/spec/rubocop/cop/rails/duplicate_association_spec.rb
@@ -227,4 +227,15 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
       RUBY
     end
   end
+
+  describe 'a class that does not descend from Active Record' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY)
+        class Post < ActiveModel::Serializer
+          has_many :comments, key: :remarks, if: :formal_mode?
+          has_many :comments, key: :rejoinders, if: :debate_mode?
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Previously this cop would run against all classes, which led to false positives when the class was not descended from `ActiveRecord::Base` and thus might have acceptable use cases for repeating association declarations in ways that would not be acceptable in AR classes.