### PR TITLE
[Fix #1158] Rails/HasManyOrHasOneDependent reports false positive when has_many or has_one called on explicit receiver

### DIFF
--- a/changelog/fix_has_many_or_has_one_dependent_false_positive.md
+++ b/changelog/fix_has_many_or_has_one_dependent_false_positive.md
@@ -1,0 +1,1 @@
+* [#1158](https://github.com/rubocop/rubocop-rails/issues/1158): `Rails/HasManyOrHasOneDependent` does not add offence when has_many or has_one is called on an explicit receiver. ([@samrjenkins][])

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -60,7 +60,7 @@ module RuboCop
           (block
             (send nil? :with_options
               (hash $...))
-            (args) ...)
+            (args _?) ...)
         PATTERN
 
         def_node_matcher :association_extension_block?, <<~PATTERN

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when has_one called on explicit receiver' do
+        expect_no_offenses(<<~RUBY)
+          class Person < ApplicationRecord
+            with_options dependent: :destroy do |model|
+              model.has_one :foo
+            end
+          end
+        RUBY
+      end
     end
   end
 
@@ -183,6 +193,16 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent, :config do
           class Person < ApplicationRecord
             with_options dependent: :destroy do
               has_many :foo
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when has_many called on explicit receiver' do
+        expect_no_offenses(<<~RUBY)
+          class Person < ApplicationRecord
+            with_options dependent: :destroy do |model|
+              model.has_many :foo
             end
           end
         RUBY


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rails/issues/1158

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
