### PR TITLE
[Fix #1039] Deprecate `Rails/ActionFilter` cop

### DIFF
--- a/changelog/change_deprecate_rails_action_filter_cop.md
+++ b/changelog/change_deprecate_rails_action_filter_cop.md
@@ -1,0 +1,1 @@
+* [#1039](https://github.com/rubocop/rubocop-rails/issues/1039): Deprecate `Rails/ActionFilter` cop. ([@koic][])

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -8,6 +8,9 @@ module RuboCop
       # The cop is configurable and can enforce the use of the older
       # something_filter methods or the newer something_action methods.
       #
+      # IMPORTANT: This cop is deprecated. Because the `*_filter` methods were removed in Rails 4.2,
+      # and that Rals version is no longer supported by RuboCop Rails. This cop will be removed in RuboCop Rails 3.0.
+      #
       # @example EnforcedStyle: action (default)
       #   # bad
       #   after_filter :do_stuff


### PR DESCRIPTION
Fixes #1039.

This PR deprecates `Rails/ActionFilter` cop. Because the `*_filter` methods were removed in Rails 4.2, and that Rals version is no longer supported by RuboCop Rails. This cop will be removed in RuboCop Rails 3.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
