### PR TITLE
Refactor test structure in redundant_active_record_all_method_spec

### DIFF
--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -114,227 +114,225 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
     end
   end
 
-  context 'with receiver' do
-    [
-      'and(User.where(age: 30))',
-      'annotate("selecting id")',
-      'any?',
-      'average(:age)',
-      'calculate(:average, :age)',
-      'count',
-      'create_or_find_by(name: name)',
-      'create_or_find_by!(name: name)',
-      'create_with(name: name)',
-      'delete_all',
-      'delete_by(id: id)',
-      'destroy_all',
-      'destroy_by(id: id)',
-      'distinct',
-      'eager_load(:articles)',
-      'except(:order)',
-      'excluding(user)',
-      'exists?',
-      'extending(Pagination)',
-      'extract_associated(:articles)',
-      'fifth',
-      'fifth!',
-      'find(id)',
-      'find_by(name: name)',
-      'find_by!(name: name)',
-      'find_each(&:do_something)',
-      'find_in_batches(&:do_something)',
-      'find_or_create_by(name: name)',
-      'find_or_create_by!(name: name)',
-      'find_or_initialize_by(name: name)',
-      'find_sole_by(name: name)',
-      'first',
-      'first!',
-      'first_or_create(name: name)',
-      'first_or_create!(name: name)',
-      'first_or_initialize(name: name)',
-      'forty_two',
-      'forty_two!',
-      'fourth',
-      'fourth!',
-      'from("users")',
-      'group(:age)',
-      'having("AVG(age) > 30")',
-      'ids',
-      'in_batches(&:do_something)',
-      'in_order_of(:id, ids)',
-      'includes(:articles)',
-      'invert_where',
-      'joins(:articles)',
-      'last',
-      'last!',
-      'left_joins(:articles)',
-      'left_outer_joins(:articles)',
-      'limit(n)',
-      'lock',
-      'many?',
-      'maximum(:age)',
-      'merge(users)',
-      'minimum(:age)',
-      'none',
-      'none?',
-      'offset(n)',
-      'one?',
-      'only(:order)',
-      'optimizer_hints("SeqScan(users)", "Parallel(users 8)")',
-      'or(User.where(age: 30))',
-      'order(:created_at)',
-      'pick(:id)',
-      'pluck(:age)',
-      'preload(:articles)',
-      'readonly',
-      'references(:articles)',
-      'reorder(:created_at)',
-      'reselect(:age)',
-      'rewhere(id: ids)',
-      'second',
-      'second!',
-      'second_to_last',
-      'second_to_last!',
-      'select(:age)',
-      'sole',
-      'strict_loading',
-      'sum(:age)',
-      'take(n)',
-      'take!',
-      'third',
-      'third!',
-      'third_to_last',
-      'third_to_last!',
-      'touch_all',
-      'unscope(:order)',
-      'update_all(name: name)',
-      'where(id: ids)',
-      'without(user)'
-    ].each do |source|
-      it "registers an offense and corrects when `all.#{source}`" do
-        expect_offense(<<~RUBY)
-          User.all.#{source}
-               ^^^ Redundant `all` detected.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          User.#{source}
-        RUBY
-      end
-    end
-
-    it 'registers an offense and corrects when the receiver for `all` is Active Record relation object' do
+  [
+    'and(User.where(age: 30))',
+    'annotate("selecting id")',
+    'any?',
+    'average(:age)',
+    'calculate(:average, :age)',
+    'count',
+    'create_or_find_by(name: name)',
+    'create_or_find_by!(name: name)',
+    'create_with(name: name)',
+    'delete_all',
+    'delete_by(id: id)',
+    'destroy_all',
+    'destroy_by(id: id)',
+    'distinct',
+    'eager_load(:articles)',
+    'except(:order)',
+    'excluding(user)',
+    'exists?',
+    'extending(Pagination)',
+    'extract_associated(:articles)',
+    'fifth',
+    'fifth!',
+    'find(id)',
+    'find_by(name: name)',
+    'find_by!(name: name)',
+    'find_each(&:do_something)',
+    'find_in_batches(&:do_something)',
+    'find_or_create_by(name: name)',
+    'find_or_create_by!(name: name)',
+    'find_or_initialize_by(name: name)',
+    'find_sole_by(name: name)',
+    'first',
+    'first!',
+    'first_or_create(name: name)',
+    'first_or_create!(name: name)',
+    'first_or_initialize(name: name)',
+    'forty_two',
+    'forty_two!',
+    'fourth',
+    'fourth!',
+    'from("users")',
+    'group(:age)',
+    'having("AVG(age) > 30")',
+    'ids',
+    'in_batches(&:do_something)',
+    'in_order_of(:id, ids)',
+    'includes(:articles)',
+    'invert_where',
+    'joins(:articles)',
+    'last',
+    'last!',
+    'left_joins(:articles)',
+    'left_outer_joins(:articles)',
+    'limit(n)',
+    'lock',
+    'many?',
+    'maximum(:age)',
+    'merge(users)',
+    'minimum(:age)',
+    'none',
+    'none?',
+    'offset(n)',
+    'one?',
+    'only(:order)',
+    'optimizer_hints("SeqScan(users)", "Parallel(users 8)")',
+    'or(User.where(age: 30))',
+    'order(:created_at)',
+    'pick(:id)',
+    'pluck(:age)',
+    'preload(:articles)',
+    'readonly',
+    'references(:articles)',
+    'reorder(:created_at)',
+    'reselect(:age)',
+    'rewhere(id: ids)',
+    'second',
+    'second!',
+    'second_to_last',
+    'second_to_last!',
+    'select(:age)',
+    'sole',
+    'strict_loading',
+    'sum(:age)',
+    'take(n)',
+    'take!',
+    'third',
+    'third!',
+    'third_to_last',
+    'third_to_last!',
+    'touch_all',
+    'unscope(:order)',
+    'update_all(name: name)',
+    'where(id: ids)',
+    'without(user)'
+  ].each do |source|
+    it "registers an offense and corrects when `all.#{source}`" do
       expect_offense(<<~RUBY)
-        user.articles.all.order(:created_at)
-                      ^^^ Redundant `all` detected.
+        User.all.#{source}
+             ^^^ Redundant `all` detected.
       RUBY
 
       expect_correction(<<~RUBY)
-        user.articles.order(:created_at)
+        User.#{source}
       RUBY
     end
+  end
 
+  it 'registers an offense and corrects when the receiver for `all` is Active Record relation object' do
+    expect_offense(<<~RUBY)
+      user.articles.all.order(:created_at)
+                    ^^^ Redundant `all` detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      user.articles.order(:created_at)
+    RUBY
+  end
+
+  it 'does not register an offense when no method follows `all`' do
+    expect_no_offenses(<<~RUBY)
+      User.all
+    RUBY
+  end
+
+  it 'does not register an offense when not using defined methods in `ActiveRecord::Querying::QUERYING_METHODS`' do
+    expect_no_offenses(<<~RUBY)
+      User.all.map(&:do_something)
+    RUBY
+  end
+
+  context 'when `all` is used as a method parameter' do
     it 'does not register an offense when no method follows `all`' do
       expect_no_offenses(<<~RUBY)
-        User.all
+        do_something(User.all)
       RUBY
     end
 
-    it 'does not register an offense when not using defined methods in `ActiveRecord::Querying::QUERYING_METHODS`' do
+    it 'registers an offense and corrects when `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+      expect_offense(<<~RUBY)
+        do_something(User.all.order(:created_at))
+                          ^^^ Redundant `all` detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(User.order(:created_at))
+      RUBY
+    end
+
+    it 'does not register an offense when method matches `ActiveRecord::Querying::QUERYING_METHODS`' do
       expect_no_offenses(<<~RUBY)
-        User.all.map(&:do_something)
+        sum(User.all)
+      RUBY
+    end
+  end
+
+  context 'when `all` has any parameters, it indicates that it is not an Active Record `all`' do
+    it 'does not register an offense when no method follows `all`' do
+      expect_no_offenses(<<~RUBY)
+        page.all(:parameter)
       RUBY
     end
 
-    context 'when `all` is used as a method parameter' do
-      it 'does not register an offense when no method follows `all`' do
-        expect_no_offenses(<<~RUBY)
-          do_something(User.all)
-        RUBY
-      end
-
-      it 'registers an offense and corrects when `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
-        expect_offense(<<~RUBY)
-          do_something(User.all.order(:created_at))
-                            ^^^ Redundant `all` detected.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          do_something(User.order(:created_at))
-        RUBY
-      end
-
-      it 'does not register an offense when method matches `ActiveRecord::Querying::QUERYING_METHODS`' do
-        expect_no_offenses(<<~RUBY)
-          sum(User.all)
-        RUBY
-      end
+    it 'does not register an offense when method follows `all`' do
+      expect_no_offenses(<<~RUBY)
+        page.all(:parameter).do_something
+      RUBY
     end
 
-    context 'when `all` has any parameters, it indicates that it is not an Active Record `all`' do
-      it 'does not register an offense when no method follows `all`' do
-        expect_no_offenses(<<~RUBY)
-          page.all(:parameter)
-        RUBY
-      end
+    it 'does not register an offense when method from `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+      expect_no_offenses(<<~RUBY)
+        page.all(:parameter).select(some_filter)
+      RUBY
+    end
+  end
 
-      it 'does not register an offense when method follows `all`' do
-        expect_no_offenses(<<~RUBY)
-          page.all(:parameter).do_something
-        RUBY
-      end
-
-      it 'does not register an offense when method from `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
-        expect_no_offenses(<<~RUBY)
-          page.all(:parameter).select(some_filter)
-        RUBY
-      end
+  context 'when `all` has parentheses' do
+    it 'does not register an offense when no method follows `all`' do
+      expect_no_offenses(<<~RUBY)
+        User.all()
+      RUBY
     end
 
-    context 'when `all` has parentheses' do
-      it 'does not register an offense when no method follows `all`' do
-        expect_no_offenses(<<~RUBY)
-          User.all()
-        RUBY
-      end
+    it 'registers an offense and corrects when method in `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+      expect_offense(<<~RUBY)
+        User.all().order(:created_at)
+             ^^^^^ Redundant `all` detected.
+      RUBY
 
-      it 'registers an offense and corrects when method in `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
-        expect_offense(<<~RUBY)
-          User.all().order(:created_at)
-               ^^^^^ Redundant `all` detected.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          User.order(:created_at)
-        RUBY
-      end
-
-      it 'does not register an offense when method not in `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
-        expect_no_offenses(<<~RUBY)
-          User.all().do_something
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        User.order(:created_at)
+      RUBY
     end
 
-    described_class::POSSIBLE_ENUMERABLE_BLOCK_METHODS.each do |method|
-      context "using `#{method}`" do
-        it "does not register an offense when using `#{method}` with block" do
-          expect_no_offenses(<<~RUBY)
-            User.all.#{method} { |item| item.do_something }
-          RUBY
-        end
+    it 'does not register an offense when method not in `ActiveRecord::Querying::QUERYING_METHODS` follows `all`' do
+      expect_no_offenses(<<~RUBY)
+        User.all().do_something
+      RUBY
+    end
+  end
 
-        it "does not register an offense when using `#{method}` with numbered block" do
-          expect_no_offenses(<<~RUBY)
-            User.all.#{method} { _1.do_something }
-          RUBY
-        end
+  described_class::POSSIBLE_ENUMERABLE_BLOCK_METHODS.each do |method|
+    context "using `#{method}`" do
+      it "does not register an offense when using `#{method}` with block" do
+        expect_no_offenses(<<~RUBY)
+          User.all.#{method} { |item| item.do_something }
+        RUBY
+      end
 
-        it "does not register an offense when using `#{method}` with symbol block" do
-          expect_no_offenses(<<~RUBY)
-            User.all.#{method}(&:do_something)
-          RUBY
-        end
+      it "does not register an offense when using `#{method}` with numbered block" do
+        expect_no_offenses(<<~RUBY)
+          User.all.#{method} { _1.do_something }
+        RUBY
+      end
+
+      it "does not register an offense when using `#{method}` with symbol block" do
+        expect_no_offenses(<<~RUBY)
+          User.all.#{method}(&:do_something)
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -315,6 +315,28 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
         RUBY
       end
     end
+
+    described_class::POSSIBLE_ENUMERABLE_BLOCK_METHODS.each do |method|
+      context "using `#{method}`" do
+        it "does not register an offense when using `#{method}` with block" do
+          expect_no_offenses(<<~RUBY)
+            User.all.#{method} { |item| item.do_something }
+          RUBY
+        end
+
+        it "does not register an offense when using `#{method}` with numbered block" do
+          expect_no_offenses(<<~RUBY)
+            User.all.#{method} { _1.do_something }
+          RUBY
+        end
+
+        it "does not register an offense when using `#{method}` with symbol block" do
+          expect_no_offenses(<<~RUBY)
+            User.all.#{method}(&:do_something)
+          RUBY
+        end
+      end
+    end
   end
 
   context 'with no receiver' do
@@ -396,28 +418,6 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
           scope :admins, -> { where(admin: true) }
         end
       RUBY
-    end
-
-    described_class::POSSIBLE_ENUMERABLE_BLOCK_METHODS.each do |method|
-      context "using `#{method}`" do
-        it "does not register an offense when using `#{method}` with block" do
-          expect_no_offenses(<<~RUBY)
-            User.all.#{method} { |item| item.do_something }
-          RUBY
-        end
-
-        it "does not register an offense when using `#{method}` with numbered block" do
-          expect_no_offenses(<<~RUBY)
-            User.all.#{method} { _1.do_something }
-          RUBY
-        end
-
-        it "does not register an offense when using `#{method}` with symbol block" do
-          expect_no_offenses(<<~RUBY)
-            User.all.#{method}(&:do_something)
-          RUBY
-        end
-      end
     end
   end
 


### PR DESCRIPTION
When adding a test to `redundant_active_record_all_method_spec`, I was sometimes confused about which context to include the test in. So, I have refactored the test in structure to improve clarity and maintainability.

I've split the commits for better readability, so it might be easier to review them individually.
(If it would be better to split the PR, I am willing to do so.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
