### PR TITLE
[Fix #1116] Update Rails/UnusedRenderContent documentation to recommend use of `head` instead of `render`

### DIFF
--- a/lib/rubocop/cop/rails/unused_render_content.rb
+++ b/lib/rubocop/cop/rails/unused_render_content.rb
@@ -14,8 +14,8 @@ module RuboCop
       #   render status: 100, plain: 'Ruby!'
       #
       #   # good
-      #   render status: :continue
-      #   render status: 100
+      #   head :continue
+      #   head 100
       class UnusedRenderContent < Base
         extend AutoCorrector
         include RangeHelp


### PR DESCRIPTION
@shepmaster [reported](https://github.com/rubocop/rubocop-rails/issues/1116) that, by following the examples for the Rails/UnusedRenderContent cop from the rubocop-rails documentation, they were seeing errors in their Rails application. Please see the issue for a full discussion of the issue.

TLDR:
Using `render` without specifying a content option (for example `:json` option), will cause Rails to look for a view template matching the controller/action name. If a matching view template cannot be found, Rails will raise a `ActionView::MissingTemplate` error. This is true even for no-content response statuses.

The documentation should demonstrate and recommend the use of `head` instead of `render` to avoid these errors.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
