### PR TITLE
[Fix #1143, #1138] Bump minimum required rubocop version to 1.52

### DIFF
--- a/changelog/fix_required_minimum_rubocop_version.md
+++ b/changelog/fix_required_minimum_rubocop_version.md
@@ -1,0 +1,1 @@
+* [#1143](https://github.com/rubocop/rubocop-rails/issues/1143): Fix crash by bumping minimum required rubocop version from 1.33 to 1.52. ([@zarthus][])

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_runtime_dependency 'rack', '>= 1.1'
-  s.add_runtime_dependency 'rubocop', '>= 1.33.0', '< 2.0'
+  s.add_runtime_dependency 'rubocop', '>= 1.52.0', '< 2.0'
 end


### PR DESCRIPTION
Update minimum required rubocop version since 2.21.2 (#1143, #1138)


I am not sure if this should be considered a "fix" so much as a mitigation. Feel free to do what makes the most sense to you as maintainer - this improves error messages but does not resolve the root problem. For this reason, I am merely referencing the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
