### PR TITLE
Add Configurable option for `Rails/TransactionExitStatement`

### DIFF
--- a/changelog/new_add_allow_methods_and_allow_patterns_to_transaction_exit_statement.md
+++ b/changelog/new_add_allow_methods_and_allow_patterns_to_transaction_exit_statement.md
@@ -1,0 +1,1 @@
+* [#1072](https://github.com/rubocop/rubocop-rails/pull/1072): Add `AllowedMethods` and `AllowedPatterns` for `Rails/TransactionExitStatement`. ([@marocchino][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1083,6 +1083,8 @@ Rails/TransactionExitStatement:
     - https://github.com/rails/rails/commit/15aa4200e083
   Enabled: pending
   VersionAdded: '2.14'
+  AllowedMethods: []
+  AllowedPatterns: []
 
 Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -6190,6 +6190,20 @@ ApplicationRecord.transaction do
 end
 ----
 
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedMethods
+| `[]`
+| Array
+
+| AllowedPatterns
+| `[]`
+| Array
+|===
+
 === References
 
 * https://github.com/rails/rails/commit/15aa4200e083

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -108,4 +108,16 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
 
   it_behaves_like 'flags transaction exit statements', :transaction
   it_behaves_like 'flags transaction exit statements', :with_lock
+
+  context 'when `AllowedMethods: [writable_transaction]`' do
+    let(:cop_config) { { 'AllowedMethods' => %w[writable_transaction] } }
+
+    it_behaves_like 'flags transaction exit statements', :writable_transaction
+  end
+
+  context 'when `AllowedPatterns: [transaction]`' do
+    let(:cop_config) { { 'AllowedPatterns' => %w[transaction] } }
+
+    it_behaves_like 'flags transaction exit statements', :foo_transaction
+  end
 end


### PR DESCRIPTION
Hi. 

We differentiate transactions by using methods with different names depending on the target DB. 
So I would like to be able to leave the transaction on_lock as the default and add another method name to use it.

like..

```yaml
Rails/TransactionExitStatement:
  TransactionMethods:
    - transaction
    - on_lock
    - some_custom
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* ~~[ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
