### PR TITLE
ReflectionClassName: accept method calls on local variables

### DIFF
--- a/changelog/change_accept_method_calls_on_local_variables.md
+++ b/changelog/change_accept_method_calls_on_local_variables.md
@@ -1,0 +1,1 @@
+* [#1179](https://github.com/rubocop/rubocop-rails/issues/1179): `Rails/ReflectionClassName`: Accept method calls on local variables. ([@exterm][])

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def on_send(node)
           association_with_reflection(node) do |reflection_class_name|
-            return if reflection_class_name.value.send_type? && reflection_class_name.value.receiver.nil?
+            return if reflection_class_name.value.send_type? && !reflection_class_name.value.receiver&.const_type?
             return if reflection_class_name.value.lvar_type? && str_assigned?(reflection_class_name)
 
             add_offense(reflection_class_name.source_range) do |corrector|

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -124,6 +124,12 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName, :config do
     RUBY
   end
 
+  it 'does not register an offense when parameter value is a method call on an object in a variable' do
+    expect_no_offenses(<<~RUBY)
+      has_many :accounts, class_name: some_thing.class_name
+    RUBY
+  end
+
   context 'Ruby >= 3.1', :ruby31 do
     it 'registers an offense when shorthand syntax value is a local variable assigned a constant' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop-rails/issues/1179

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/
