### PR TITLE
[Fix #1108] Fix an incorrect autocorrect for `Rails/TimeZone`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_time_zone.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_time_zone.md
@@ -1,0 +1,1 @@
+* [#1108](https://github.com/rubocop/rubocop-rails/issues/1108): Fix an incorrect autocorrect for `Rails/TimeZone` when using `String#to_time`. ([@koic][])

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -69,7 +69,7 @@ module RuboCop
           return if !node.receiver&.str_type? || !node.method?(:to_time)
 
           add_offense(node.loc.selector, message: MSG_STRING_TO_TIME) do |corrector|
-            autocorrect(corrector, node)
+            corrector.replace(node, "Time.zone.parse(#{node.receiver.source})")
           end
         end
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -129,6 +129,10 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
         "2012-03-02 16:05:37".to_time
                               ^^^^^^^ Do not use `String#to_time` without zone. Use `Time.zone.parse` instead.
       RUBY
+
+      expect_correction(<<~RUBY)
+        Time.zone.parse("2012-03-02 16:05:37")
+      RUBY
     end
 
     it 'does not register an offense for `to_time` without receiver' do


### PR DESCRIPTION
Fixes #1108.

This PR fixes an incorrect autocorrect for `Rails/TimeZone` when using `String#to_time`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
