### PR TITLE
[Fix #1244] Fix a false positive for `Rails/ActionControllerFlashBeforeRender` when returning `redirect_to`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
+++ b/changelog/fix_a_false_positive_for_rails_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#1244](https://github.com/rubocop/rubocop-rails/issues/1244): Fix a false positive for `Rails/ActionControllerFlashBeforeRender` when returning `redirect_to`. ([@earlopain][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -99,6 +99,8 @@ module RuboCop
 
         def use_redirect_to?(context)
           context.right_siblings.compact.any? do |sibling|
+            # Unwrap `return redirect_to :index`
+            sibling = sibling.children.first if sibling.return_type? && sibling.children.one?
             sibling.send_type? && sibling.method?(:redirect_to)
           end
         end

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -312,4 +312,20 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
       RUBY
     end
   end
+
+  context 'when using `flash` after `render` and returning `redirect_to` in condition block' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class HomeController < ApplicationController
+          def create
+            if condition
+              flash[:alert] = "msg"
+              return redirect_to "https://www.example.com/"
+            end
+            render :index
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Closes #1244

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
