### PR TITLE
Change `Rails/RedundantActiveRecordAllMethod` to ignore `delete_all` and `destroy_all` when receiver is an association

### DIFF
--- a/changelog/change_rails_redundant_active_record_all_method.md
+++ b/changelog/change_rails_redundant_active_record_all_method.md
@@ -1,0 +1,1 @@
+* [#1171](https://github.com/rubocop/rubocop-rails/pull/1171): Change `Rails/RedundantActiveRecordAllMethod` to ignore `delete_all` and `destroy_all` when receiver is an association. ([@masato-bkn][])

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -421,6 +421,36 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
     end
   end
 
+  described_class::SENSITIVE_METHODS_ON_ASSOCIATION.each do |method|
+    context "using `#{method}`" do
+      it "registers an offense when using `#{method}` and the receiver for `all` is a model" do
+        expect_offense(<<~RUBY)
+          User.all.#{method}
+               ^^^ Redundant `all` detected.
+        RUBY
+      end
+
+      it "does not register an offense when using `#{method}` and the receiver for `all` is an association" do
+        expect_no_offenses(<<~RUBY)
+          user.articles.all.#{method}
+        RUBY
+      end
+
+      it "does not register an offense when using `#{method}` and the receiver for `all` is a relation" do
+        expect_no_offenses(<<~RUBY)
+          users = User.all
+          users.all.#{method}
+        RUBY
+      end
+
+      it "does not register an offense when using `#{method}` and `all` has no receiver" do
+        expect_no_offenses(<<~RUBY)
+          all.#{method}
+        RUBY
+      end
+    end
+  end
+
   context 'with `AllowedReceivers` config' do
     let(:cop_config) do
       { 'AllowedReceivers' => %w[ActionMailer::Preview ActiveSupport::TimeZone] }


### PR DESCRIPTION
This PR changes `Rails/RedundantActiveRecordAllMethod` to ignore `delete_all` and `destroy_all` when the receiver is an association (e.g., user.articles.all.delete_all). It only checks cases where the receiver is a model.

As pointed out in https://github.com/rubocop/rails-style-guide/issues/347, it has been found that when the receiver of `all` is an association, omitting `all` can change the behavior of certain methods.  I think that in cases where behavior could change, it would be better for the cop not to add an offense.

## Methods that change behavior
Currently, among the methods targeted by this cop, the following methods have been confirmed to change behavior when `all` is omitted from an association:

- `delete_all`
- `destroy_all`

**delete_all**
```ruby
user.articles.all.delete_all
# Method: `ActiveRecord::Relation#delete_all`
# SQL: DELETE FROM articles WHERE articles.user_id = 1
# Doc:  https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-delete_all

user.articles.delete_all
# Method: `ActiveRecord::Associations::CollectionProxy#delete_all`  
# SQL: UPDATE articles SET user_id = NULL WHERE articles.user_id = 1
# Doc: https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-delete_all
```

**destroy_all**
```ruby
user.articles.all.destroy_all 
# Method: `ActiveRecord::Relation#destroy_all`
# Behavior: Does not execute callbacks
# Doc: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_all

user.articles.destroy_all
# Method: `ActiveRecord::Associations::CollectionProxy#destroy_all`
# Behavior: Executes callbacks
# Doc: https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-destroy_all
```

## Additional Context
Several approaches can be taken regarding the cop itself, but it's challenging to decide on a policy:

1. Add an offense for `delete_all` and `destroy_all` only when the receiver is a Model (e.g., `User.all.delete_all`). If the receiver might be an association, do not add an offense. (<- **This PR**)
2. For cases where the receiver of `all` is an association for `delete_all` and `destroy_all`, output an offensive message indicating that omitting `all` changes the behavior.
    - It might be challenging to come up with a concise and clear message.
3. Do not modify the cop implementation. Only add a cautionary note to the this cop description. 

I think that in cases where behavior could change, it would be better for the cop not to add an offense. I had my doubts, but for this PR, I've decided to adopt the first approach.

Any feedback on the policy for handling this cop would be greatly appreciated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
~~* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
