### PR TITLE
Add `:rails71` shared context

### DIFF
--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -27,3 +27,7 @@ end
 RSpec.shared_context 'with Rails 7.0', :rails70 do
   let(:rails_version) { 7.0 }
 end
+
+RSpec.shared_context 'with Rails 7.1', :rails71 do
+  let(:rails_version) { 7.1 }
+end


### PR DESCRIPTION
This adds a shared context for the upcoming Rails 7.1, whose release candidate was released yesterday. As a release candidate indicates APIs are likely stable, we can begin writing/updating cops for it.

This commit was extracted from #906, and could be used in #894.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
* ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
