### PR TITLE
[Fix #1078] Fix false negative for `Rails/LexicallyScopedActionFilter`

### DIFF
--- a/changelog/fix_a_false_negative_for_lexically_scoped_action_filter.md
+++ b/changelog/fix_a_false_negative_for_lexically_scoped_action_filter.md
@@ -1,0 +1,1 @@
+* [#1078](https://github.com/rubocop/rubocop-rails/issues/1078): Fix a false negative for `Rails/LexicallyScopedActionFilter` when no methods are defined. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/rails/lexically_scoped_action_filter.rb
+++ b/lib/rubocop/cop/rails/lexically_scoped_action_filter.rb
@@ -122,24 +122,23 @@ module RuboCop
           parent = node.each_ancestor(:class, :module).first
           return unless parent
 
+          # NOTE: a `:begin` node may not exist if the class/module consists of a single statement
           block = parent.each_child_node(:begin).first
-          return unless block
-
           defined_action_methods = defined_action_methods(block)
 
-          methods = array_values(methods_node).reject do |method|
-            defined_action_methods.include?(method)
-          end
+          unmatched_methods = array_values(methods_node) - defined_action_methods
+          return if unmatched_methods.empty?
 
-          message = message(methods, parent)
-          add_offense(node, message: message) unless methods.empty?
+          message = message(unmatched_methods, parent)
+          add_offense(node, message: message)
         end
 
         private
 
         def defined_action_methods(block)
-          defined_methods = block.each_child_node(:def).map(&:method_name)
+          return [] unless block
 
+          defined_methods = block.each_child_node(:def).map(&:method_name)
           defined_methods + aliased_action_methods(block, defined_methods)
         end
 

--- a/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe RuboCop::Cop::Rails::LexicallyScopedActionFilter, :config do
     RUBY
   end
 
+  it 'registers an offense when no methods are defined' do
+    expect_offense <<~RUBY
+      class LoginController < ApplicationController
+        before_action :require_login, only: %i[index show]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `index`, `show` are not explicitly defined on the class.
+      end
+    RUBY
+  end
+
   it 'register an offense when using action filter in module' do
     expect_offense <<~RUBY
       module FooMixin


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop-rails/issues/1078

This PR fixes the edge case where the class/module body does not define any methods at all.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
