### PR TITLE
Add support for custom formats in `Rails/ToSWithArgument`

### DIFF
--- a/changelog/change_add_support_custom_formats.md
+++ b/changelog/change_add_support_custom_formats.md
@@ -1,0 +1,1 @@
+* [#1133](https://github.com/rubocop/rubocop-rails/pull/1133): Add support for custom formats in `Rails/ToSWithArgument`. ([@wata727][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1105,6 +1105,7 @@ Rails/ToSWithArgument:
   Enabled: pending
   Safe: false
   VersionAdded: '2.16'
+  CustomFormatTypes: []
 
 Rails/TopLevelHashWithIndifferentAccess:
   Description: 'Identifies top-level `HashWithIndifferentAccess`.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -6227,6 +6227,16 @@ obj.to_s(:delimited)
 obj.to_formatted_s(:delimited)
 ----
 
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| CustomFormatTypes
+| `[]`
+| Array
+|===
+
 == Rails/TopLevelHashWithIndifferentAccess
 
 |===

--- a/lib/rubocop/cop/rails/to_s_with_argument.rb
+++ b/lib/rubocop/cop/rails/to_s_with_argument.rb
@@ -17,6 +17,14 @@ module RuboCop
       #   # good
       #   obj.to_formatted_s(:delimited)
       #
+      # @example CustomFormatTypes: ["custom"]
+      #
+      #   # bad
+      #   obj.to_s(:custom)
+      #
+      #   # good
+      #   obj.to_formatted_s(:custom)
+      #
       class ToSWithArgument < Base
         extend AutoCorrector
         extend TargetRailsVersion
@@ -70,7 +78,15 @@ module RuboCop
         private
 
         def rails_extended_to_s?(node)
-          node.first_argument&.sym_type? && EXTENDED_FORMAT_TYPES.include?(node.first_argument.value)
+          node.first_argument&.sym_type? && extended_format_types.include?(node.first_argument.value)
+        end
+
+        def extended_format_types
+          EXTENDED_FORMAT_TYPES + custom_format_types
+        end
+
+        def custom_format_types
+          Set.new(cop_config.fetch('CustomFormatTypes', []).map(&:to_sym))
         end
       end
     end

--- a/spec/rubocop/cop/rails/to_s_with_argument_spec.rb
+++ b/spec/rubocop/cop/rails/to_s_with_argument_spec.rb
@@ -9,11 +9,38 @@ RSpec.describe RuboCop::Cop::Rails::ToSWithArgument, :config, :rails70 do
     end
   end
 
-  context 'with unrelated argument' do
+  context 'with non-sym_type argument' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         10.to_s(2)
       RUBY
+    end
+  end
+
+  context 'with non-defined argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        to_s(:custom)
+      RUBY
+    end
+
+    context 'but the argument is in CustomFormatTypes' do
+      let(:cop_config) do
+        {
+          'CustomFormatTypes' => %w[custom]
+        }
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          to_s(:custom)
+          ^^^^ Use `to_formatted_s` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          to_formatted_s(:custom)
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds support for custom formats in `Rails/ToSWithArgument` cop.

Currently this cop only supports formats defined by Rails due to https://github.com/rubocop/rubocop-rails/pull/869 changes, but some users may have added their own formats, such as:

```ruby
Time::DATE_FORMATS[:datetime] = '%Y-%m-%d %H:%M:%S'
```

Even in such cases, it would be convenient if autocorrection by this cop could be used. You can add any format to `FormatTypes` as below.

```yaml
Rails/ToSWithArgument:
  FormatTypes:
    - datetime
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
