### PR TITLE
[Fix: #1119] Fix an incorrect autocorrect for `Rails/RedundantActiveRecordAllMethod`  when `all` has parentheses

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_redundant_active_record_all_method_when_all_has_parentheses.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_redundant_active_record_all_method_when_all_has_parentheses.md
@@ -1,0 +1,1 @@
+* [#1119](https://github.com/rubocop/rubocop-rails/issues/1119): Fix an incorrect autocorrect for `Rails/RedundantActiveRecordAllMethod`  when `all` has parentheses. ([@masato-bkn][])

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -22,6 +22,7 @@ module RuboCop
       #   user.articles.order(:created_at)
       class RedundantActiveRecordAllMethod < Base
         include ActiveRecordHelper
+        include RangeHelp
         extend AutoCorrector
 
         MSG = 'Redundant `all` detected.'
@@ -134,11 +135,17 @@ module RuboCop
           return unless followed_by_query_method?(node.parent)
           return if node.receiver.nil? && !inherit_active_record_base?(node)
 
-          range_of_all_method = node.loc.selector
+          range_of_all_method = offense_range(node)
           add_offense(range_of_all_method) do |collector|
             collector.remove(range_of_all_method)
             collector.remove(node.parent.loc.dot)
           end
+        end
+
+        private
+
+        def offense_range(node)
+          range_between(node.loc.selector.begin_pos, node.source_range.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -280,6 +280,31 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
         RUBY
       end
     end
+
+    context 'when `all` has parentheses' do
+      it 'does not register an offense when no method follows `all`' do
+        expect_no_offenses(<<~RUBY)
+          User.all()
+        RUBY
+      end
+
+      it 'registers an offense and corrects when method in `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+        expect_offense(<<~RUBY)
+          User.all().order(:created_at)
+               ^^^^^ Redundant `all` detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          User.order(:created_at)
+        RUBY
+      end
+
+      it 'does not register an offense when method not in `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+        expect_no_offenses(<<~RUBY)
+          User.all().do_something
+        RUBY
+      end
+    end
   end
 
   context 'with no receiver' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rails/issues/1119

This PR fixes an incorrect autocorrect for `Rails/RedundantActiveRecordAllMethod` when `all` has parentheses.

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* ~~[ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
