### PR TITLE
[Fix #1080] Make `Rails/HttpStatus` aware of string number status

### DIFF
--- a/changelog/change_make_rails_http_status_aware_of_string_number_status.md
+++ b/changelog/change_make_rails_http_status_aware_of_string_number_status.md
@@ -1,0 +1,1 @@
+* [#1080](https://github.com/rubocop/rubocop-rails/issues/1080): Make `Rails/HttpStatus` aware of string number status. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -8,6 +8,7 @@ module RuboCop
       # @example EnforcedStyle: symbolic (default)
       #   # bad
       #   render :foo, status: 200
+      #   render :foo, status: '200'
       #   render json: { foo: 'bar' }, status: 200
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
@@ -50,7 +51,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :status_code, <<~PATTERN
-          (hash <(pair (sym :status) ${int sym}) ...>)
+          (hash <(pair (sym :status) ${int sym str}) ...>)
         PATTERN
 
         def on_send(node)
@@ -108,7 +109,7 @@ module RuboCop
           private
 
           def symbol
-            ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(number)
+            ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(number.to_i)
           end
 
           def number

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects using numeric string value' do
+      expect_offense(<<~RUBY)
+        render :foo, status: '200'
+                             ^^^^^ Prefer `:ok` over `200` to define HTTP status code.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        render :foo, status: :ok
+      RUBY
+    end
+
     it 'does not register an offense when using symbolic value' do
       expect_no_offenses(<<~RUBY)
         render :foo, status: :ok


### PR DESCRIPTION
Resolves #1080.

This PR makes `Rails/HttpStatus` aware of string number status.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
