### PR TITLE
Fix an error for `Rails/UniqueValidationWithoutIndex`

### DIFF
--- a/changelog/fix_an_error_for_rails_unique_validation_without_index.md
+++ b/changelog/fix_an_error_for_rails_unique_validation_without_index.md
@@ -1,0 +1,1 @@
+* [#1028](https://github.com/rubocop/rubocop-rails/pull/1028): Fix an error for `Rails/UniqueValidationWithoutIndex` when the `presence: true` option is used alone for the `validates` method. ([@koic][])

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         end
       RUBY
 
-      it 'registers an offense' do
+      it 'registers an offense when `uniqueness: true`' do
         expect_offense(<<~RUBY)
           class User
             validates :account, uniqueness: true
@@ -45,10 +45,18 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         RUBY
       end
 
-      it 'does not register an offense' do
+      it 'does not register an offense when `uniqueness: false`' do
         expect_no_offenses(<<~RUBY)
           class User
             validates :account, uniqueness: false
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when `uniqueness: nil`' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates :account, uniqueness: nil
           end
         RUBY
       end
@@ -64,11 +72,19 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         end
       RUBY
 
-      it 'registers an offense' do
+      it 'registers an offense when the `uniqueness: true` option is used alone' do
         expect_offense(<<~RUBY)
           class User
             validates :account, uniqueness: true
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should have a unique index on the database column.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the `presence: true` option is used alone' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates :account, presence: true
           end
         RUBY
       end


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop-rails/issues/1022#issuecomment-1596712691.

This PR fixes an error for `Rails/UniqueValidationWithoutIndex` when the `presence: true` option is used alone for the `validates` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
