### PR TITLE
Fix an incorrect autocorrect for `Rails/FilePath` when File.join with Rails.root and path starting with `/`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_file_path_when_file_join_with_start_slash.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_file_path_when_file_join_with_start_slash.md
@@ -1,0 +1,1 @@
+* [#1049](https://github.com/rubocop/rubocop-rails/pull/1049): Fix an incorrect autocorrect for `Rails/FilePath` when File.join with Rails.root and path starting with `/`. ([@ydah][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -180,6 +180,9 @@ module RuboCop
               side: :right
             )
           )
+          node.arguments.filter(&:str_type?).each do |argument|
+            corrector.replace(argument, argument.value.delete_prefix('/').inspect)
+          end
           corrector.insert_after(node, '.to_s')
         end
 

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when using File.join with Rails.root and path starting with `/`' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, '/app/models', '/user.rb')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join("app/models/user.rb").to_s
+        RUBY
+      end
+    end
+
     context 'when using ::Rails.root.join with some path strings' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
@@ -246,7 +259,20 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join('app', 'models').to_s
+          Rails.root.join("app", "models").to_s
+        RUBY
+      end
+    end
+
+    context 'when using File.join with Rails.root and path starting with `/`' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, '/app/models', '/user.rb')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join("app", "models", "user.rb").to_s
         RUBY
       end
     end


### PR DESCRIPTION
This PR is fix an incorrect autocorrect for `Rails/FilePath` when File.join with Rails.root and path starting with `/`.

Auto-correct of following code would change the path.

Code to reproduce:
```ruby
File.join(Rails.root, '/app/models', 'user.rb')
```

Expected behavior:
```ruby
Rails.root.join("app/models/user.rb").to_s
# => "/rails/root/path/app/models/user.rb"
```

Actual behavior:
```ruby
Rails.root.join("/app/models/user.rb").to_s
# => "/app/models/user.rb"
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
