### PR TITLE
do not allow EnvironmentVariableAccess in initializers

### DIFF
--- a/changelog/change_fix_do_not_allow.md
+++ b/changelog/change_fix_do_not_allow.md
@@ -1,0 +1,1 @@
+* [#1229](https://github.com/rubocop/rubocop-rails/pull/1229): Make `Rails/EnvironmentVariableAccess` aware of initializers. ([@markokajzer][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -445,9 +445,10 @@ Rails/EnvironmentVariableAccess:
   # TODO: Set to `pending` status in RuboCop Rails 2 series when migration doc will be written.
   Enabled: false
   VersionAdded: '2.10'
-  VersionChanged: '2.11'
+  VersionChanged: '<<next>>'
   Include:
     - app/**/*.rb
+    - config/initializers/**/*.rb
     - lib/**/*.rb
   Exclude:
     - lib/**/*.rake

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -2068,7 +2068,7 @@ ENV["FOO"] = "bar"
 | Name | Default value | Configurable values
 
 | Include
-| `+app/**/*.rb+`, `+lib/**/*.rb+`
+| `+app/**/*.rb+`, `+config/initializers/**/*.rb+`, `+lib/**/*.rb+`
 | Array
 
 | Exclude

--- a/spec/rubocop/cop/rails/environment_variable_access_spec.rb
+++ b/spec/rubocop/cop/rails/environment_variable_access_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe RuboCop::Cop::Rails::EnvironmentVariableAccess, :config do
         Foo::ENV.fetch("BAR")
       RUBY
     end
+
+    it 'registers an offense when reading from an `ENV` key in the config/initializers folder' do
+      file_path = 'config/initializers/foo.rb'
+
+      expect_offense(<<~RUBY, file_path)
+        ACCESS_TOKEN = ENV["ACCESS_TOKEN"]
+                       ^^^ Do not read from `ENV` directly post initialization.
+      RUBY
+    end
+
+    it 'does not register an offense when reading from an `ENV` key in the config folder' do
+      file_path = '/config/foo.rb'
+
+      expect_no_offenses(<<~RUBY, file_path)
+        ACCESS_TOKEN = ENV["ACCESS_TOKEN"]
+      RUBY
+    end
   end
 
   context 'when allowing reads' do


### PR DESCRIPTION
The description of the cop states `Do not access ENV directly after initialization.`. However in some ways, the application is already initialized when we get to `config/**/*.rb`:
1. `config_for(:service)` is already available to read config from `service.yml`
2. `Rails.application.credentials` is already available to read application credentials / secrets

I think it could make sense to push people to move their config in either of these two places. If they want to access their config / secrets in a Ruby file, let's say, `config/initializers/service.rb` they can use `credentials` or `config_for`, no need to access `ENV` directly again.

Also see https://guides.rubyonrails.org/initialization.html.

I understand this is a bit nuanced, so if this is not desired, that's completely fine ✌️ 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] ~~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
