### PR TITLE
[Fix: #1110] Fix false positive for `Rails/RedundantActiveRecordAllMethod` when `all` has any parameters

### DIFF
--- a/changelog/fix_false_positive_for_rails_redundant_active_record_all_method_when_all_has_any_parameters.md
+++ b/changelog/fix_false_positive_for_rails_redundant_active_record_all_method_when_all_has_any_parameters.md
@@ -1,0 +1,1 @@
+* [#1110](https://github.com/rubocop/rubocop-rails/issues/1110): Fix false positive for `Rails/RedundantActiveRecordAllMethod` when `all` has any parameters. ([@masato-bkn][])

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -127,7 +127,7 @@ module RuboCop
         ].to_set.freeze
 
         def_node_matcher :followed_by_query_method?, <<~PATTERN
-          (send (send _ :all ...) QUERYING_METHODS ...)
+          (send (send _ :all) QUERYING_METHODS ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -260,6 +260,26 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
         RUBY
       end
     end
+
+    context 'when `all` has any parameters, it indicates that it is not an Active Record `all`' do
+      it 'does not register an offense when no method follows `all`' do
+        expect_no_offenses(<<~RUBY)
+          page.all(:parameter)
+        RUBY
+      end
+
+      it 'does not register an offense when method follows `all`' do
+        expect_no_offenses(<<~RUBY)
+          page.all(:parameter).do_something
+        RUBY
+      end
+
+      it 'does not register an offense when method from `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+        expect_no_offenses(<<~RUBY)
+          page.all(:parameter).select(some_filter)
+        RUBY
+      end
+    end
   end
 
   context 'with no receiver' do


### PR DESCRIPTION
Resolved the following issue: https://github.com/rubocop/rubocop-rails/issues/1110
As pointed out in the mentioned issue, there was an oversight. I apologize for the mistake.

In this PR, the cop treats `all` with parameters as not being an ActiveRecord method and excludes it from offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* ~~[ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
