### PR TITLE
[Fix #997] Allow NotNullColumn to work with method calls

### DIFF
--- a/changelog/fix_not_allow_not_null_to_work_with_methods_and_variables.md
+++ b/changelog/fix_not_allow_not_null_to_work_with_methods_and_variables.md
@@ -1,0 +1,1 @@
+* [#997](https://github.com/rubocop/rubocop-rails/issues/997): Fix to Allow `NotNullColumn` to work with method calls and variables. ([@fidalgo][])

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         def check_add_column(node)
           add_not_null_column?(node) do |type, pairs|
-            return if type.value == :virtual || type.value == 'virtual'
+            return if type.respond_to?(:value) && (type.value == :virtual || type.value == 'virtual')
 
             check_pairs(pairs)
           end

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
       end
     end
 
+    context 'with the type argument is a variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          add_column(:users, :name, type, default: 'default')
+        RUBY
+      end
+    end
+
     context 'with null: false and default: nil' do
       it 'reports an offense' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
At the NotNullColumn cop if a method is passed as arguments for `add_column` an error is triggered:
```
NoMethodError:
  undefined method `value' for s(:send, nil, :string):RuboCop::AST::SendNode
```

In this commit, we check if the argument is a method and when positive we return its name as a String.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
