### PR TITLE
Fix an error for `Rails/UniqueValidationWithoutIndex`

### DIFF
--- a/changelog/fix_an_error_for_rails_unique_validation_without_index.md
+++ b/changelog/fix_an_error_for_rails_unique_validation_without_index.md
@@ -1,0 +1,1 @@
+* [#1021](https://github.com/rubocop/rubocop-rails/pull/1021): Fix an error for `Rails/UniqueValidationWithoutIndex`. ([@ydah][])

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -31,7 +31,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[validates].freeze
 
         def on_send(node)
-          return if uniqueness_part(node).falsey_literal?
+          return if uniqueness_part(node)&.falsey_literal?
           return if condition_part?(node)
           return unless schema
 

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -2,12 +2,24 @@
 
 RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
   context 'without db/schema.rb' do
-    it 'does nothing' do
-      expect_no_offenses(<<~RUBY)
-        class User < ApplicationRecord
-          validates :account, uniqueness: true
-        end
-      RUBY
+    context 'when using `uniqueness: true`' do
+      it 'does nothing' do
+        expect_no_offenses(<<~RUBY)
+          class User < ApplicationRecord
+            validates :account, uniqueness: true
+          end
+        RUBY
+      end
+    end
+
+    context 'when using other validation helpers' do
+      it 'does nothing' do
+        expect_no_offenses(<<~RUBY)
+          class User < ApplicationRecord
+            validates :name, presence: true
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This PR is fix an error for `Rails/UniqueValidationWithoutIndex`.

Code to reproduce in `models/**/*.rb`:
```ruby
validates :name, presence: true
```

Occurred Error:
```
An error occurred while Rails/UniqueValidationWithoutIndex cop was inspecting /Users/ydah/test/app/models/test.rb:18:2.
undefined method `falsey_literal?' for nil:NilClass
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-rails-2.20.0/lib/rubocop/cop/rails/unique_validation_without_index.rb:34:in `on_send'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:143:in `public_send'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:143:in `block (2 levels) in trigger_restricted_cops'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:171:in `with_cop_error_handling'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:142:in `block in trigger_restricted_cops'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:141:in `each'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:141:in `trigger_restricted_cops'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:70:in `on_send'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:137:in `block in on_dstr'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:137:in `each'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:137:in `on_dstr'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:71:in `on_begin'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:154:in `on_class'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:71:in `on_class'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:20:in `walk'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/commissioner.rb:87:in `investigate'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/team.rb:156:in `investigate_partial'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cop/team.rb:98:in `investigate'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:345:in `block in inspect_file'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:344:in `each'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:344:in `flat_map'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:344:in `inspect_file'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:287:in `block in do_inspection_loop'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:321:in `block in iterate_until_no_changes'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:314:in `loop'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:314:in `iterate_until_no_changes'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:283:in `do_inspection_loop'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:164:in `block in file_offenses'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:189:in `file_offense_cache'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:163:in `file_offenses'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:154:in `process_file'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:135:in `block in each_inspected_file'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:134:in `each'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:134:in `reduce'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:134:in `each_inspected_file'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:120:in `inspect_files'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/runner.rb:73:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli/command.rb:11:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli/environment.rb:18:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli.rb:118:in `run_command'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli.rb:125:in `execute_runners'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli.rb:51:in `block in run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli.rb:77:in `profile_if_needed'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/lib/rubocop/cli.rb:43:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/exe/rubocop:19:in `block in <top (required)>'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/3.0.0/benchmark.rb:308:in `realtime'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-1.52.1/exe/rubocop:19:in `<top (required)>'
/Users/ydah/.rbenv/versions/3.0.4/bin/rubocop:25:in `load'
/Users/ydah/.rbenv/versions/3.0.4/bin/rubocop:25:in `<top (required)>'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/cli/exec.rb:58:in `load'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/cli/exec.rb:58:in `kernel_load'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/cli/exec.rb:23:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/cli.rb:491:in `exec'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/cli.rb:34:in `dispatch'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/cli.rb:28:in `start'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/exe/bundle:45:in `block in <top (required)>'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/Users/ydah/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/bundler-2.4.3/exe/bundle:33:in `<top (required)>'
/Users/ydah/.rbenv/versions/3.0.4/bin/bundle:25:in `load'
/Users/ydah/.rbenv/versions/3.0.4/bin/bundle:25:in `<main>'
```

bundle exec rubocop -V
```
1.52.1 (using Parser 3.2.2.3, rubocop-ast 1.29.0, running on ruby 3.0.4) [x86_64-darwin21]
  - rubocop-capybara 2.18.0
  - rubocop-factory_bot 2.23.1
  - rubocop-performance 1.18.0
  - rubocop-rails 2.20.0
  - rubocop-rspec 2.22.0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
