### PR TITLE
Fix database adapter detection for nested config

### DIFF
--- a/changelog/change_fix_database_adapter_detection_for.md
+++ b/changelog/change_fix_database_adapter_detection_for.md
@@ -1,0 +1,1 @@
+* [#1056](https://github.com/rubocop/rubocop-rails/pull/1056): Fix database adapter detection for nested config. ([@mjankowski][])

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -181,12 +181,16 @@ module RuboCop
         def database_from_yaml
           return nil unless database_yaml
 
-          case database_yaml['adapter']
+          case database_adapter
           when 'mysql2'
             MYSQL
           when 'postgresql'
             POSTGRESQL
           end
+        end
+
+        def database_adapter
+          database_yaml['adapter'] || database_yaml.first.last['adapter']
         end
 
         def database_yaml

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -452,32 +452,70 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
     end
 
     context 'mysql2' do
-      let(:yaml) do
-        {
-          'development' => {
-            'adapter' => 'mysql2'
+      context 'with top-level adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'adapter' => 'mysql2'
+            }
           }
-        }
+        end
+
+        it_behaves_like 'offense for mysql'
       end
 
-      it_behaves_like 'offense for mysql'
+      context 'with nested adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'primary' => {
+                'adapter' => 'mysql2'
+              }
+            }
+          }
+        end
+
+        it_behaves_like 'offense for mysql'
+      end
     end
 
     context 'postgresql' do
-      let(:yaml) do
-        {
-          'development' => {
-            'adapter' => 'postgresql'
+      context 'with top-level adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'adapter' => 'postgresql'
+            }
           }
-        }
+        end
+
+        context 'with Rails 5.2', :rails52 do
+          it_behaves_like 'offense for postgresql'
+        end
+
+        context 'with Rails 5.1', :rails51 do
+          it_behaves_like 'no offense for postgresql'
+        end
       end
 
-      context 'with Rails 5.2', :rails52 do
-        it_behaves_like 'offense for postgresql'
-      end
+      context 'with nested adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'primary' => {
+                'adapter' => 'postgresql'
+              }
+            }
+          }
+        end
 
-      context 'with Rails 5.1', :rails51 do
-        it_behaves_like 'no offense for postgresql'
+        context 'with Rails 5.2', :rails52 do
+          it_behaves_like 'offense for postgresql'
+        end
+
+        context 'with Rails 5.1', :rails51 do
+          it_behaves_like 'no offense for postgresql'
+        end
       end
     end
 


### PR DESCRIPTION
When a database yml is configured with nested named databases (for example: `primary`, `read`, `replica`, etc) the adapter detection fails by only looking for a top-level `adapter` key in the hash.

This changes the detection to try the top-level location first, and then also attempt to look for an `adapter` key in the first nested hash under `development` as well.
