### PR TITLE
Add explicit style to `Rails/I18nLazyLookup`

### DIFF
--- a/changelog/new_explicit_style_to_i18n_lazy_lookup.md
+++ b/changelog/new_explicit_style_to_i18n_lazy_lookup.md
@@ -1,0 +1,1 @@
+* [#1052](https://github.com/rubocop/rubocop-rails/pull/1052): Add explicit style to `Rails/I18nLazyLookup`. ([@sunny][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -547,6 +547,10 @@ Rails/I18nLazyLookup:
   Reference: 'https://guides.rubyonrails.org/i18n.html#lazy-lookup'
   Enabled: pending
   VersionAdded: '2.14'
+  EnforcedStyle: lazy
+  SupportedStyles:
+    - lazy
+    - explicit
   Include:
     - 'app/controllers/**/*.rb'
 

--- a/spec/rubocop/cop/rails/i18n_lazy_lookup_spec.rb
+++ b/spec/rubocop/cop/rails/i18n_lazy_lookup_spec.rb
@@ -1,114 +1,190 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::I18nLazyLookup, :config do
-  it 'registers an offense and corrects when using translation helpers with the key scoped to controller and action' do
-    expect_offense(<<~RUBY)
-      class FooController
-        def action
-          t 'foo.action.key'
-            ^^^^^^^^^^^^^^^^ Use "lazy" lookup for the text used in controllers.
-          translate 'foo.action.key'
-                    ^^^^^^^^^^^^^^^^ Use "lazy" lookup for the text used in controllers.
-        end
-      end
-    RUBY
+  context 'when EnforcedStyle is lazy' do
+    let(:cop_config) { { 'EnforcedStyle' => 'lazy' } }
 
-    expect_correction(<<~RUBY)
-      class FooController
-        def action
-          t '.key'
-          translate '.key'
-        end
-      end
-    RUBY
-  end
-
-  it 'does not register an offense when translation methods scoped to `I18n`' do
-    expect_no_offenses(<<~RUBY)
-      class FooController
-        def action
-          I18n.t 'foo.action.key'
-          I18n.translate 'foo.action.key'
-        end
-      end
-    RUBY
-  end
-
-  it 'does not register an offense when not inside controller' do
-    expect_no_offenses(<<~RUBY)
-      class FooService
-        def do_something
-          t 'foo_service.do_something.key'
-        end
-      end
-    RUBY
-  end
-
-  it 'does not register an offense when not inside controller action' do
-    expect_no_offenses(<<~RUBY)
-      class FooController
-        private
-
-        def action
-          t 'foo.action.key'
-        end
-      end
-    RUBY
-  end
-
-  it 'does not register an offense when translating key not scoped to controller and action' do
-    expect_no_offenses(<<~RUBY)
-      class FooController
-        def action
-          t 'one.two.key'
-        end
-      end
-    RUBY
-  end
-
-  it 'does not register an offense when using "lazy" translation' do
-    expect_no_offenses(<<~RUBY)
-      class FooController
-        def action
-          t '.key'
-        end
-      end
-    RUBY
-  end
-
-  it 'does not register an offense when translation key is not a string nor a symbol' do
-    expect_no_offenses(<<~RUBY)
-      class FooController
-        def action
-          t ['foo.action.key']
-          t key
-        end
-      end
-    RUBY
-  end
-
-  it 'handles scoped controllers' do
-    expect_offense(<<~RUBY)
-      module Bar
+    it 'registers an offense when using translation helpers with the key scoped to controller and action' do
+      expect_offense(<<~RUBY)
         class FooController
           def action
-            t 'bar.foo.action.key'
-              ^^^^^^^^^^^^^^^^^^^^ Use "lazy" lookup for the text used in controllers.
             t 'foo.action.key'
+              ^^^^^^^^^^^^^^^^ Use lazy lookup for the text used in controllers.
+            translate 'foo.action.key'
+                      ^^^^^^^^^^^^^^^^ Use lazy lookup for the text used in controllers.
           end
         end
-      end
-    RUBY
+      RUBY
 
-    expect_correction(<<~RUBY)
-      module Bar
+      expect_correction(<<~RUBY)
         class FooController
           def action
             t '.key'
+            translate '.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when translation methods scoped to `I18n`' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          def action
+            I18n.t 'foo.action.key'
+            I18n.translate 'foo.action.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not inside controller' do
+      expect_no_offenses(<<~RUBY)
+        class FooService
+          def do_something
+            t 'foo_service.do_something.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not inside controller action' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          private
+
+          def action
             t 'foo.action.key'
           end
         end
-      end
-    RUBY
+      RUBY
+    end
+
+    it 'does not register an offense when translating key not scoped to controller and action' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          def action
+            t 'one.two.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using "lazy" translation' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          def action
+            t '.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when translation key is not a string nor a symbol' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          def action
+            t ['foo.action.key']
+            t key
+          end
+        end
+      RUBY
+    end
+
+    it 'handles scoped controllers' do
+      expect_offense(<<~RUBY)
+        module Bar
+          class FooController
+            def action
+              t 'bar.foo.action.key'
+                ^^^^^^^^^^^^^^^^^^^^ Use lazy lookup for the text used in controllers.
+              t 'foo.action.key'
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Bar
+          class FooController
+            def action
+              t '.key'
+              t 'foo.action.key'
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when EnforcedStyle is explicit' do
+    let(:cop_config) { { 'EnforcedStyle' => 'explicit' } }
+
+    it 'registers an offense and corrects when using "lazy" translation' do
+      expect_offense(<<~RUBY)
+        class FooController
+          def action
+            t '.key'
+              ^^^^^^ Use explicit lookup for the text used in controllers.
+            translate '.key'
+                      ^^^^^^ Use explicit lookup for the text used in controllers.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FooController
+          def action
+            t 'foo.action.key'
+            translate 'foo.action.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using explicit translation keys' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          def action
+            t 'foo.action.key'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when translation key is not a string nor a symbol' do
+      expect_no_offenses(<<~RUBY)
+        class FooController
+          def action
+            t ['.key']
+            t key
+          end
+        end
+      RUBY
+    end
+
+    it 'handles scoped controllers' do
+      expect_offense(<<~RUBY)
+        module Bar
+          class FooController
+            def action
+              t '.key'
+                ^^^^^^ Use explicit lookup for the text used in controllers.
+              t 'foo.action.key'
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Bar
+          class FooController
+            def action
+              t 'bar.foo.action.key'
+              t 'foo.action.key'
+            end
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Adds a new `explicit` style to the `Rails/I18nLazyLookup` cop (and names the default one `lazy`).

This way we can enforce the use of fully qualified i18n key names eg. `"recipes.show.title"` rather than shorthand `".title"`.

See also: https://github.com/cookpad/global-style-guides/pull/203

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
