### PR TITLE
[Fix #1189] Fix false negatives for `Rails/Pluck`

### DIFF
--- a/changelog/fix_false_negatives_for_rails_pluck.md
+++ b/changelog/fix_false_negatives_for_rails_pluck.md
@@ -1,0 +1,1 @@
+* [#1189](https://github.com/rubocop/rubocop-rails/issues/1189): Fix false negatives for `Rails/Pluck` when using safe navigation method calls. ([@koic][])

--- a/lib/rubocop/cop/rails/pluck.rb
+++ b/lib/rubocop/cop/rails/pluck.rb
@@ -38,7 +38,7 @@ module RuboCop
         minimum_target_rails_version 5.0
 
         def_node_matcher :pluck_candidate?, <<~PATTERN
-          ({block numblock} (send _ {:map :collect}) $_argument (send lvar :[] $_key))
+          ({block numblock} (call _ {:map :collect}) $_argument (send lvar :[] $_key))
         PATTERN
 
         def on_block(node)

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
+      context "when safe navigation `#{method}` with symbol literal key can be replaced with `pluck`" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            x&.%{method} { |a| a[:foo] }
+               ^{method}^^^^^^^^^^^^^^^^ Prefer `pluck(:foo)` over `%{method} { |a| a[:foo] }`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x&.pluck(:foo)
+          RUBY
+        end
+      end
+
       context "when `#{method}` with string literal key can be replaced with `pluck`" do
         it 'registers an offense' do
           expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
Fixes #1189.

This PR fixes false negatives for `Rails/Pluck` when using safe navigation method calls.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
