### PR TITLE
Support some Rails 7.1's new querying methods for `Rails/RedundantActiveRecordAllMethod`

### DIFF
--- a/changelog/new_support_rails_7_1_methods_for_redundant_active_record_all_method.md
+++ b/changelog/new_support_rails_7_1_methods_for_redundant_active_record_all_method.md
@@ -1,0 +1,1 @@
+* [#1158](https://github.com/rubocop/rubocop-rails/pull/1158): Support some Rails 7.1's new querying methods for `Rails/RedundantActiveRecordAllMethod`. ([@koic][])

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -35,11 +35,19 @@ module RuboCop
 
         RESTRICT_ON_SEND = [:all].freeze
 
-        # Defined methods in `ActiveRecord::Querying::QUERYING_METHODS` on activerecord 7.0.5.
+        # Defined methods in `ActiveRecord::Querying::QUERYING_METHODS` on activerecord 7.1.0.
         QUERYING_METHODS = %i[
           and
           annotate
           any?
+          async_average
+          async_count
+          async_ids
+          async_maximum
+          async_minimum
+          async_pick
+          async_pluck
+          async_sum
           average
           calculate
           count
@@ -109,6 +117,7 @@ module RuboCop
           preload
           readonly
           references
+          regroup
           reorder
           reselect
           rewhere
@@ -130,6 +139,7 @@ module RuboCop
           unscope
           update_all
           where
+          with
           without
         ].to_set.freeze
 

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
           and
           annotate
           any?
+          async_average
+          async_count
+          async_ids
+          async_maximum
+          async_minimum
+          async_pick
+          async_pluck
+          async_sum
           average
           calculate
           count
@@ -77,6 +85,7 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
           preload
           readonly
           references
+          regroup
           reorder
           reselect
           rewhere
@@ -98,6 +107,7 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
           unscope
           update_all
           where
+          with
           without
         ].to_set
       )


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/44446, https://github.com/rails/rails/pull/37944, https://github.com/rails/rails/pull/46503, and https://github.com/rails/rails/pull/47010.

This PR supports some Rails 7.1's new querying methods for `Rails/RedundantActiveRecordAllMethod`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
