### PR TITLE
Remove `object_id` from `Rails/DangerousColumnNames` targets

### DIFF
--- a/changelog/change_remove_object_id_from.md
+++ b/changelog/change_remove_object_id_from.md
@@ -1,0 +1,1 @@
+* [#1231](https://github.com/rubocop/rubocop-rails/pull/1231): Remove `object_id` from `Rails/DangerousColumnNames` targets. ([@r7kamura][])

--- a/lib/rubocop/cop/rails/dangerous_column_names.rb
+++ b/lib/rubocop/cop/rails/dangerous_column_names.rb
@@ -31,7 +31,7 @@ module RuboCop
           time
         ].to_set.freeze
 
-        # Generated from `ActiveRecord::AttributeMethods.dangerous_attribute_methods` on activerecord 7.1.0.
+        # Generated from `ActiveRecord::AttributeMethods.dangerous_attribute_methods` on activerecord 7.1.3.
         # rubocop:disable Metrics/CollectionLiteralLength
         DANGEROUS_COLUMN_NAMES = %w[
           __callbacks
@@ -290,7 +290,6 @@ module RuboCop
           new_record
           no_touching
           normalize_reflection_attribute
-          object_id
           partial_inserts
           partial_updates
           perform_validations


### PR DESCRIPTION
Rails 7.1.3 has been released and it includes a change that `object_id` is no longer a dangerous column, so let's remove this from `Rails/DangerousColumnNames` as well.

- https://github.com/rails/rails/releases/tag/v7.1.3
- https://github.com/rails/rails/pull/50162

This change was originally planned in the following comments:

- https://github.com/rubocop/rubocop-rails/pull/1152#issuecomment-1837319370

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
