### PR TITLE
Add more dangerous column names to `Rails/DangerousColumnNames`

### DIFF
--- a/changelog/change_add_more_dangerous_column_names_to.md
+++ b/changelog/change_add_more_dangerous_column_names_to.md
@@ -1,0 +1,1 @@
+* [#1152](https://github.com/rubocop/rubocop-rails/pull/1152): Add more dangerous column names to `Rails/DangerousColumnNames`. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/dangerous_column_names.rb
+++ b/lib/rubocop/cop/rails/dangerous_column_names.rb
@@ -31,10 +31,11 @@ module RuboCop
           time
         ].to_set.freeze
 
-        # Generated from `ActiveRecord::AttributeMethods.dangerous_attribute_methods` on activerecord 7.0.5.
+        # Generated from `ActiveRecord::AttributeMethods.dangerous_attribute_methods` on activerecord 7.1.0.
         # rubocop:disable Metrics/CollectionLiteralLength
         DANGEROUS_COLUMN_NAMES = %w[
           __callbacks
+          __id__
           _assign_attribute
           _assign_attributes
           _before_commit_callbacks
@@ -195,11 +196,13 @@ module RuboCop
           changes_to_save
           check_record_limit
           ciphertext_for
+          class
           clear_attribute_change
           clear_attribute_changes
           clear_changes_information
           clear_timestamp_attributes
           clear_transaction_record_state
+          clone
           collection_cache_versioning
           column_for_attribute
           committed
@@ -227,6 +230,7 @@ module RuboCop
           destroyed
           destroyed_by_association
           destroyed_by_association=
+          dup
           each_counter_cached_associations
           encode_with
           encrypt
@@ -243,7 +247,9 @@ module RuboCop
           find_parameter_position
           forget_attribute_assignments
           format_for_inspect
+          freeze
           from_json
+          frozen?
           halted_callback_hook
           has_attribute
           has_changes_to_save
@@ -252,6 +258,7 @@ module RuboCop
           has_encrypted_attributes
           has_encrypted_rich_texts
           has_transactional_callbacks
+          hash
           id
           id_before_type_cast
           id_for_database
@@ -283,6 +290,7 @@ module RuboCop
           new_record
           no_touching
           normalize_reflection_attribute
+          object_id
           partial_inserts
           partial_updates
           perform_validations


### PR DESCRIPTION
Between rails 7.0.5 and 7.1.0, several more method names were added as dangerous targets, so I will add them to this cop as well in this pull request.

- https://github.com/rails/rails/pull/45883
  - `__id__`
  - `class`
  - `clone`
  - `dup`
  - `freeze`
  - `frozen?`
  - `hash`
  - `object_id`
- https://github.com/rails/rails/pull/46394
  - `frozen?`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
