### PR TITLE
[Fix #1172] Fix an error for `Rails/UnknownEnv`

### DIFF
--- a/changelog/fix_an_error_for_rails_unknown_env.md
+++ b/changelog/fix_an_error_for_rails_unknown_env.md
@@ -1,0 +1,1 @@
+* [#1172](https://github.com/rubocop/rubocop-rails/issues/1172): Fix an error for `Rails/UnknownEnv` when using Rails 7.1. ([@koic][])

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -87,9 +87,9 @@ module RuboCop
 
         def environments
           @environments ||= begin
-            e = cop_config['Environments']
-            e += ['local'] if target_rails_version >= 7.1
-            e
+            environments = cop_config['Environments'] || []
+            environments << 'local' if target_rails_version >= 7.1
+            environments
           end
         end
       end

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -91,5 +91,20 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
         Rails.env == 'local'
       RUBY
     end
+
+    context 'when `Environments` is nil' do
+      let(:cop_config) do
+        {
+          'Environments' => nil
+        }
+      end
+
+      it 'accepts local as an environment name' do
+        expect_no_offenses(<<~RUBY)
+          Rails.env.local?
+          Rails.env == 'local'
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1172.

This PR fixes an error for `Rails/UnknownEnv` when using Rails 7.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
