### PR TITLE
[Doc] Prevent unintended auto-correct with after_generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ module YourCoolApp
   class Application < Rails::Application
     config.generators.after_generate do |files|
       parsable_files = files.filter { |file| file.end_with?('.rb') }
-      system("bundle exec rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
+      unless parsable_files.empty?
+        system("bundle exec rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
+      end
     end
   end
 end

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -42,7 +42,9 @@ module YourCoolApp
   class Application < Rails::Application
     config.generators.after_generate do |files|
       parsable_files = files.filter { |file| file.end_with?('.rb') }
-      system("bundle exec rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
+      unless parsable_files.empty?
+        system("bundle exec rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
+      end
     end
   end
 end


### PR DESCRIPTION
Some `rails generators` may not generate `*.rb`. (e.g. `bin/rails g stimulus`)
In this case, `parsable_files` is empty, so RuboCop will parse all files.
This behavior is not intended, so it fixes the doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
