### PR TITLE
support postGIS adapter for postgreSQL

### DIFF
--- a/changelog/new_support_postgis_adapter_for_postgresql.md
+++ b/changelog/new_support_postgis_adapter_for_postgresql.md
@@ -1,0 +1,1 @@
+* [#1183](https://github.com/rubocop/rubocop-rails/pull/1183): Support PostGIS adapter for PostgreSQL. ([@Dania02525][])

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -977,7 +977,7 @@ the PostgreSQL (5.2 later) adapter; thus it will
 automatically detect an adapter from `development` environment
 in `config/database.yml` or the environment variable `DATABASE_URL`
 when the `Database` option is not set.
-If the adapter is not `mysql2`, `trilogy`, or `postgresql`,
+If the adapter is not `mysql2`, `trilogy`, `postgresql`, or `postgis`,
 this Cop ignores offenses.
 
 === Examples

--- a/lib/rubocop/cop/mixin/database_type_resolvable.rb
+++ b/lib/rubocop/cop/mixin/database_type_resolvable.rb
@@ -23,7 +23,7 @@ module RuboCop
         case database_adapter
         when 'mysql2', 'trilogy'
           MYSQL
-        when 'postgresql'
+        when 'postgresql', 'postgis'
           POSTGRESQL
         end
       end

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -14,7 +14,7 @@ module RuboCop
       # automatically detect an adapter from `development` environment
       # in `config/database.yml` or the environment variable `DATABASE_URL`
       # when the `Database` option is not set.
-      # If the adapter is not `mysql2`, `trilogy`, or `postgresql`,
+      # If the adapter is not `mysql2`, `trilogy`, `postgresql`, or `postgis`,
       # this Cop ignores offenses.
       #
       # @example

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -547,6 +547,46 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       end
     end
 
+    context 'postgis' do
+      context 'with top-level adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'adapter' => 'postgis'
+            }
+          }
+        end
+
+        context 'with Rails 5.2', :rails52 do
+          it_behaves_like 'offense for postgresql'
+        end
+
+        context 'with Rails 5.1', :rails51 do
+          it_behaves_like 'no offense for postgresql'
+        end
+      end
+
+      context 'with nested adapter configuration' do
+        let(:yaml) do
+          {
+            'development' => {
+              'primary' => {
+                'adapter' => 'postgis'
+              }
+            }
+          }
+        end
+
+        context 'with Rails 5.2', :rails52 do
+          it_behaves_like 'offense for postgresql'
+        end
+
+        context 'with Rails 5.1', :rails51 do
+          it_behaves_like 'no offense for postgresql'
+        end
+      end
+    end
+
     context 'invalid (e.g. ERB)' do
       before do
         allow(YAML).to receive(:load_file).with('config/database.yml') do


### PR DESCRIPTION
When using the `postgis` adapter, this the `Rails/BulkChangeTable` cop interprets this as a database which does not support bulk alter statements.  Since postgis is an extension for postgreSQL, it should be treated the same as postgreSQL when determining if this cop should be run.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
