### PR TITLE
[Fix #1031] Make `Lint/SafeNavigationChain` allow `presence_in`

### DIFF
--- a/changelog/change_make_lint_safe_navigation_chain_allow_presence_in.md
+++ b/changelog/change_make_lint_safe_navigation_chain_allow_presence_in.md
@@ -1,0 +1,1 @@
+* [#1031](https://github.com/rubocop/rubocop-rails/pull/1031): Make `Lint/SafeNavigationChain` allow `presence_in`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -61,6 +61,18 @@ Lint/RedundantSafeNavigation:
     - presence
     - present?
 
+Lint/SafeNavigationChain:
+  # Add `presence_in` method to the default of the RuboCop core:
+  # https://github.com/rubocop/rubocop/blob/v1.56.0/config/default.yml#L2265-L2271
+  AllowedMethods:
+    - present?
+    - blank?
+    - presence
+    - presence_in
+    - try
+    - try!
+    - in?
+
 Rails:
   Enabled: true
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails


### PR DESCRIPTION
Fixes #1031.

This PR makes `Lint/SafeNavigationChain` allow `presence_in`.

It adds `presence_in` method to the default of the RuboCop core: https://github.com/rubocop/rubocop/blob/v1.56.0/config/default.yml#L2265-L2271

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
