### PR TITLE
[Doc] Remove missing style guide link from `Rails/DefaultScope`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -338,7 +338,6 @@ Rails/Date:
 
 Rails/DefaultScope:
   Description: 'Avoid use of `default_scope`.'
-  StyleGuide: 'https://rails.rubystyle.guide#avoid-default-scope'
   Enabled: false
   VersionAdded: '2.7'
 


### PR DESCRIPTION
This PR removes the style guide link from `Rails/DefaultScope` because the URL is missing. 
The style guide section was not merged in https://github.com/rubocop/rails-style-guide/pull/267.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* ~~[ ] Added tests.~~
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~~[X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~~
* ~~[ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
