### PR TITLE
[Fix #1105] Fix false positives for `Rails/RedundantPresenceValidationOnBelongsTo`

### DIFF
--- a/changelog/fix_false_positives_for_redundant_presence_validation_on_belongs_to.md
+++ b/changelog/fix_false_positives_for_redundant_presence_validation_on_belongs_to.md
@@ -1,0 +1,1 @@
+* [#1105](https://github.com/rubocop/rubocop-rails/issues/1105): Fix false positives for `Rails/RedundantPresenceValidationOnBelongsTo` when using `validates` with `:if` or `:unless` options. ([@koic][])

--- a/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
+++ b/lib/rubocop/cop/rails/redundant_presence_validation_on_belongs_to.rb
@@ -53,6 +53,12 @@ module RuboCop
         #   @example source that matches - by a foreign key
         #     validates :user_id, presence: true
         #
+        #   @example source that DOES NOT match - if condition
+        #     validates :user_id, presence: true, if: condition
+        #
+        #   @example source that DOES NOT match - unless condition
+        #     validates :user_id, presence: true, unless: condition
+        #
         #   @example source that DOES NOT match - strict validation
         #     validates :user_id, presence: true, strict: true
         #
@@ -65,6 +71,7 @@ module RuboCop
             $[
               (hash <$(pair (sym :presence) true) ...>)         # presence: true
               !(hash <$(pair (sym :strict) {true const}) ...>)  # strict: true
+              !(hash <$(pair (sym {:if :unless}) _) ...>)       # if: some_condition or unless: some_condition
             ]
           )
         PATTERN

--- a/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
@@ -271,6 +271,20 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
       RUBY
     end
 
+    it 'does not register an offense with `if` option' do
+      expect_no_offenses(<<~RUBY)
+        belongs_to :user
+        validates :user, presence: true, if: -> { condition }
+      RUBY
+    end
+
+    it 'does not register an offense with `unless` option' do
+      expect_no_offenses(<<~RUBY)
+        belongs_to :user
+        validates :user, presence: true, unless: -> { condition }
+      RUBY
+    end
+
     it 'does not register an offense with strict validation' do
       expect_no_offenses(<<~RUBY)
         belongs_to :user


### PR DESCRIPTION
Fixes #1105.

This PR fixes false positives for `Rails/RedundantPresenceValidationOnBelongsTo` when using `validates` with `:if` or `:unless` options.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
