### PR TITLE
[Fix #1130] Fix crash for Rails/UniqueValidationWithoutIndex with bare validate

### DIFF
--- a/changelog/fix_bug_unique_validation_without_index.md
+++ b/changelog/fix_bug_unique_validation_without_index.md
@@ -1,0 +1,1 @@
+* [#1130](https://github.com/rubocop/rubocop-rails/issues/1130): Fix crash for `Rails/UniqueValidationWithoutIndex` with bare validate. ([@jamiemccarthy][])

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -125,7 +125,7 @@ module RuboCop
 
         def uniqueness_part(node)
           pairs = node.arguments.last
-          return unless pairs.hash_type?
+          return unless pairs&.hash_type?
 
           pairs.each_pair.find do |pair|
             next unless pair.key.sym_type? && pair.key.value == :uniqueness

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
       end
+
+      it 'ignores a bare validates directive by itself' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates
+          end
+        RUBY
+      end
+
+      it 'ignores a bare validates directive among others' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates
+            after_commit :foo
+            def foo; true; end
+          end
+        RUBY
+      end
     end
 
     context 'when the table has an index but it is not unique' do


### PR DESCRIPTION
This PR fixes #1130 , a bug in `Rails/UniqueValidationWithoutIndex` that raises an exception if some (admittedly invalid) code is encountered.

It's just a method call on an object that might be nil. Since `&.` was added in ruby 2.3 and the gemspec requires ruby 2.7, I used that to fix it.

Tests that trigger the exception are added.

I'm happy to make any changes requested.