### PR TITLE
[Fix #1124] Fix false positives for `Rails/RedundantActiveRecordAllMethod`

### DIFF
--- a/changelog/fix_false_positive_for_rails_redundant_active_record_dll_method.md
+++ b/changelog/fix_false_positive_for_rails_redundant_active_record_dll_method.md
@@ -1,0 +1,1 @@
+* [#1124](https://github.com/rubocop/rubocop-rails/issues/1124): Fix false positives for `Rails/RedundantActiveRecordAllMethod` when receiver is not an Active Record model. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -801,6 +801,9 @@ Rails/RedundantActiveRecordAllMethod:
   StyleGuide: 'https://rails.rubystyle.guide/#redundant-all'
   Enabled: pending
   Safe: false
+  AllowedReceivers:
+    - ActionMailer::Preview
+    - ActiveSupport::TimeZone
   VersionAdded: '2.21'
 
 Rails/RedundantAllowNil:

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -20,8 +20,14 @@ module RuboCop
       #   User.order(:created_at)
       #   users.where(id: ids)
       #   user.articles.order(:created_at)
+      #
+      # @example AllowedReceivers: ['ActionMailer::Preview', 'ActiveSupport::TimeZone'] (default)
+      #   # good
+      #   ActionMailer::Preview.all.first
+      #   ActiveSupport::TimeZone.all.first
       class RedundantActiveRecordAllMethod < Base
         include ActiveRecordHelper
+        include AllowedReceivers
         include RangeHelp
         extend AutoCorrector
 
@@ -133,7 +139,7 @@ module RuboCop
 
         def on_send(node)
           return unless followed_by_query_method?(node.parent)
-          return if node.receiver.nil? && !inherit_active_record_base?(node)
+          return if node.receiver ? allowed_receiver?(node.receiver) : !inherit_active_record_base?(node)
 
           range_of_all_method = offense_range(node)
           add_offense(range_of_all_method) do |collector|

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -388,4 +388,23 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
       RUBY
     end
   end
+
+  context 'with `AllowedReceivers` config' do
+    let(:cop_config) do
+      { 'AllowedReceivers' => %w[ActionMailer::Preview ActiveSupport::TimeZone] }
+    end
+
+    it 'registers an offense when not using allowed receiver' do
+      expect_offense(<<~RUBY)
+        User.all.first
+             ^^^ Redundant `all` detected.
+      RUBY
+    end
+
+    it 'does not register an offense when using allowed receiver' do
+      expect_no_offenses(<<~RUBY)
+        ActiveSupport::TimeZone.all.first
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1124.

This PR fixes false positives for `Rails/RedundantActiveRecordAllMethod` when receiver is not an Active Record model.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
