### PR TITLE
[Fix #1015] Make `Style/InvertibleUnlessCondition` aware of Active Support methods

### DIFF
--- a/changelog/change_make_style_invertible_unless_condition_aware_of_as_methods.md
+++ b/changelog/change_make_style_invertible_unless_condition_aware_of_as_methods.md
@@ -1,0 +1,1 @@
+* [#1015](https://github.com/rubocop/rubocop-rails/issues/1015): Make `Style/InvertibleUnlessCondition` aware of Active Support methods. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1204,6 +1204,14 @@ Style/FormatStringToken:
   AllowedMethods:
     - redirect
 
+Style/InvertibleUnlessCondition:
+  InverseMethods:
+    # Active Support defines some common inverse methods. They are listed below:
+    :present?: :blank?
+    :blank?: :present?
+    :include?: :exclude?
+    :exclude?: :include?
+
 Style/SymbolProc:
   AllowedMethods:
     - define_method


### PR DESCRIPTION
Resolves #1015.

This PR makes `Style/InvertibleUnlessCondition` aware of Active Support methods. It still inherits the default disabled.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
