### PR TITLE
[Fix #1060] Fix a false positive for `Rails/HttpStatus`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_http_status.md
+++ b/changelog/fix_a_false_positive_for_rails_http_status.md
@@ -1,0 +1,1 @@
+* [#1060](https://github.com/rubocop/rubocop-rails/issues/1060): Fix a false positive for `Rails/HttpStatus` when using symbolic value that have no numeric value mapping. ([@koic][])

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -133,7 +133,7 @@ module RuboCop
           end
 
           def offensive?
-            !node.int_type? && !permitted_symbol?
+            !node.int_type? && !permitted_symbol? && number
           end
 
           def message

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -125,5 +125,11 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         render :foo, status: :redirect
       RUBY
     end
+
+    it 'does not register an offense when using symbolic value that have no numeric value mapping' do
+      expect_no_offenses(<<~RUBY)
+        render json: { foo: 'bar' }, status: :ng
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #1060.

This PR fixes a false positive for `Rails/HttpStatus` when using symbolic value that have no numeric value mapping.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
