### PR TITLE
Fix an error for `UniqueValidationWithoutIndex` when `db/schema.rb` is empty

### DIFF
--- a/changelog/fix_error_for_unique_validation_without_index_when_schema_empty.md
+++ b/changelog/fix_error_for_unique_validation_without_index_when_schema_empty.md
@@ -1,0 +1,1 @@
+* [#1036](https://github.com/rubocop/rubocop-rails/issues/1036): Fix an error for `UniqueValidationWithoutIndex` when `db/schema.rb` is empty. ([@fatkodima][])

--- a/lib/rubocop/rails/schema_loader.rb
+++ b/lib/rubocop/rails/schema_loader.rb
@@ -43,7 +43,7 @@ module RuboCop
         return unless path
 
         ast = parse(path, target_ruby_version)
-        Schema.new(ast)
+        Schema.new(ast) if ast
       end
 
       def parse(path, target_ruby_version)

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -690,5 +690,17 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         RUBY
       end
     end
+
+    context 'when db/schema.rb file is empty' do
+      let(:schema) { '' }
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates :account, uniqueness: true
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1036.