### PR TITLE
Add autocorrection for `Rails/Date`

### DIFF
--- a/changelog/new_add_autocorrection_for_rails_date.md
+++ b/changelog/new_add_autocorrection_for_rails_date.md
@@ -1,0 +1,1 @@
+* [#999](https://github.com/rubocop/rubocop-rails/pull/999): Add autocorrection for `Rails/Date`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -283,6 +283,7 @@ Rails/Date:
                   Checks the correct usage of date aware methods,
                   such as Date.today, Date.current etc.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.30'
   VersionChanged: '2.11'
   # The value `strict` disallows usage of `Date.today`, `Date.current`,

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
           date.to_time_in_current_zone
                ^^^^^^^^^^^^^^^^^^^^^^^ `to_time_in_current_zone` is deprecated. Use `in_time_zone` instead.
         RUBY
+
+        expect_correction(<<~RUBY)
+          date.in_time_zone
+        RUBY
       end
 
       context 'when using safe navigation operator' do
@@ -61,6 +65,10 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
           expect_offense(<<~RUBY)
             date&.to_time_in_current_zone
                   ^^^^^^^^^^^^^^^^^^^^^^^ `to_time_in_current_zone` is deprecated. Use `in_time_zone` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            date&.in_time_zone
           RUBY
         end
       end
@@ -137,6 +145,8 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
             date.to_time
                  ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
           RUBY
+
+          expect_no_corrections
         end
 
         context 'when using safe navigation operator' do
@@ -145,6 +155,8 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
               date&.to_time
                     ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
             RUBY
+
+            expect_no_corrections
           end
         end
 
@@ -162,6 +174,8 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
               "2016-07-12 14:36:31".to_time(:utc)
                                     ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
             RUBY
+
+            expect_no_corrections
           end
         end
 
@@ -189,6 +203,10 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
         "2016-07-12 14:36:31".to_time_in_current_zone
                               ^^^^^^^^^^^^^^^^^^^^^^^ `to_time_in_current_zone` is deprecated. Use `in_time_zone` instead.
       RUBY
+
+      expect_correction(<<~RUBY)
+        "2016-07-12 14:36:31".in_time_zone
+      RUBY
     end
   end
 
@@ -206,6 +224,21 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
         Date.today
              ^^^^^ Do not use `Date.today` without zone. Use `Time.zone.today` instead.
       RUBY
+
+      expect_correction(<<~RUBY)
+        Time.zone.today
+      RUBY
+    end
+
+    it 'registers an offense for ::Date.today' do
+      expect_offense(<<~RUBY)
+        ::Date.today
+               ^^^^^ Do not use `Date.today` without zone. Use `Time.zone.today` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::Time.zone.today
+      RUBY
     end
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
@@ -218,6 +251,10 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
       expect_offense(<<~RUBY)
         "2016-07-12 14:36:31".to_time_in_current_zone
                               ^^^^^^^^^^^^^^^^^^^^^^^ `to_time_in_current_zone` is deprecated. Use `in_time_zone` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "2016-07-12 14:36:31".in_time_zone
       RUBY
     end
   end


### PR DESCRIPTION
For the same reason as `Rails/TimeZone`, this autocorrection is unsafe.

As you can see where `expect_no_corrections`s are added, I could not provide autocorrection for the rule that considers `to_time` as a violation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
