### PR TITLE
[Fix #952] Fix a false positive for `Rails/NotNullColumn`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_not_null_column.md
+++ b/changelog/fix_a_false_positive_for_rails_not_null_column.md
@@ -1,0 +1,1 @@
+* [#952](https://github.com/rubocop/rubocop-rails/issues/952): Fix a false positive for `Rails/NotNullColumn` when using `null: false` for MySQL's TEXT type. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -694,6 +694,9 @@ Rails/NotNullColumn:
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '2.20'
+  Database: null
+  SupportedDatabases:
+    - mysql
   Include:
     - db/**/*.rb
 

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -113,4 +113,41 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
       end
     end
   end
+
+  context 'when database is MySQL' do
+    let(:cop_config) do
+      { 'Database' => 'mysql' }
+    end
+
+    it 'does not register an offense when using `null: false` for `:text` type' do
+      expect_no_offenses(<<~RUBY)
+        def change
+          add_column :articles, :content, :text, null: false
+        end
+      RUBY
+    end
+
+    it "does not register an offense when using `null: false` for `'text'` type" do
+      expect_no_offenses(<<~RUBY)
+        def change
+          add_column :articles, :content, 'text', null: false
+        end
+      RUBY
+    end
+  end
+
+  context 'when database is PostgreSQL' do
+    let(:cop_config) do
+      { 'Database' => 'postgresql' }
+    end
+
+    it 'registers an offense when using `null: false` for `:text` type' do
+      expect_offense(<<~RUBY)
+        def change
+          add_column :articles, :content, :text, null: false
+                                                 ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #952.

This PR fixes a false positive for `Rails/NotNullColumn` when using `null: false` for MySQL's TEXT type.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
