### PR TITLE
[Fix #1145] Fix a false positive for `Rails/DuplicateAssociation`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_duplicate_association.md
+++ b/changelog/fix_a_false_positive_for_rails_duplicate_association.md
@@ -1,0 +1,1 @@
+* [#1145](https://github.com/rubocop/rubocop-rails/issues/1145): Fix a false positive for `Rails/DuplicateAssociation` when using duplicate `belongs_to` associations of same class without other arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/duplicate_association.rb
+++ b/lib/rubocop/cop/rails/duplicate_association.rb
@@ -21,12 +21,12 @@ module RuboCop
       #   has_one :foo
       #
       #   # bad
-      #   belongs_to :foo, class_name: 'Foo'
-      #   belongs_to :bar, class_name: 'Foo'
+      #   has_many :foo, class_name: 'Foo'
+      #   has_many :bar, class_name: 'Foo'
       #   has_one :baz
       #
       #   # good
-      #   belongs_to :bar, class_name: 'Foo'
+      #   has_many :bar, class_name: 'Foo'
       #   has_one :foo
       #
       class DuplicateAssociation < Base
@@ -87,7 +87,8 @@ module RuboCop
         end
 
         def duplicated_class_name_nodes(association_nodes)
-          grouped_associations = association_nodes.group_by do |node|
+          filtered_nodes = association_nodes.reject { |node| node.method?(:belongs_to) }
+          grouped_associations = filtered_nodes.group_by do |node|
             arguments = association(node).last
             next unless arguments.count == 1
 

--- a/spec/rubocop/cop/rails/duplicate_association_spec.rb
+++ b/spec/rubocop/cop/rails/duplicate_association_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
       RUBY
     end
 
-    it 'registers offenses when using duplicate associations of same class without other arguments' do
+    it 'registers offenses when using duplicate `has_*` associations of same class without other arguments' do
       expect_offense(<<~RUBY)
         class Post < ApplicationRecord
           has_many :foos, class_name: 'Foo'
@@ -230,6 +230,15 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
           has_many :bars, class_name: 'Foo'
 
           has_one :qux, class_name: 'Bar'
+        end
+      RUBY
+    end
+
+    it 'does not register an offenses when using duplicate `belongs_to` assocs of same class without other args' do
+      expect_no_offenses(<<~RUBY)
+        class Post < ApplicationRecord
+          belongs_to :foos, class_name: 'Foo'
+          belongs_to :bars, class_name: 'Foo'
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #1145.

This PR fixes a false positive for `Rails/DuplicateAssociation` when using duplicate `belongs_to` associations of same class without other arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
