### PR TITLE
Fix create_table with multi t columns for `Rails/SchemaComment`

### DIFF
--- a/changelog/fix_no_offences_for_schema_comment_when_create_table_with_multi_t_columns.md
+++ b/changelog/fix_no_offences_for_schema_comment_when_create_table_with_multi_t_columns.md
@@ -1,0 +1,1 @@
+* [#1042](https://github.com/rubocop/rubocop-rails/pull/1042): Fix no offences for `Rails/SchemaComment` when create_table with multi t columns. ([@nipe0324][])

--- a/spec/rubocop/cop/rails/schema_comment_spec.rb
+++ b/spec/rubocop/cop/rails/schema_comment_spec.rb
@@ -87,6 +87,28 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
       RUBY
     end
 
+    it 'registers two offenses when two `t.column` have no `comment` option' do
+      expect_offense(<<~RUBY)
+        create_table :users, comment: 'Table' do |t|
+          t.column :column1, :integer
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
+          t.column :column2, :integer
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
+        end
+      RUBY
+    end
+
+    it 'registers two offenses when two `t.integer` have no `comment` option' do
+      expect_offense(<<~RUBY)
+        create_table :users, comment: 'Table' do |t|
+          t.integer :column1
+          ^^^^^^^^^^^^^^^^^^ New database column without `comment`.
+          t.integer :column2
+          ^^^^^^^^^^^^^^^^^^ New database column without `comment`.
+        end
+      RUBY
+    end
+
     it 'does not register an offense when `t.column` has `comment` option' do
       expect_no_offenses(<<~RUBY)
         create_table :users, comment: 'Table' do |t|


### PR DESCRIPTION
This PR is fix no offenses for `Rails/SchemaComment`.

```rb
# create_table` with multi `t` columns 
create_table :users, comment: 'Table' do |t|
  t.integer :column1 # <- no offenses this line
  t.integer :column2 # <- also no offenses this line
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
