### PR TITLE
[Fix #1234] Fix an incorrect autocorrect for `Rails/FindBy`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_find_by.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_find_by.md
@@ -1,0 +1,1 @@
+* [#1234](https://github.com/rubocop/rubocop-rails/issues/1234): Fix an incorrect autocorrect for `Rails/FindBy` when using multi-line leading dot method calls. ([@ymap][])

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -59,7 +59,7 @@ module RuboCop
           return if node.method?(:first)
 
           where_loc = node.receiver.loc.selector
-          first_loc = range_between(node.loc.dot.begin_pos, node.loc.selector.end_pos)
+          first_loc = range_between(node.receiver.source_range.end_pos, node.loc.selector.end_pos)
 
           corrector.replace(where_loc, 'find_by')
           corrector.replace(first_loc, '')

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -34,6 +34,34 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using multi-line leading dot method calls' do
+    expect_offense(<<~RUBY)
+      User
+        .where(id: x)
+         ^^^^^^^^^^^^ Use `find_by` instead of `where.take`.
+        .take
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User
+        .find_by(id: x)
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using multi-line trailing dot method calls' do
+    expect_offense(<<~RUBY)
+      User.
+        where(id: x).
+        ^^^^^^^^^^^^^ Use `find_by` instead of `where.take`.
+        take
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User.
+        find_by(id: x)
+    RUBY
+  end
+
   context 'when using safe navigation operator' do
     it 'registers an offense when using `#take`' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #1234.

This PR fixes an incorrect autocorrect for `Rails/FindBy` when using multi-line leading dot method calls.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
