### PR TITLE
Remove NOTE tag from `Rails/RedundantActiveRecordAllMethod` description for readability

### DIFF
--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -34,8 +34,7 @@ module RuboCop
 
       # Detect redundant `all` used as a receiver for Active Record query methods.
       #
-      # NOTE: For the methods `delete_all` and `destroy_all`,
-      # this cop will only check cases where the receiver is a model.
+      # For the methods `delete_all` and `destroy_all`, this cop will only check cases where the receiver is a model.
       # It will ignore cases where the receiver is an association (e.g., `user.articles.all.delete_all`).
       # This is because omitting `all` from an association changes the methods
       # from `ActiveRecord::Relation` to `ActiveRecord::Associations::CollectionProxy`,


### PR DESCRIPTION
This PR removes NOTE tag from `Rails/RedundantActiveRecordAllMethod` description for readability.

The inline code written in the NOTE section is not being displayed in the [RuboCop Rails documentation](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundantactiverecordallmethod), making it difficult to read.
I think removing the NOTE tag would enhance the documentation's readability.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
