### PR TITLE
Fix a false positive for Rails/NotNullColumn when adding a :json columns

### DIFF
--- a/changelog/fix_not_null_column_to_accept_json_columns.md
+++ b/changelog/fix_not_null_column_to_accept_json_columns.md
@@ -1,0 +1,1 @@
+* [#996](https://github.com/rubocop/rubocop-rails/pull/996): Fix a false positive for `Rails/NotNullColumn` when adding a `:json` column. ([@RayYokoyama][])

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -46,6 +46,7 @@ module RuboCop
         def check_add_column(node)
           add_not_null_column?(node) do |type, pairs|
             return if type.value == :virtual || type.value == 'virtual'
+            return if type.value == :json || type.value == 'json'
 
             check_pairs(pairs)
           end

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
           add_column :users, :height_in, 'virtual', as: "height_cm / 2.54", null: false, default: nil
         RUBY
       end
+
+      it 'does not register an offense for json columns' do
+        expect_no_offenses(<<~RUBY)
+          add_column :users, :metadata, :json, null: false
+        RUBY
+      end
     end
 
     context 'with null: true' do


### PR DESCRIPTION
When adding a json column, Rails/NotNullColumn is notified, but according to [the documentation](https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html#data-types-defaults-explicit), a default value cannot be set for a json column.
> The BLOB, TEXT, GEOMETRY, and JSON data types cannot be assigned a default value.

Fix to pass cop when adding json columns.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
