### PR TITLE
[Fix #1164] Fix autocorrection in `Rails/Delegate` to preserve comments

### DIFF
--- a/changelog/fix_autocorrection_for_rails_delegate.md
+++ b/changelog/fix_autocorrection_for_rails_delegate.md
@@ -1,0 +1,1 @@
+* [#1164](https://github.com/rubocop/rubocop-rails/issues/1164): Fix autocorrection for `Rails/Delegate` to preserve comments. ([@masato-bkn][])

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -82,15 +82,19 @@ module RuboCop
 
         def register_offense(node)
           add_offense(node.loc.keyword) do |corrector|
-            body = node.body
-
-            receiver = body.receiver.self_type? ? 'self' : ":#{body.receiver.method_name}"
-
-            delegation = ["delegate :#{body.method_name}", "to: #{receiver}"]
-            delegation << ['prefix: true'] if node.method?(prefixed_method_name(node.body))
-
-            corrector.replace(node, delegation.join(', '))
+            corrector.replace(node, build_delegation(node))
           end
+        end
+
+        def build_delegation(node)
+          body = node.body
+
+          receiver = body.receiver.self_type? ? 'self' : ":#{body.receiver.method_name}"
+
+          delegation = ["delegate :#{body.method_name}", "to: #{receiver}"]
+          delegation << ['prefix: true'] if node.method?(prefixed_method_name(node.body))
+
+          delegation.join(', ')
         end
 
         def trivial_delegate?(def_node)

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -55,6 +55,80 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
     RUBY
   end
 
+  it 'finds trivial delegate with single line comment' do
+    expect_offense(<<~RUBY)
+      def foo
+      ^^^ Use `delegate` to define delegations.
+        # comment
+        bar.foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      delegate :foo, to: :bar
+    RUBY
+  end
+
+  it 'finds trivial delegate with multiline comments' do
+    expect_offense(<<~RUBY)
+      def foo
+      ^^^ Use `delegate` to define delegations.
+        # comment 1
+        # comment 2
+        bar.foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment 1
+      # comment 2
+      delegate :foo, to: :bar
+    RUBY
+  end
+
+  it 'finds trivial delegate with multiline comments including blank lines' do
+    expect_offense(<<~RUBY)
+      def foo
+      ^^^ Use `delegate` to define delegations.
+        # comment 1
+
+        # comment 2
+
+
+        # comment 3
+        bar.foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment 1
+
+      # comment 2
+
+
+      # comment 3
+      delegate :foo, to: :bar
+    RUBY
+  end
+
+  it 'finds trivial delegate with preceding comments' do
+    expect_offense(<<~RUBY)
+      # comment 1
+      def foo
+      ^^^ Use `delegate` to define delegations.
+        # comment 2
+        bar.foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment 1
+      # comment 2
+      delegate :foo, to: :bar
+    RUBY
+  end
+
   it 'finds trivial delegate to `self` when underscored method' do
     expect_offense(<<~RUBY)
       def bar_foo


### PR DESCRIPTION
Fixes #1164.

This PR fixes the issue in `Rails/Delegate` where comments are being deleted due to the autocorrection.

I have made a small refactor to avoid a `Metrics/AbcSize` offense, and have split the commits for readability. I intend to squash the commits once it is ready to merge.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
