### PR TITLE
Fix `Rails/UniquenessValidationWithoutIndex` false positive on explicit disable

### DIFF
--- a/changelog/fix_uniqueness_validation_without_index_explicit_disable_false_positive.md
+++ b/changelog/fix_uniqueness_validation_without_index_explicit_disable_false_positive.md
@@ -1,0 +1,1 @@
+* [#1008](https://github.com/rubocop/rubocop-rails/pull/1008): Fix `UniqueValidationWithoutIndex` to not detect offenses when a validation specifies `uniqueness: false`. ([@samrjenkins][])

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -31,7 +31,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[validates].freeze
 
         def on_send(node)
-          return unless uniqueness_part(node)
+          return if uniqueness_part(node).falsey_literal?
           return if condition_part?(node)
           return unless schema
 

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates :account, uniqueness: false
+          end
+        RUBY
+      end
     end
 
     context 'when the table has an index but it is not unique' do


### PR DESCRIPTION
Fixes: `Rails/UniqueValidationWithoutIndex`

Currently `validates :column_name, uniqueness: false` will report an offence if the schema does not specify a unique index for the corresponding database column. The cop is currently insensitive to the value of the `:uniqueness` option. Any value (including falsy `false` and `nil`) will cause this cop to expect a unique index in the schema.

This pull request fixes this behaviour such that we will now only report offences when the value of the `:uniqueness` option is truthy.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
