### PR TITLE
Rename `AllowedMethods` to `TransactionMethods` for `Rails/TransactionExitStatement`

### DIFF
--- a/changelog/new_add_allow_methods_and_allow_patterns_to_transaction_exit_statement.md
+++ b/changelog/new_add_allow_methods_and_allow_patterns_to_transaction_exit_statement.md
@@ -1,1 +1,0 @@
-* [#1072](https://github.com/rubocop/rubocop-rails/pull/1072): Add `AllowedMethods` and `AllowedPatterns` for `Rails/TransactionExitStatement`. ([@marocchino][])

--- a/changelog/new_add_transaction_methods_to_transaction_exit_statement.md
+++ b/changelog/new_add_transaction_methods_to_transaction_exit_statement.md
@@ -1,0 +1,1 @@
+* [#1072](https://github.com/rubocop/rubocop-rails/pull/1072): Add `TransactionMethods` config for `Rails/TransactionExitStatement` to detect custom transaction methods. ([@marocchino][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1104,8 +1104,7 @@ Rails/TransactionExitStatement:
     - https://github.com/rails/rails/commit/15aa4200e083
   Enabled: pending
   VersionAdded: '2.14'
-  AllowedMethods: []
-  AllowedPatterns: []
+  TransactionMethods: []
 
 Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -109,15 +109,9 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
   it_behaves_like 'flags transaction exit statements', :transaction
   it_behaves_like 'flags transaction exit statements', :with_lock
 
-  context 'when `AllowedMethods: [writable_transaction]`' do
-    let(:cop_config) { { 'AllowedMethods' => %w[writable_transaction] } }
+  context 'when `TransactionMethods: [writable_transaction]`' do
+    let(:cop_config) { { 'TransactionMethods' => %w[writable_transaction] } }
 
     it_behaves_like 'flags transaction exit statements', :writable_transaction
-  end
-
-  context 'when `AllowedPatterns: [transaction]`' do
-    let(:cop_config) { { 'AllowedPatterns' => %w[transaction] } }
-
-    it_behaves_like 'flags transaction exit statements', :foo_transaction
   end
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-rails/pull/1072.

This PR renames `AllowedMethods` to `TransactionMethods` for `Rails/TransactionExitStatement` because it's a configuration for detecting, not for allowing custom transaction methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
