### PR TITLE
Make some cops aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_some_cops_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_some_cops_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#1204](https://github.com/rubocop/rubocop-rails/pull/1204): Make `Rails/ActiveSupportAliases`, `Rails/FindBy`, `Rails/FindById`, `Rails/Inquiry`, `Rails/Pick` `Rails/PluckId`, `Rails/PluckInWhere`, `Rails/WhereEquals`, `Rails/WhereExists`, and `Rails/WhereNot` cops aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -98,7 +98,7 @@ module RuboCop
       end
 
       def in_where?(node)
-        send_node = node.each_ancestor(:send).first
+        send_node = node.each_ancestor(:send, :csend).first
         return false unless send_node
 
         return true if WHERE_METHODS.include?(send_node.method_name)

--- a/lib/rubocop/cop/rails/active_support_aliases.rb
+++ b/lib/rubocop/cop/rails/active_support_aliases.rb
@@ -27,13 +27,13 @@ module RuboCop
 
         ALIASES = {
           starts_with?: {
-            original: :start_with?, matcher: '(send str :starts_with? _)'
+            original: :start_with?, matcher: '(call str :starts_with? _)'
           },
           ends_with?: {
-            original: :end_with?, matcher: '(send str :ends_with? _)'
+            original: :end_with?, matcher: '(call str :ends_with? _)'
           },
-          append: { original: :<<, matcher: '(send array :append _)' },
-          prepend: { original: :unshift, matcher: '(send array :prepend _)' }
+          append: { original: :<<, matcher: '(call array :append _)' },
+          prepend: { original: :unshift, matcher: '(call array :prepend _)' }
         }.freeze
 
         ALIASES.each do |aliased_method, options|
@@ -47,13 +47,14 @@ module RuboCop
             preferred_method = ALIASES[aliased_method][:original]
             message = format(MSG, prefer: preferred_method, current: aliased_method)
 
-            add_offense(node, message: message) do |corrector|
+            add_offense(node.loc.selector.join(node.source_range.end), message: message) do |corrector|
               next if append(node)
 
               corrector.replace(node.loc.selector, preferred_method)
             end
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -28,7 +28,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Use `find_by` instead of `where.%<method>s`.'
+        MSG = 'Use `find_by` instead of `where%<dot>s%<method>s`.'
         RESTRICT_ON_SEND = %i[first take].freeze
 
         def on_send(node)
@@ -37,7 +37,7 @@ module RuboCop
 
           range = offense_range(node)
 
-          add_offense(range, message: format(MSG, method: node.method_name)) do |corrector|
+          add_offense(range, message: format(MSG, dot: node.loc.dot.source, method: node.method_name)) do |corrector|
             autocorrect(corrector, node)
           end
         end

--- a/lib/rubocop/cop/rails/inquiry.rb
+++ b/lib/rubocop/cop/rails/inquiry.rb
@@ -33,6 +33,7 @@ module RuboCop
 
           add_offense(node.loc.selector)
         end
+        alias on_csend on_send
       end
     end
   end

--- a/lib/rubocop/cop/rails/pluck_id.rb
+++ b/lib/rubocop/cop/rails/pluck_id.rb
@@ -34,7 +34,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[pluck].freeze
 
         def_node_matcher :pluck_id_call?, <<~PATTERN
-          (send _ :pluck {(sym :id) (send nil? :primary_key)})
+          (call _ :pluck {(sym :id) (send nil? :primary_key)})
         PATTERN
 
         def on_send(node)
@@ -47,6 +47,7 @@ module RuboCop
             corrector.replace(offense_range(node), 'ids')
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/lib/rubocop/cop/rails/pluck_in_where.rb
+++ b/lib/rubocop/cop/rails/pluck_in_where.rb
@@ -65,13 +65,14 @@ module RuboCop
             corrector.replace(range, replacement)
           end
         end
+        alias on_csend on_send
 
         private
 
         def root_receiver(node)
           receiver = node.receiver
 
-          if receiver&.send_type?
+          if receiver&.call_type?
             root_receiver(receiver)
           else
             receiver

--- a/lib/rubocop/cop/rails/where_equals.rb
+++ b/lib/rubocop/cop/rails/where_equals.rb
@@ -33,8 +33,8 @@ module RuboCop
 
         def_node_matcher :where_method_call?, <<~PATTERN
           {
-            (send _ :where (array $str_type? $_ ?))
-            (send _ :where $str_type? $_ ?)
+            (call _ :where (array $str_type? $_ ?))
+            (call _ :where $str_type? $_ ?)
           }
         PATTERN
 
@@ -55,6 +55,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
 
         EQ_ANONYMOUS_RE = /\A([\w.]+)\s+=\s+\?\z/.freeze             # column = ?
         IN_ANONYMOUS_RE = /\A([\w.]+)\s+IN\s+\(\?\)\z/i.freeze       # column IN (?)

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -6,11 +6,24 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases, :config do
       it 'registers as an offense and corrects' do
         expect_offense(<<~RUBY)
           'some_string'.starts_with?('prefix')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `start_with?` instead of `starts_with?`.
+                        ^^^^^^^^^^^^^^^^^^^^^^ Use `start_with?` instead of `starts_with?`.
         RUBY
 
         expect_correction(<<~RUBY)
           'some_string'.start_with?('prefix')
+        RUBY
+      end
+    end
+
+    describe '&.starts_with?' do
+      it 'registers as an offense and corrects' do
+        expect_offense(<<~RUBY)
+          'some_string'&.starts_with?('prefix')
+                         ^^^^^^^^^^^^^^^^^^^^^^ Use `start_with?` instead of `starts_with?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          'some_string'&.start_with?('prefix')
         RUBY
       end
     end
@@ -25,11 +38,24 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases, :config do
       it 'registers as an offense and corrects' do
         expect_offense(<<~RUBY)
           'some_string'.ends_with?('prefix')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `end_with?` instead of `ends_with?`.
+                        ^^^^^^^^^^^^^^^^^^^^ Use `end_with?` instead of `ends_with?`.
         RUBY
 
         expect_correction(<<~RUBY)
           'some_string'.end_with?('prefix')
+        RUBY
+      end
+    end
+
+    describe '&ends_with?' do
+      it 'registers as an offense and corrects' do
+        expect_offense(<<~RUBY)
+          'some_string'&.ends_with?('prefix')
+                         ^^^^^^^^^^^^^^^^^^^^ Use `end_with?` instead of `ends_with?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          'some_string'&.end_with?('prefix')
         RUBY
       end
     end
@@ -46,7 +72,18 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases, :config do
       it 'registers as an offense and does not correct' do
         expect_offense(<<~RUBY)
           [1, 'a', 3].append('element')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `<<` instead of `append`.
+                      ^^^^^^^^^^^^^^^^^ Use `<<` instead of `append`.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    describe '&.append' do
+      it 'registers as an offense and does not correct' do
+        expect_offense(<<~RUBY)
+          [1, 'a', 3]&.append('element')
+                       ^^^^^^^^^^^^^^^^^ Use `<<` instead of `append`.
         RUBY
 
         expect_no_corrections
@@ -63,11 +100,24 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases, :config do
       it 'registers as an offense and corrects' do
         expect_offense(<<~RUBY)
           [1, 'a', 3].prepend('element')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `unshift` instead of `prepend`.
+                      ^^^^^^^^^^^^^^^^^^ Use `unshift` instead of `prepend`.
         RUBY
 
         expect_correction(<<~RUBY)
           [1, 'a', 3].unshift('element')
+        RUBY
+      end
+    end
+
+    describe '&.prepend' do
+      it 'registers as an offense and corrects' do
+        expect_offense(<<~RUBY)
+          [1, 'a', 3]&.prepend('element')
+                       ^^^^^^^^^^^^^^^^^^ Use `unshift` instead of `prepend`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 'a', 3]&.unshift('element')
         RUBY
       end
     end

--- a/spec/rubocop/cop/rails/find_by_id_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_id_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe RuboCop::Cop::Rails::FindById, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `where(id: ...)&.take!`' do
+    expect_offense(<<~RUBY)
+      User.where(id: 1)&.take!
+           ^^^^^^^^^^^^^^^^^^^ Use `find(1)` instead of `where(id: 1)&.take!`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User.find(1)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `where(id: ...)&.take!` with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.where(id: 1)&.take!
+            ^^^^^^^^^^^^^^^^^^^ Use `find(1)` instead of `where(id: 1)&.take!`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.find(1)
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `find_by_id!`' do
     expect_offense(<<~RUBY)
       User.find_by_id!(1)
@@ -23,6 +45,17 @@ RSpec.describe RuboCop::Cop::Rails::FindById, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `find_by_id!` with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.find_by_id!(1)
+            ^^^^^^^^^^^^^^ Use `find(1)` instead of `find_by_id!(1)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.find(1)
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `find_by!(id: ...)`' do
     expect_offense(<<~RUBY)
       User.find_by!(id: 1)
@@ -31,6 +64,17 @@ RSpec.describe RuboCop::Cop::Rails::FindById, :config do
 
     expect_correction(<<~RUBY)
       User.find(1)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `find_by!(id: ...)` with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.find_by!(id: 1)
+            ^^^^^^^^^^^^^^^ Use `find(1)` instead of `find_by!(id: 1)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.find(1)
     RUBY
   end
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `&.take`' do
+    expect_offense(<<~RUBY)
+      User.where(id: x)&.take
+           ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where&.take`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User.find_by(id: x)
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `&.take` with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.where(id: x)&.take
+            ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where&.take`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.find_by(id: x)
+    RUBY
+  end
+
   context 'when using safe navigation operator' do
     it 'registers an offense when using `#take`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rails/inquiry_spec.rb
+++ b/spec/rubocop/cop/rails/inquiry_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe RuboCop::Cop::Rails::Inquiry, :config do
     RUBY
   end
 
+  it 'registers an offense when using `String&.inquiry`' do
+    expect_offense(<<~RUBY)
+      'two'&.inquiry
+             ^^^^^^^ Prefer Ruby's comparison operators over Active Support's `inquiry`.
+    RUBY
+  end
+
   it 'registers an offense when using `Array#inquiry`' do
     expect_offense(<<~RUBY)
       [foo, bar].inquiry

--- a/spec/rubocop/cop/rails/pick_spec.rb
+++ b/spec/rubocop/cop/rails/pick_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Rails::Pick, :config do
   context 'when using Rails 6.0 or newer', :rails60 do
     context 'with one argument' do
-      it 'registers an offense for `pluck(...).first' do
+      it 'registers an offense for `pluck(...).first`' do
         expect_offense(<<~RUBY)
           x.pluck(:a).first
             ^^^^^^^^^^^^^^^ Prefer `pick(:a)` over `pluck(:a).first`.
@@ -13,10 +13,32 @@ RSpec.describe RuboCop::Cop::Rails::Pick, :config do
           x.pick(:a)
         RUBY
       end
+
+      it 'registers an offense for `pluck(...)&.first`' do
+        expect_offense(<<~RUBY)
+          x.pluck(:a)&.first
+            ^^^^^^^^^^^^^^^^ Prefer `pick(:a)` over `pluck(:a)&.first`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.pick(:a)
+        RUBY
+      end
+
+      it 'registers an offense for `pluck(...)&.first` with safe navigation' do
+        expect_offense(<<~RUBY)
+          x&.pluck(:a)&.first
+             ^^^^^^^^^^^^^^^^ Prefer `pick(:a)` over `pluck(:a)&.first`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x&.pick(:a)
+        RUBY
+      end
     end
 
     context 'with multiple arguments' do
-      it 'registers an offense for `pluck(...).first' do
+      it 'registers an offense for `pluck(...).first`' do
         expect_offense(<<~RUBY)
           x.pluck(:a, :b).first
             ^^^^^^^^^^^^^^^^^^^ Prefer `pick(:a, :b)` over `pluck(:a, :b).first`.
@@ -31,7 +53,7 @@ RSpec.describe RuboCop::Cop::Rails::Pick, :config do
 
   context 'when using Rails 5.2 or older', :rails52 do
     context 'with one argument' do
-      it 'does not register an offense for `pluck(...).first' do
+      it 'does not register an offense for `pluck(...).first`' do
         expect_no_offenses(<<~RUBY)
           x.pluck(:a).first
         RUBY
@@ -39,7 +61,7 @@ RSpec.describe RuboCop::Cop::Rails::Pick, :config do
     end
 
     context 'with multiple arguments' do
-      it 'does not register an offense for `pluck(...).first' do
+      it 'does not register an offense for `pluck(...).first`' do
         expect_no_offenses(<<~RUBY)
           x.pluck(:a, :b).first
         RUBY

--- a/spec/rubocop/cop/rails/pluck_id_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_id_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Rails::PluckId, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `pluck(:id)` with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.pluck(:id)
+            ^^^^^^^^^^ Use `ids` instead of `pluck(:id)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.ids
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `pluck(primary_key)`' do
     expect_offense(<<~RUBY)
       def self.user_ids

--- a/spec/rubocop/cop/rails/pluck_in_where_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_in_where_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe RuboCop::Cop::Rails::PluckInWhere, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using `pluck` in `where` for constant with safe navigation' do
+      expect_offense(<<~RUBY)
+        Post&.where(user_id: User&.active&.pluck(:id))
+                                           ^^^^^ Use `select` instead of `pluck` within `where` query method.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Post&.where(user_id: User&.active&.select(:id))
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `pluck` in `rewhere` for constant' do
       expect_offense(<<~RUBY)
         Post.rewhere('user_id IN (?)', User.active.pluck(:id))

--- a/spec/rubocop/cop/rails/where_equals_spec.rb
+++ b/spec/rubocop/cop/rails/where_equals_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `=` and anonymous placeholder with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.where('name = ?', 'Gabe')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where(name: 'Gabe')` instead of manually constructing SQL.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.where(name: 'Gabe')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `=` and named placeholder' do
     expect_offense(<<~RUBY)
       User.where('name = :name', name: 'Gabe')
@@ -76,6 +87,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals, :config do
 
       expect_correction(<<~RUBY)
         User.where(name: 'Gabe')
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `=` and anonymous placeholder with safe navigation' do
+      expect_offense(<<~RUBY)
+        User&.where(['name = ?', 'Gabe'])
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where(name: 'Gabe')` instead of manually constructing SQL.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User&.where(name: 'Gabe')
       RUBY
     end
 

--- a/spec/rubocop/cop/rails/where_exists_spec.rb
+++ b/spec/rubocop/cop/rails/where_exists_spec.rb
@@ -15,6 +15,28 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using `where(...)&.exists?` with hash argument' do
+      expect_offense(<<~RUBY)
+        User.where(name: 'john')&.exists?
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(name: 'john')` over `where(name: 'john')&.exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.exists?(name: 'john')
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `where(...)&.exists?` with hash argument with safe navigation' do
+      expect_offense(<<~RUBY)
+        User&.where(name: 'john')&.exists?
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(name: 'john')` over `where(name: 'john')&.exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User&.exists?(name: 'john')
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `where(...).exists?` with array argument' do
       expect_offense(<<~RUBY)
         User.where(['name = ?', 'john']).exists?
@@ -84,6 +106,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
 
       expect_correction(<<~RUBY)
         User.where(name: 'john').exists?
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `exists?` with a hash with safe navigation' do
+      expect_offense(<<~RUBY)
+        User&.exists?(name: 'john')
+              ^^^^^^^^^^^^^^^^^^^^^ Prefer `where(name: 'john')&.exists?` over `exists?(name: 'john')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User&.where(name: 'john')&.exists?
       RUBY
     end
 

--- a/spec/rubocop/cop/rails/where_not_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `!=` and anonymous placeholder with safe navigation' do
+    expect_offense(<<~RUBY)
+      User&.where('name != ?', 'Gabe')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where&.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User&.where&.not(name: 'Gabe')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `!=` and named placeholder' do
     expect_offense(<<~RUBY)
       User.where('name != :name', name: 'Gabe')
@@ -109,6 +120,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot, :config do
 
       expect_correction(<<~RUBY)
         User.where.not(name: 'Gabe')
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `!=` and anonymous placeholder with safe navigation' do
+      expect_offense(<<~RUBY)
+        User&.where(['name != ?', 'Gabe'])
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where&.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User&.where&.not(name: 'Gabe')
       RUBY
     end
 


### PR DESCRIPTION
Fixes #1191, #1192, #1193, #1194, #1196, #1197, #1201, and #1202.

This PR makes `Rails/ActiveSupportAliases`, `Rails/FindBy`, `Rails/FindById`, `Rails/Inquiry`, `Rails/Pick` `Rails/PluckId`, `Rails/PluckInWhere`, `Rails/WhereEquals`, `Rails/WhereExists`, and `Rails/WhereNot` cops aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
