### PR TITLE
[Fix #1200] Make `Rails/TimeZone` aware of safe navigation

### DIFF
--- a/changelog/fix_make_rails_time_zone_aware_of_safe_navigation.md
+++ b/changelog/fix_make_rails_time_zone_aware_of_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#1200](https://github.com/rubocop/rubocop-rails/issues/1200): Make `Rails/TimeZone` aware of safe navigation. ([@earlopain][])

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -69,9 +69,10 @@ module RuboCop
           return if !node.receiver&.str_type? || !node.method?(:to_time)
 
           add_offense(node.loc.selector, message: MSG_STRING_TO_TIME) do |corrector|
-            corrector.replace(node, "Time.zone.parse(#{node.receiver.source})")
+            corrector.replace(node, "Time.zone.parse(#{node.receiver.source})") unless node.csend_type?
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -135,6 +135,15 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       RUBY
     end
 
+    it 'registers an offense for `to_time` with safe navigation' do
+      expect_offense(<<~RUBY)
+        "2012-03-02 16:05:37"&.to_time
+                               ^^^^^^^ Do not use `String#to_time` without zone. Use `Time.zone.parse` instead.
+      RUBY
+
+      expect_no_corrections
+    end
+
     it 'does not register an offense for `to_time` without receiver' do
       expect_no_offenses(<<~RUBY)
         to_time


### PR DESCRIPTION
`parse` raises on `nil` so autocorrect is not possible in this case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
