### PR TITLE
Make `Lint/RedundantSafeNavigation` aware of several methods

### DIFF
--- a/changelog/change_make_lint_redundant_safe_navigation_aware_of_several_methods.md
+++ b/changelog/change_make_lint_redundant_safe_navigation_aware_of_several_methods.md
@@ -1,0 +1,1 @@
+* [#1014](https://github.com/rubocop/rubocop-rails/pull/1014): Make `Lint/RedundantSafeNavigation` aware of `blank?`, `presence`, and `present?` methods. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -48,6 +48,20 @@ Lint/NumberConversion:
     - in_milliseconds
   AllowedPatterns: []
 
+Lint/RedundantSafeNavigation:
+  # Add `blank?`, `presence`, and `present?` methods to the default of the RuboCop core.
+  # https://github.com/rubocop/rubocop/blob/v1.51.0/config/default.yml#L2148-L2159
+  AllowedMethods:
+    - instance_of?
+    - kind_of?
+    - is_a?
+    - eql?
+    - respond_to?
+    - equal?
+    - blank?
+    - presence
+    - present?
+
 Rails:
   Enabled: true
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails


### PR DESCRIPTION
This PR makes `Lint/RedundantSafeNavigation` aware of `blank?`, `presence`, and `present?` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
