### PR TITLE
 Fix an error for `Rails/WhereExists` with `EnforcedStyle: where` and implicit recievers

### DIFF
--- a/changelog/fix_error_for_rails_where_exists.md
+++ b/changelog/fix_error_for_rails_where_exists.md
@@ -1,0 +1,1 @@
+* [#1241](https://github.com/rubocop/rubocop-rails/pull/1241): Fix an error for `Rails/WhereExists` with `EnforcedStyle: where` and implicit receivers. ([@earlopain][])

--- a/lib/rubocop/cop/rails/where_exists.rb
+++ b/lib/rubocop/cop/rails/where_exists.rb
@@ -67,7 +67,7 @@ module RuboCop
             return unless convertable_args?(args)
 
             range = correction_range(node)
-            good_method = build_good_method(args, dot_source: node.loc.dot.source)
+            good_method = build_good_method(args, dot: node.loc.dot)
             message = format(MSG, good_method: good_method, bad_method: range.source)
 
             add_offense(range, message: message) do |corrector|
@@ -109,11 +109,11 @@ module RuboCop
           end
         end
 
-        def build_good_method(args, dot_source: '.')
+        def build_good_method(args, dot:)
           if exists_style?
             build_good_method_exists(args)
           elsif where_style?
-            build_good_method_where(args, dot_source)
+            build_good_method_where(args, dot&.source || '.')
           end
         end
 

--- a/spec/rubocop/cop/rails/where_exists_spec.rb
+++ b/spec/rubocop/cop/rails/where_exists_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
       RUBY
     end
 
+    it 'registers an offense when using implicit receiver and arg' do
+      expect_offense(<<~RUBY)
+        where('name = ?', 'john').exists?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(['name = ?', 'john'])` over `where('name = ?', 'john').exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        exists?(['name = ?', 'john'])
+      RUBY
+    end
+
     it 'registers an offense when using `where(...).exists?` with an association' do
       expect_offense(<<~RUBY)
         user.posts.where(published: true).exists?
@@ -139,6 +150,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
 
       expect_correction(<<~RUBY)
         User.where('name = ?', 'john').exists?
+      RUBY
+    end
+
+    it 'registers an offense when using implicit receiver and arg' do
+      expect_offense(<<~RUBY)
+        exists?('name = ?', 'john')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where('name = ?', 'john').exists?` over `exists?('name = ?', 'john')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        where('name = ?', 'john').exists?
       RUBY
     end
 


### PR DESCRIPTION
`EnforcedStyle: exists` works fine, but since there was no test for this I added one.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
