### PR TITLE
[Fix #1128] Make `Rails/DuplicateAssociation` aware of duplicate `class_name`

### DIFF
--- a/changelog/new_make_rails_duplicate_association_aware_of_duplicate_class_name.md
+++ b/changelog/new_make_rails_duplicate_association_aware_of_duplicate_class_name.md
@@ -1,0 +1,1 @@
+* [#1128](https://github.com/rubocop/rubocop-rails/issues/1128): Make `Rails/DuplicateAssociation` aware of duplicate `class_name`. ([@koic][])

--- a/lib/rubocop/cop/rails/duplicate_association.rb
+++ b/lib/rubocop/cop/rails/duplicate_association.rb
@@ -20,6 +20,15 @@ module RuboCop
       #   belongs_to :bar
       #   has_one :foo
       #
+      #   # bad
+      #   belongs_to :foo, class_name: 'Foo'
+      #   belongs_to :bar, class_name: 'Foo'
+      #   has_one :baz
+      #
+      #   # good
+      #   belongs_to :bar, class_name: 'Foo'
+      #   has_one :foo
+      #
       class DuplicateAssociation < Base
         include RangeHelp
         extend AutoCorrector
@@ -27,31 +36,75 @@ module RuboCop
         include ActiveRecordHelper
 
         MSG = "Association `%<name>s` is defined multiple times. Don't repeat associations."
+        MSG_CLASS_NAME = "Association `class_name: %<name>s` is defined multiple times. Don't repeat associations."
 
         def_node_matcher :association, <<~PATTERN
-          (send nil? {:belongs_to :has_one :has_many :has_and_belongs_to_many} ({sym str} $_) ...)
+          (send nil? {:belongs_to :has_one :has_many :has_and_belongs_to_many} ({sym str} $_) $...)
+        PATTERN
+
+        def_node_matcher :class_name, <<~PATTERN
+          (hash (pair (sym :class_name) $_))
         PATTERN
 
         def on_class(class_node)
           return unless active_record?(class_node.parent_class)
 
-          offenses(class_node).each do |name, nodes|
-            nodes.each do |node|
-              add_offense(node, message: format(MSG, name: name)) do |corrector|
-                next if same_line?(nodes.last, node)
+          association_nodes = association_nodes(class_node)
 
-                corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
-              end
-            end
+          duplicated_association_name_nodes(association_nodes).each do |name, nodes|
+            register_offense(name, nodes, MSG)
+          end
+
+          duplicated_class_name_nodes(association_nodes).each do |class_name, nodes|
+            register_offense(class_name, nodes, MSG_CLASS_NAME)
           end
         end
 
         private
 
-        def offenses(class_node)
-          class_send_nodes(class_node).select { |node| association(node) }
-                                      .group_by { |node| association(node).to_sym }
-                                      .select { |_, nodes| nodes.length > 1 }
+        def register_offense(name, nodes, message_template)
+          nodes.each do |node|
+            add_offense(node, message: format(message_template, name: name)) do |corrector|
+              next if same_line?(nodes.last, node)
+
+              corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
+            end
+          end
+        end
+
+        def association_nodes(class_node)
+          class_send_nodes(class_node).select do |node|
+            association(node)&.first
+          end
+        end
+
+        def duplicated_association_name_nodes(association_nodes)
+          grouped_associations = association_nodes.group_by do |node|
+            association(node).first.to_sym
+          end
+
+          leave_duplicated_association(grouped_associations)
+        end
+
+        def duplicated_class_name_nodes(association_nodes)
+          grouped_associations = association_nodes.group_by do |node|
+            arguments = association(node).last
+            next unless arguments.count == 1
+
+            if (class_name = class_name(arguments.first))
+              class_name.source
+            end
+          end
+
+          grouped_associations.delete(nil)
+
+          leave_duplicated_association(grouped_associations)
+        end
+
+        def leave_duplicated_association(grouped_associations)
+          grouped_associations.select do |_, nodes|
+            nodes.length > 1
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #1128.

This PR makes `Rails/DuplicateAssociation` aware of duplicate `class_name`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
