### PR TITLE
[Fix #1249] Disable `Rails/UnusedIgnoredColumns` by default

### DIFF
--- a/changelog/change_disable_rails_unused_ignored_columns.md
+++ b/changelog/change_disable_rails_unused_ignored_columns.md
@@ -1,0 +1,1 @@
+* [#1249](https://github.com/rubocop/rubocop-rails/issues/1249): Disable `Rails/UnusedIgnoredColumns` by default. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1163,8 +1163,9 @@ Rails/UnknownEnv:
 
 Rails/UnusedIgnoredColumns:
   Description: 'Remove a column that does not exist from `ignored_columns`.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '2.11'
+  VersionChanged: <<next>>
   Include:
     - app/models/**/*.rb
 

--- a/lib/rubocop/cop/rails/unused_ignored_columns.rb
+++ b/lib/rubocop/cop/rails/unused_ignored_columns.rb
@@ -7,6 +7,12 @@ module RuboCop
       # `ignored_columns` is necessary to drop a column from RDBMS, but you don't need it after the migration
       # to drop the column. You avoid forgetting to remove `ignored_columns` by this cop.
       #
+      # IMPORTANT: This cop can't be used to effectively check for unused columns because the development
+      # and production schema can be out of sync until the migration has been run on production. As such,
+      # this cop can cause `ignored_columns` to be removed even though the production schema still contains
+      # the column, which can lead to downtime when the migration is actually executed. Only enable this cop
+      # if you know your migrations will be run before any of your Rails applications boot with the modified code.
+      #
       # @example
       #   # bad
       #   class User < ApplicationRecord


### PR DESCRIPTION
Fix #1249

This cop can't be used to effectivly check for unused columns because the development and production schema can be out of sync until the migration has been run on production.
As such, this cop can cause `ignored_columns` to be removed even though the production schema still contains the column, which can lead to downtime when the migration is actually executed.

Users can manually enable this cop if they know this isn't an issue that can/will impact them.

cc @rafaelfranca, let me know if the added tidbit to the cops documentation is not correct.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
