### PR TITLE
[Fix #1041] Fix a false positive for `Rails/Output`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_output.md
+++ b/changelog/fix_a_false_positive_for_rails_output.md
@@ -1,0 +1,1 @@
+* [#1041](https://github.com/rubocop/rubocop-rails/issues/1041): Fix a false positive for `Rails/Output` when output method is called with block argument. ([@koic][])

--- a/lib/rubocop/cop/rails/output.rb
+++ b/lib/rubocop/cop/rails/output.rb
@@ -23,6 +23,7 @@ module RuboCop
 
         MSG = "Do not write to stdout. Use Rails's logger if you want to log."
         RESTRICT_ON_SEND = %i[ap p pp pretty_print print puts binwrite syswrite write write_nonblock].freeze
+        ALLOWED_TYPES = %i[send csend block numblock].freeze
 
         def_node_matcher :output?, <<~PATTERN
           (send nil? {:ap :p :pp :pretty_print :print :puts} ...)
@@ -39,8 +40,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if node.parent&.call_type?
-          return unless output?(node) || io_output?(node)
+          return if ALLOWED_TYPES.include?(node.parent&.type)
+          return if !output?(node) && !io_output?(node)
 
           range = offense_range(node)
 

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -140,6 +140,27 @@ RSpec.describe RuboCop::Cop::Rails::Output, :config do
     RUBY
   end
 
+  it 'does not register an offense when the `p` method is called with block argument' do
+    expect_no_offenses(<<~RUBY)
+      # phlex-rails gem.
+      div do
+        p { 'Some text' }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when io method is called with block argument' do
+    expect_no_offenses(<<~RUBY)
+      obj.write { do_somethig }
+    RUBY
+  end
+
+  it 'does not register an offense when io method is called with numbered block argument' do
+    expect_no_offenses(<<~RUBY)
+      obj.write { do_something(_1) }
+    RUBY
+  end
+
   it 'does not register an offense when a method is ' \
      'safe navigation called to a local variable with the same name as a print method' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #1041.

This PR fixes a false positive for `Rails/Output` when output method is called with block argument.

The output method for the bad case is not designed to take a block argument. Thus, by ignoring this, it can likely reduce false positives.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
