### PR TITLE
[Fix: #1109] Fix error for `Rails/RedundantActiveRecordAllMethod` when `all` is an argument for AR methods

### DIFF
--- a/changelog/fix_error_for_rails_redundant_active_record_all_method_when_all_is_an_argument_for_ar_methods.md
+++ b/changelog/fix_error_for_rails_redundant_active_record_all_method_when_all_is_an_argument_for_ar_methods.md
@@ -1,0 +1,1 @@
+* [#1109](https://github.com/rubocop/rubocop-rails/issues/1109): Fix error for `Rails/RedundantActiveRecordAllMethod` when `all` is an argument for AR methods.([@masato-bkn][])


### PR DESCRIPTION
Resolved the following issues #1109, #1111

As pointed out in the mentioned issues, there was an oversight. I apologize for the mistake.

-----------------
Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
- ~~[ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
