### PR TITLE
[Fix #1045] Fix an incorrect autocorrect for `Rails/NegateInclude`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_negate_include.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_negate_include.md
@@ -1,0 +1,1 @@
+* [#1045](https://github.com/rubocop/rubocop-rails/issues/1045): Fix an incorrect autocorrect for `Rails/NegateInclude` when using `Style/InverseMethods`'s autocorrection together. ([@koic][])

--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -17,6 +17,14 @@ require_relative 'rubocop/cop/rails_cops'
 
 RuboCop::Cop::Style::HashExcept.minimum_target_ruby_version(2.0)
 
+RuboCop::Cop::Style::InverseMethods.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::Rails::NegateInclude)
+    end
+  end
+)
+
 RuboCop::Cop::Style::MethodCallWithArgsParentheses.singleton_class.prepend(
   Module.new do
     def autocorrect_incompatible_with

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Rails/NegateInclude,` with `Style/InverseMethods`' do
+    create_file('example.rb', <<~RUBY)
+      array.select { |item| !do_something.include?(item) }
+    RUBY
+
+    expect(cli.run(['-A', '--only', 'Rails/NegateInclude,Style/InverseMethods'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      array.reject { |item| do_something.include?(item) }
+    RUBY
+  end
+
   it 'corrects `Rails/SafeNavigation` with `Style/RedundantSelf`' do
     create_file('.rubocop.yml', <<~YAML)
       Rails/SafeNavigation:


### PR DESCRIPTION
Fixes #1045.

This PR fixes an incorrect autocorrect for `Rails/NegateInclude` when using `Style/InverseMethods`'s autocorrection together.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
