### PR TITLE
Workaround for installation error of BigDecimal 3.1.5 in JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,19 @@ gem 'simplecov'
 gem 'test-queue'
 gem 'yard', '~> 0.9'
 
+group :test do
+  # FIXME: This is a workaround for installation error of BigDecimal 3.1.5 in JRuby:
+  #
+  # ```
+  # Installing bigdecimal 3.1.5 with native extensions
+  # Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
+  # ```
+  #
+  # https://github.com/rubocop/rubocop-rails/actions/runs/7192052922/job/19587776909
+  #
+  # See: https://github.com/ruby/bigdecimal/issues/279
+  gem 'bigdecimal', '< 3.1.5', platform: :jruby
+end
+
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile local_gemfile if File.exist?(local_gemfile)


### PR DESCRIPTION
This PR is a workaround for installation error of BigDecimal 3.1.5 in JRuby:

```console
Installing bigdecimal 3.1.5 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
```

https://github.com/rubocop/rubocop-rails/actions/runs/7192052922/job/19587776909

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
