### PR TITLE
Fix Rails/WhereNot when using implicit receiver

### DIFF
--- a/changelog/fix_where_not_with_implicit_receiver.md
+++ b/changelog/fix_where_not_with_implicit_receiver.md
@@ -1,0 +1,1 @@
+* [#1221](https://github.com/rubocop/rubocop-rails/issues/1221): Fix an exception in `Rails/WhereNot` when calling `.where` on an implicit receiver (e.g. inside model code). ([@bquorning][])

--- a/lib/rubocop/cop/rails/where_not.rb
+++ b/lib/rubocop/cop/rails/where_not.rb
@@ -46,7 +46,7 @@ module RuboCop
             column_and_value = extract_column_and_value(template_node, value_node)
             return unless column_and_value
 
-            good_method = build_good_method(node.loc.dot.source, *column_and_value)
+            good_method = build_good_method(node.loc.dot&.source, *column_and_value)
             message = format(MSG, good_method: good_method)
 
             add_offense(range, message: message) do |corrector|
@@ -88,6 +88,7 @@ module RuboCop
         end
 
         def build_good_method(dot, column, value)
+          dot ||= '.'
           if column.include?('.')
             table, column = column.split('.')
 

--- a/spec/rubocop/cop/rails/where_not_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_spec.rb
@@ -111,6 +111,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using implicit receiver' do
+    expect_offense(<<~RUBY)
+      where('name != ?', 'Gabe')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      where.not(name: 'Gabe')
+    RUBY
+  end
+
   context 'with array arguments' do
     it 'registers an offense and corrects when using `!=` and anonymous placeholder' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fix an exception in `Rails/WhereNot` when calling `.where` on an implicit receiver (e.g. inside model code).

Fixes #1221

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
