### PR TITLE
Support `Nokogiri::HTML.parse` and `Nokogiri::HTML5.parse` on `Rails/ResponseParsedBody`

### DIFF
--- a/changelog/change_support_nokogiri_html_parse.md
+++ b/changelog/change_support_nokogiri_html_parse.md
@@ -1,0 +1,1 @@
+* [#1181](https://github.com/rubocop/rubocop-rails/pull/1181): Support `Nokogiri::HTML.parse` and `Nokogiri::HTML5.parse` on `Rails/ResponseParsedBody`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -902,7 +902,7 @@ Rails/RequireDependency:
   VersionAdded: '2.10'
 
 Rails/ResponseParsedBody:
-  Description: Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+  Description: Prefer `response.parsed_body` to custom parsing logic for `response.body`.
   Enabled: pending
   Safe: false
   VersionAdded: '2.18'

--- a/lib/rubocop/cop/rails/response_parsed_body.rb
+++ b/lib/rubocop/cop/rails/response_parsed_body.rb
@@ -3,24 +3,29 @@
 module RuboCop
   module Cop
     module Rails
-      # Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+      # Prefer `response.parsed_body` to custom parsing logic for `response.body`.
       #
       # @safety
-      #   This cop is unsafe because Content-Type may not be `application/json`. For example, the proprietary
-      #   Content-Type provided by corporate entities such as `application/vnd.github+json` is not supported at
-      #   `response.parsed_body` by default, so you still have to use `JSON.parse(response.body)` there.
+      #   This cop is unsafe because Content-Type may not be `application/json` or `text/html`.
+      #   For example, the proprietary Content-Type provided by corporate entities such as
+      #   `application/vnd.github+json` is not supported at `response.parsed_body` by default,
+      #   so you still have to use `JSON.parse(response.body)` there.
       #
       # @example
       #   # bad
       #   JSON.parse(response.body)
+      #
+      #   # bad
+      #   Nokogiri::HTML.parse(response.body)
+      #
+      #   # bad
+      #   Nokogiri::HTML5.parse(response.body)
       #
       #   # good
       #   response.parsed_body
       class ResponseParsedBody < Base
         extend AutoCorrector
         extend TargetRailsVersion
-
-        MSG = 'Prefer `response.parsed_body` to `JSON.parse(response.body)`.'
 
         RESTRICT_ON_SEND = %i[parse].freeze
 
@@ -38,18 +43,55 @@ module RuboCop
           )
         PATTERN
 
-        def on_send(node)
-          return unless json_parse_response_body?(node)
+        # @!method nokogiri_html_parse_response_body(node)
+        def_node_matcher :nokogiri_html_parse_response_body, <<~PATTERN
+          (send
+            (const
+              (const {nil? cbase} :Nokogiri)
+              ${:HTML :HTML5}
+            )
+            :parse
+            (send
+              (send nil? :response)
+              :body
+            )
+          )
+        PATTERN
 
-          add_offense(node) do |corrector|
-            autocorrect(corrector, node)
-          end
+        def on_send(node)
+          check_json_parse_response_body(node)
+
+          return unless target_rails_version >= 7.1
+
+          check_nokogiri_html_parse_response_body(node)
         end
 
         private
 
         def autocorrect(corrector, node)
           corrector.replace(node, 'response.parsed_body')
+        end
+
+        def check_json_parse_response_body(node)
+          return unless json_parse_response_body?(node)
+
+          add_offense(
+            node,
+            message: 'Prefer `response.parsed_body` to `JSON.parse(response.body)`.'
+          ) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        def check_nokogiri_html_parse_response_body(node)
+          return unless (const = nokogiri_html_parse_response_body(node))
+
+          add_offense(
+            node,
+            message: "Prefer `response.parsed_body` to `Nokogiri::#{const}.parse(response.body)`."
+          ) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rails/response_parsed_body_spec.rb
+++ b/spec/rubocop/cop/rails/response_parsed_body_spec.rb
@@ -42,4 +42,38 @@ RSpec.describe RuboCop::Cop::Rails::ResponseParsedBody, :config do
       RUBY
     end
   end
+
+  context 'when `Nokogiri::HTML.parse(response.body)` is used on Rails 7.0', :rails70 do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        Nokogiri::HTML.parse(response.body)
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML.parse(response.body)` is used on Rails 7.1', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `Nokogiri::HTML.parse(response.body)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML5.parse(response.body)` is used on Rails 7.1', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML5.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `Nokogiri::HTML5.parse(response.body)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Since Rails 7.1, `response.parse_body` now supports `Content-Type: text/html` responses:

- https://github.com/rails/rails/pull/47144

So, how about adding support for this in the `Rails/ResponseParsedBody` cop?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
