### PR TITLE
Support the Trilogy adapter for MySQL

### DIFF
--- a/changelog/new_support_trilogy_adapter_for_mysql.md
+++ b/changelog/new_support_trilogy_adapter_for_mysql.md
@@ -1,0 +1,1 @@
+* [#1147](https://github.com/rubocop/rubocop-rails/issues/1147): Support the Trilogy adapter for MySQL. ([@koic][])

--- a/lib/rubocop/cop/mixin/database_type_resolvable.rb
+++ b/lib/rubocop/cop/mixin/database_type_resolvable.rb
@@ -21,7 +21,7 @@ module RuboCop
         return unless database_yaml
 
         case database_adapter
-        when 'mysql2'
+        when 'mysql2', 'trilogy'
           MYSQL
         when 'postgresql'
           POSTGRESQL
@@ -33,7 +33,7 @@ module RuboCop
         return unless url
 
         case url
-        when %r{\Amysql2://}
+        when %r{\A(mysql2|trilogy)://}
           MYSQL
         when %r{\Apostgres(ql)?://}
           POSTGRESQL

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -14,7 +14,7 @@ module RuboCop
       # automatically detect an adapter from `development` environment
       # in `config/database.yml` or the environment variable `DATABASE_URL`
       # when the `Database` option is not set.
-      # If the adapter is not `mysql2` or `postgresql`,
+      # If the adapter is not `mysql2`, `trilogy`, or `postgresql`,
       # this Cop ignores offenses.
       #
       # @example

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -479,6 +479,34 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       end
     end
 
+    context 'trilogy' do
+      context 'with top-level adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'adapter' => 'trilogy'
+            }
+          }
+        end
+
+        it_behaves_like 'offense for mysql'
+      end
+
+      context 'with nested adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'primary' => {
+                'adapter' => 'trilogy'
+              }
+            }
+          }
+        end
+
+        it_behaves_like 'offense for mysql'
+      end
+    end
+
     context 'postgresql' do
       context 'with top-level adapter configuration' do
         let(:yaml) do
@@ -537,6 +565,12 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
 
     context 'mysql2' do
       let(:database_url) { 'mysql2://localhost/my_database' }
+
+      it_behaves_like 'offense for mysql'
+    end
+
+    context 'trilogy' do
+      let(:database_url) { 'trilogy://localhost/my_database' }
 
       it_behaves_like 'offense for mysql'
     end


### PR DESCRIPTION
This PR supports the Trilogy adapter for MySQL.
https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released#built-in-support-for-the-trilogy-mysql-adapter

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
