### PR TITLE
[Fix #1247] Fix an error for `Rails/UnusedIgnoredColumns`

### DIFF
--- a/changelog/fix_an_error_for_rails_unused_ignored_column.md
+++ b/changelog/fix_an_error_for_rails_unused_ignored_column.md
@@ -1,0 +1,1 @@
+* [#1247](https://github.com/rubocop/rubocop-rails/issues/1247): Fix an error for `Rails/UnusedIgnoredColumns` when without tables in db/schema.rb. ([@koic][])

--- a/lib/rubocop/rails/schema_loader/schema.rb
+++ b/lib/rubocop/rails/schema_loader/schema.rb
@@ -30,6 +30,7 @@ module RuboCop
 
         def build!(ast)
           raise "Unexpected type: #{ast.type}" unless ast.block_type?
+          return unless ast.body
 
           each_table(ast) do |table_def|
             next unless table_def.method?(:create_table)

--- a/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
+++ b/spec/rubocop/cop/rails/unused_ignored_columns_spec.rb
@@ -123,6 +123,25 @@ RSpec.describe RuboCop::Cop::Rails::UnusedIgnoredColumns, :config do
 
     let(:schema) { <<~RUBY }
       ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+      end
+    RUBY
+
+    context 'with an unused ignored column as a Symbol' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class User < ApplicationRecord
+            self.ignored_columns = [:real_name]
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'with `enable_extension` and no tables db/schema.rb' do
+    include_context 'with SchemaLoader'
+
+    let(:schema) { <<~RUBY }
+      ActiveRecord::Schema.define(version: 2020_02_02_075409) do
         enable_extension 'plpgsql'
       end
     RUBY


### PR DESCRIPTION
Fixes #1247.

This PR fixes an error for `Rails/UnusedIgnoredColumns` when without tables in db/schema.rb.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
