### PR TITLE
[Fix #1143] Fix an error for `Rails/RedundantActiveRecordAllMethod`

### DIFF
--- a/changelog/fix_an_error_for_rails_redundant_active_record_all_method.md
+++ b/changelog/fix_an_error_for_rails_redundant_active_record_all_method.md
@@ -1,0 +1,1 @@
+* [#1143](https://github.com/rubocop/rubocop-rails/issues/1143): Fix an error for `Rails/RedundantActiveRecordAllMethod` when using RuboCop 1.51 or lower. ([@koic][])

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -172,6 +172,35 @@ module RuboCop
         def offense_range(node)
           range_between(node.loc.selector.begin_pos, node.source_range.end_pos)
         end
+
+        # TODO: In the future, please support only RuboCop 1.52+ and use `RuboCop::Cop::AllowedReceivers`:
+        #       https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/cop/mixin/allowed_receivers.rb
+        #       At that time, this duplicated module implementation can be removed.
+        module AllowedReceivers
+          def allowed_receiver?(receiver)
+            receiver_name = receiver_name(receiver)
+
+            allowed_receivers.include?(receiver_name)
+          end
+
+          def receiver_name(receiver)
+            return receiver_name(receiver.receiver) if receiver.receiver && !receiver.receiver.const_type?
+
+            if receiver.send_type?
+              if receiver.receiver
+                "#{receiver_name(receiver.receiver)}.#{receiver.method_name}"
+              else
+                receiver.method_name.to_s
+              end
+            else
+              receiver.source
+            end
+          end
+
+          def allowed_receivers
+            cop_config.fetch('AllowedReceivers', [])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1143.

This PR fixes an error for `Rails/RedundantActiveRecordAllMethod` when using RuboCop 1.51 or lower.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
