### PR TITLE
Migrate `TargetRailsVersion` to the new `requires_gem` RuboCop API

### DIFF
--- a/changelog/change_migrate_to_requires_gem_api.md
+++ b/changelog/change_migrate_to_requires_gem_api.md
@@ -1,0 +1,1 @@
+* [#1137](https://github.com/rubocop/rubocop-rails/pull/1137): Migrate to `TargetRailsVersion` the new [`requires_gem` API](https://github.com/rubocop/rubocop/pull/12186). ([@amomchilov][])

--- a/lib/rubocop/cop/mixin/target_rails_version.rb
+++ b/lib/rubocop/cop/mixin/target_rails_version.rb
@@ -4,13 +4,40 @@ module RuboCop
   module Cop
     # Common functionality for checking target rails version.
     module TargetRailsVersion
+      # Informs the base RuboCop gem that it the Rails version is checked via `requires_gem` API,
+      # without needing to call this `#support_target_rails_version` method.
+      USES_REQUIRES_GEM_API = true
+
       def minimum_target_rails_version(version)
-        @minimum_target_rails_version = version
+        if respond_to?(:requires_gem)
+          case version
+          when Integer, Float then requires_gem(TARGET_GEM_NAME, ">= #{version}")
+          when String then requires_gem(TARGET_GEM_NAME, version)
+          end
+        else
+          # Fallback path for previous versions of RuboCop which don't support the `requires_gem` API yet.
+          @minimum_target_rails_version = version
+        end
       end
 
       def support_target_rails_version?(version)
-        @minimum_target_rails_version <= version
+        if respond_to?(:requires_gem)
+          return false unless gem_requirements
+
+          gem_requirement = gem_requirements[TARGET_GEM_NAME]
+          return true unless gem_requirement # If we have no requirement, then we support all versions
+
+          gem_requirement.satisfied_by?(Gem::Version.new(version))
+        else
+          # Fallback path for previous versions of RuboCop which don't support the `requires_gem` API yet.
+          @minimum_target_rails_version <= version
+        end
       end
+
+      # Look for `railties` instead of `rails`, to support apps that only use a subset of `rails`
+      # See https://github.com/rubocop/rubocop/pull/11289
+      TARGET_GEM_NAME = 'railties'
+      private_constant :TARGET_GEM_NAME
     end
   end
 end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -61,20 +61,20 @@ RSpec.describe RuboCop::Config do
                   remote: https://rubygems.org/
                   specs:
                     actionmailer (4.1.0)
-                    actionpack (= 4.1.0)
-                    actionview (= 4.1.0)
-                    mail (~> 2.5.4)
-                  rails (4.1.0)
-                    actionmailer (= 4.1.0)
-                    actionpack (= 4.1.0)
-                    actionview (= 4.1.0)
-                    activemodel (= 4.1.0)
-                    activerecord (= 4.1.0)
-                    activesupport (= 4.1.0)
-                    bundler (>= 1.3.0, < 2.0)
-                    railties (= 4.1.0)
-                    sprockets-rails (~> 2.0)
-                  railties (4.1.0)
+                    actionpack (4.1.0)
+                    actionview (4.1.0)
+                    mail (2.5.4)
+                    rails (4.1.0)
+                      actionmailer (= 4.1.0)
+                      actionpack (= 4.1.0)
+                      actionview (= 4.1.0)
+                      activemodel (= 4.1.0)
+                      activerecord (= 4.1.0)
+                      activesupport (= 4.1.0)
+                      bundler (>= 1.3.0, < 2.0)
+                      railties (= 4.1.0)
+                      sprockets-rails (~> 2.0)
+                    railties (4.1.0)
 
                 PLATFORMS
                   ruby
@@ -96,20 +96,20 @@ RSpec.describe RuboCop::Config do
                   remote: https://rubygems.org/
                   specs:
                     actionmailer (4.1.0)
-                    actionpack (= 4.1.0)
-                    actionview (= 4.1.0)
-                    mail (~> 2.5.4)
-                  rails (400.33.22)
-                    actionmailer (= 4.1.0)
-                    actionpack (= 4.1.0)
-                    actionview (= 4.1.0)
-                    activemodel (= 4.1.0)
-                    activerecord (= 4.1.0)
-                    activesupport (= 4.1.0)
-                    bundler (>= 1.3.0, < 2.0)
-                    railties (= 4.1.0)
-                    sprockets-rails (~> 2.0)
-                  railties (400.33.22)
+                    actionpack (4.1.0)
+                    actionview (4.1.0)
+                    mail (2.5.4)
+                    rails (400.33.22)
+                      actionmailer (= 4.1.0)
+                      actionpack (= 4.1.0)
+                      actionview (= 4.1.0)
+                      activemodel (= 4.1.0)
+                      activerecord (= 4.1.0)
+                      activesupport (= 4.1.0)
+                      bundler (>= 1.3.0, < 2.0)
+                      railties (= 4.1.0)
+                      sprockets-rails (~> 2.0)
+                    railties (400.33.22)
 
                 PLATFORMS
                   ruby
@@ -131,9 +131,9 @@ RSpec.describe RuboCop::Config do
                   remote: https://rubygems.org/
                   specs:
                     actionmailer (4.1.0)
-                    actionpack (= 4.1.0)
-                    actionview (= 4.1.0)
-                    mail (~> 2.5.4)
+                    actionpack (4.1.0)
+                    actionview (4.1.0)
+                    mail (2.5.4)
 
                 PLATFORMS
                   ruby


### PR DESCRIPTION
This PR updates the `TargetRailsVersion` to conditionally use the [`requires_gem` API](https://github.com/rubocop/rubocop/pull/12186/files) when available (depending on the version of the base RuboCop gem). This has several advantages:

1. It resolves a circular dependancy.
    * `rubocop-rails` depends on `rubocop` (e.g. for `RuboCop::Cop::Base`), and that's fine, but there's also a hidden reverse dependency, where `rubocop` implicitly depends on `rubocop-rails`.
    * Now it's just one-way. `rubocop-rails` registers its minimum version requirements, and `rubocop` knows how to understand those without needing to call back into `rubcop-rails`.
2. It removes a "snowflake" case that's treated specially. For now we need to support both for backwards compatibility, but eventually when old versions are drop, it can just standardize on `requires_gem`.
3. It adds rails requirements to a Cop's `gem_requirements` list, just like any other.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
