### PR TITLE
Replace "re-use" with "reuse"

### DIFF
--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -2510,7 +2510,7 @@ end
 Checks for use of the helper methods which reference
 instance variables.
 
-Relying on instance variables makes it difficult to re-use helper
+Relying on instance variables makes it difficult to reuse helper
 methods.
 
 If it seems awkward to explicitly pass in each dependent

--- a/lib/rubocop/cop/rails/helper_instance_variable.rb
+++ b/lib/rubocop/cop/rails/helper_instance_variable.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks for use of the helper methods which reference
       # instance variables.
       #
-      # Relying on instance variables makes it difficult to re-use helper
+      # Relying on instance variables makes it difficult to reuse helper
       # methods.
       #
       # If it seems awkward to explicitly pass in each dependent


### PR DESCRIPTION
This replaces "re-use" with "reuse", which was [flagged](https://github.com/rubocop/rubocop-rails/actions/runs/6418291313/job/17425777413?pr=38) on #38 for some reason. That PR didn't touch those files, but I figured I'd fix them anyway.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
* ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
