### PR TITLE
Fix incorrect comments as AsciiDoc inline code

### DIFF
--- a/lib/rubocop/cop/rails/action_controller_test_case.rb
+++ b/lib/rubocop/cop/rails/action_controller_test_case.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Rails
-      # Using `ActionController::TestCase`` is discouraged and should be replaced by
-      # `ActionDispatch::IntegrationTest``. Controller tests are too close to the
+      # Using `ActionController::TestCase` is discouraged and should be replaced by
+      # `ActionDispatch::IntegrationTest`. Controller tests are too close to the
       # internals of a controller whereas integration tests mimic the browser/user.
       #
       # @safety

--- a/lib/rubocop/cop/rails/root_pathname_methods.rb
+++ b/lib/rubocop/cop/rails/root_pathname_methods.rb
@@ -12,7 +12,7 @@ module RuboCop
       # `Style/FileRead`, `Style/FileWrite` and `Rails/RootJoinChain`.
       #
       # @safety
-      #   This cop is unsafe for autocorrection because `Dir`'s `children`, `each_child`, `entries`, and `glob`
+      #   This cop is unsafe for autocorrection because ``Dir``'s `children`, `each_child`, `entries`, and `glob`
       #   methods return string element, but these methods of `Pathname` return `Pathname` element.
       #
       # @example


### PR DESCRIPTION
- Remove unnecessary backquotes.
  - https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactioncontrollertestcase
- Add backquotes  to prevent apostrophe-S from being interpreted as a [single curved quote](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-formatting).
  - https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpathnamemethods

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
