### PR TITLE
Qualify Struct reference to avoid collisions with possible cop namespace

### DIFF
--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -102,7 +102,7 @@ module RuboCop
       end
 
       # Internal helper class to hold match data
-      Captures = Struct.new(
+      Captures = ::Struct.new(
         :transformed_argname,
         :transforming_body_expr
       ) do
@@ -112,7 +112,7 @@ module RuboCop
       end
 
       # Internal helper class to hold autocorrect data
-      Autocorrection = Struct.new(:match, :block_node, :leading, :trailing) do
+      Autocorrection = ::Struct.new(:match, :block_node, :leading, :trailing) do
         def self.from_each_with_object(node, match)
           new(match, node, 0, 0)
         end


### PR DESCRIPTION
We were trying to add a custom cop called `Struct/RequiresTypedStructHelper`, but ran into a problem where we got an error like:

```
undefined method `new' for RuboCop::Cop::Struct:Module
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop/cop/mixin/index_method.rb:105:in `module:IndexMethod'
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop/cop/mixin/index_method.rb:6:in `module:Cop'
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop/cop/mixin/index_method.rb:4:in `module:RuboCop'
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop/cop/mixin/index_method.rb:3:in `top (required)'
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop/cop/rails_cops.rb:7:in `require_relative'
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop/cop/rails_cops.rb:7:in `top (required)'
/Users/technicalpickles/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-rails-2.21.1/lib/rubocop-rails.rb:16:in `require_relative'
```

It turned out this module has method that were calling `Struct.new`, but Ruby constant lookup ended up using our `Rubocop::Cop::Struct`, instead of the actual `Struct` class.

We were able to work around it by changing the constant name, but `Struct` is always going to be part of the stdlib so a possible name collision.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
