### PR TITLE
Support `where.not` for `Rails/PluckInWhere`

### DIFF
--- a/changelog/change_support_where_not_for_pluck_in_where.md
+++ b/changelog/change_support_where_not_for_pluck_in_where.md
@@ -1,0 +1,1 @@
+* [#1198](https://github.com/rubocop/rubocop-rails/issues/1198): Support `where.not` for `Rails/PluckInWhere`. ([@fatkodima][])

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -99,7 +99,14 @@ module RuboCop
 
       def in_where?(node)
         send_node = node.each_ancestor(:send).first
-        send_node && WHERE_METHODS.include?(send_node.method_name)
+        return false unless send_node
+
+        return true if WHERE_METHODS.include?(send_node.method_name)
+
+        receiver = send_node.receiver
+        return false unless receiver&.send_type?
+
+        send_node.method?(:not) && WHERE_METHODS.include?(receiver.method_name)
       end
     end
   end

--- a/lib/rubocop/cop/rails/pluck_in_where.rb
+++ b/lib/rubocop/cop/rails/pluck_in_where.rb
@@ -22,10 +22,12 @@ module RuboCop
       # @example
       #   # bad
       #   Post.where(user_id: User.active.pluck(:id))
+      #   Post.where.not(user_id: User.active.pluck(:id))
       #
       #   # good
       #   Post.where(user_id: User.active.select(:id))
       #   Post.where(user_id: active_users.select(:id))
+      #   Post.where.not(user_id: active_users.select(:id))
       #
       # @example EnforcedStyle: conservative (default)
       #   # good

--- a/spec/rubocop/cop/rails/pluck_in_where_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_in_where_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe RuboCop::Cop::Rails::PluckInWhere, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using `pluck` in `where.not` for constant' do
+      expect_offense(<<~RUBY)
+        Post.where.not(user_id: User.active.pluck(:id))
+                                            ^^^^^ Use `select` instead of `pluck` within `where` query method.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Post.where.not(user_id: User.active.select(:id))
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `pluck` in `rewhere` for constant' do
       expect_offense(<<~RUBY)
         Post.rewhere('user_id IN (?)', User.active.pluck(:id))


### PR DESCRIPTION
Fixes #1198.