### PR TITLE
Fix an error for `Rails/WhereMissing` where join method is called without arguments

### DIFF
--- a/changelog/fix_error_for_where_missing_where_joins_called_without_args.md
+++ b/changelog/fix_error_for_where_missing_where_joins_called_without_args.md
@@ -1,0 +1,1 @@
+* [#1206](https://github.com/rubocop/rubocop-rails/issues/1206): Fix an error for `Rails/WhereMissing` where join method is called without arguments. ([@fatkodima][])

--- a/lib/rubocop/cop/rails/where_missing.rb
+++ b/lib/rubocop/cop/rails/where_missing.rb
@@ -36,7 +36,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless node.first_argument.sym_type?
+          return unless node.first_argument&.sym_type?
 
           root_receiver = root_receiver(node)
           where_node_and_argument(root_receiver) do |where_node, where_argument|

--- a/spec/rubocop/cop/rails/where_missing_spec.rb
+++ b/spec/rubocop/cop/rails/where_missing_spec.rb
@@ -315,6 +315,12 @@ RSpec.describe RuboCop::Cop::Rails::WhereMissing, :config do
         Foo.left_joins(bar: :foo).where(bars: { id: nil })
       RUBY
     end
+
+    it 'does not register an offense when using `left_joins` without arguments' do
+      expect_no_offenses(<<~RUBY)
+        Foo.left_joins(left_joins).where(bars: { id: nil })
+      RUBY
+    end
   end
 
   context 'Rails 6.0', :rails60 do


### PR DESCRIPTION
Fixes #1206.