### PR TITLE
[Fix #1094] Make `Rails/TimeZone` aware of `String#to_time`

### DIFF
--- a/changelog/change_make_rails_time_zone_aware_of_string_to_time
+++ b/changelog/change_make_rails_time_zone_aware_of_string_to_time
@@ -1,0 +1,1 @@
+* [#1094](https://github.com/rubocop/rubocop-rails/issues/1094): Make `Rails/TimeZone` aware of `String#to_time`. ([@koic][])

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -124,6 +124,19 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       end
     end
 
+    it 'registers an offense for `String#to_time`' do
+      expect_offense(<<~RUBY)
+        "2012-03-02 16:05:37".to_time
+                              ^^^^^^^ Do not use `String#to_time` without zone. Use `Time.zone.parse` instead.
+      RUBY
+    end
+
+    it 'does not register an offense for `to_time` without receiver' do
+      expect_no_offenses(<<~RUBY)
+        to_time
+      RUBY
+    end
+
     it 'registers an offense for Time.parse' do
       expect_offense(<<~RUBY)
         Time.parse("2012-03-02 16:05:37")


### PR DESCRIPTION
Fixes #1094.

This PR make `Rails/TimeZone` aware of `String#to_time`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
