### PR TITLE
[Fix #1066] Fix an error for `Rails/FilePath`

### DIFF
--- a/changelog/fix_an_error_for_rails_file_path.md
+++ b/changelog/fix_an_error_for_rails_file_path.md
@@ -1,0 +1,1 @@
+* [#1066](https://github.com/rubocop/rubocop-rails/issues/1066): Fix an error for `Rails/FilePath` when string interpolated `Rails.root` is followed by a message starting with `.`. ([@koic][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -233,7 +233,7 @@ module RuboCop
         end
 
         def extension_node?(node)
-          node&.str_type? && node.source.start_with?('.')
+          node&.str_type? && node.source.match?(/\A\.[A-Za-z]+/)
         end
       end
     end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when string interpolated `Rails.root` is followed by a message starting with `.`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          "#{Rails.root}. a message"
+        RUBY
+      end
+    end
+
     context 'when using string interpolation without Rails.root' do
       it 'does not register an offense' do
         expect_no_offenses(<<~'RUBY')


### PR DESCRIPTION
Fixes #1066.

This PR fixes an error for `Rails/FilePath` when string interpolated `Rails.root` is followed by a message starting with `.`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
