### PR TITLE
[Fix #1058] Relax `Include` path for `Rails/FindBy` and `Rails/FindEach`

### DIFF
--- a/changelog/change_relax_include_path_for_rails_find_by_and_find_each.md
+++ b/changelog/change_relax_include_path_for_rails_find_by_and_find_each.md
@@ -1,0 +1,1 @@
+* [#1058](https://github.com/rubocop/rubocop-rails/issues/1058): Relax `Include` path for `Rails/FindBy` and `Rails/FindEach`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -463,10 +463,8 @@ Rails/FindBy:
   StyleGuide: 'https://rails.rubystyle.guide#find_by'
   Enabled: true
   VersionAdded: '0.30'
-  VersionChanged: '2.11'
+  VersionChanged: '<<next>>'
   IgnoreWhereFirst: true
-  Include:
-    - app/models/**/*.rb
 
 Rails/FindById:
   Description: >-
@@ -482,9 +480,7 @@ Rails/FindEach:
   Enabled: true
   Safe: false
   VersionAdded: '0.30'
-  VersionChanged: '2.19'
-  Include:
-    - app/models/**/*.rb
+  VersionChanged: '<<next>>'
   AllowedMethods:
     # Methods that don't work well with `find_each`.
     - order


### PR DESCRIPTION
Fixes #1058.

This PR relaxes `Include` path for `Rails/FindBy` and `Rails/FindEach`.

`Rails/FindBy` was introduced in https://github.com/rubocop/rubocop/commit/6188d75. This was before it was extracted to RuboCop Rails, which is probably why it was targeting `app/models`. So, RuboCop Rails targeting Rails would not need it.

`Rails/FindEach` is the same:
https://github.com/rubocop/rubocop/commit/f2e26812

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
