### PR TITLE
Change `Rails/RootPathnameMethods` to detect offenses on `Dir.[]`

### DIFF
--- a/changelog/change_rails_root_pathname_methods_to_detect_offenses_on_dir_index.md
+++ b/changelog/change_rails_root_pathname_methods_to_detect_offenses_on_dir_index.md
@@ -1,0 +1,1 @@
+* [#1003](https://github.com/rubocop/rubocop-rails/pull/1003): Change `Rails/RootPathnameMethods` to detect offenses on `Dir.[]`. ([@r7kamura][])


### PR DESCRIPTION
Added support for `Dir.[]`.

One of the most commonly used example of this pattern is the following code, generated by rspec-rails gem:

```ruby
# bad
Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }

# good
Rails.root.glob('spec/support/**/*.rb').each { |f| require f }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
