### PR TITLE
Fix a false-positive for `Rails/RootPathnameMethods` on Ruby 2.4 or lower

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_root_pathname_methods_on_ruby_2_4.md
+++ b/changelog/fix_a_false_positive_for_rails_root_pathname_methods_on_ruby_2_4.md
@@ -1,0 +1,1 @@
+* [#1004](https://github.com/rubocop/rubocop-rails/pull/1004): Fix a false-positive for `Rails/RootPathnameMethods` on Ruby 2.4 or lower. ([@r7kamura][])

--- a/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
+++ b/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
@@ -46,7 +46,15 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     end
   end
 
-  context 'when using `Dir.glob`' do
+  context 'when using `Dir.glob` on Ruby 2.4 or lower', :ruby24 do
+    it 'does not registers an offense' do
+      expect_no_offenses(<<~RUBY)
+        Dir.glob(Rails.root.join('**/*.rb'))
+      RUBY
+    end
+  end
+
+  context 'when using `Dir.glob` on Ruby 2.5 or higher', :ruby25 do
     it "registers an offense when using `Dir.glob(Rails.root.join('**/*.rb'))`" do
       expect_offense(<<~RUBY)
         Dir.glob(Rails.root.join('**/*.rb'))


### PR DESCRIPTION
`Pathname#glob` was added at Ruby 2.5, so it cannot be used on Ruby 2.4 or lower versions.

For example, this false-positive becomes a problem when a gem that uses RuboCop wants to provide code that also supports Ruby 2.4-.

```
$ ruby --version
ruby 2.4.10p364 (2020-03-31 revision 67879) [x86_64-linux]
$ ruby -r pathname -e "Pathname.new('foo').glob('*')"
-e:1:in `<main>': undefined method `glob' for #<Pathname:foo> (NoMethodError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
