### PR TITLE
[Fix #1121] Fix an error for `Rails/SelectMap`

### DIFF
--- a/changelog/fix_an_error_for_rails_select_map.md
+++ b/changelog/fix_an_error_for_rails_select_map.md
@@ -1,0 +1,1 @@
+* [#1121](https://github.com/rubocop/rubocop-rails/issues/1121): Fix an error for `Rails/SelectMap` when using `select(:column_name).map(&:column_name)` without receiver model. ([@koic][])

--- a/lib/rubocop/cop/rails/select_map.rb
+++ b/lib/rubocop/cop/rails/select_map.rb
@@ -51,10 +51,13 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def autocorrect(corrector, select_node, node, preferred_method)
-          corrector.remove(select_node.loc.dot.begin.join(select_node.source_range.end))
+          corrector.remove(select_node.loc.dot || node.loc.dot)
+          corrector.remove(select_node.loc.selector.begin.join(select_node.source_range.end))
           corrector.replace(node.loc.selector.begin.join(node.source_range.end), preferred_method)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def match_column_name?(select_candidate, column_name)
           return false unless select_candidate.arguments.one?

--- a/spec/rubocop/cop/rails/select_map_spec.rb
+++ b/spec/rubocop/cop/rails/select_map_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe RuboCop::Cop::Rails::SelectMap, :config do
     RUBY
   end
 
+  it 'registers an offense when using `select(:column_name).map(&:column_name)` without receiver model' do
+    expect_offense(<<~RUBY)
+      select(:column_name).map(&:column_name)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `pluck(:column_name)` instead of `select` with `map`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      pluck(:column_name)
+    RUBY
+  end
+
   it 'does not register an offense when using `select(:mismatch_column_name).map(&:column_name)`' do
     expect_no_offenses(<<~RUBY)
       Model.select(:mismatch_column_name).map(&:column_name)


### PR DESCRIPTION
Fixes #1121.

This PR fixes an error for `Rails/SelectMap` when using `select(:column_name).map(&:column_name)` without receiver model.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
