### PR TITLE
Fix an error for `Rails/WhereMissing` without receiver

### DIFF
--- a/changelog/fix_an_error_for_rails_where_missing.md
+++ b/changelog/fix_an_error_for_rails_where_missing.md
@@ -1,0 +1,1 @@
+* [#1253](https://github.com/rubocop/rubocop-rails/pull/1253): Fix an error for `Rails/WhereMissing` with leading `where` without receiver. ([@earlopain][])

--- a/lib/rubocop/cop/rails/where_missing.rb
+++ b/lib/rubocop/cop/rails/where_missing.rb
@@ -89,16 +89,20 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def remove_where_method(corrector, node, where_node)
           range = range_between(where_node.loc.selector.begin_pos, where_node.loc.end.end_pos)
           if node.multiline? && !same_line?(node, where_node)
             range = range_by_whole_lines(range, include_final_newline: true)
-          else
+          elsif where_node.receiver
             corrector.remove(where_node.loc.dot)
+          else
+            corrector.remove(node.loc.dot)
           end
 
           corrector.remove(range)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def same_line?(left_joins_node, where_node)
           left_joins_node.loc.selector.line == where_node.loc.selector.line

--- a/spec/rubocop/cop/rails/where_missing_spec.rb
+++ b/spec/rubocop/cop/rails/where_missing_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereMissing, :config do
       RUBY
     end
 
+    it 'registers an offense when using `left_joins(:foo).where(foo: {id: nil})` without receiver' do
+      expect_offense(<<~RUBY)
+        left_joins(:foo).where(foo: { id: nil }).where(bar: "bar")
+        ^^^^^^^^^^^^^^^^ Use `where.missing(:foo)` instead of `left_joins(:foo).where(foo: { id: nil })`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        where.missing(:foo).where(bar: "bar")
+      RUBY
+    end
+
     it 'registers an offense when using `left_outer_joins(:foo).where(foos: {id: nil})`' do
       expect_offense(<<~RUBY)
         Foo.left_outer_joins(:foo).where(foos: { id: nil }).where(bar: "bar")
@@ -46,6 +57,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereMissing, :config do
       RUBY
     end
 
+    it 'registers an offense when using `where(foos: {id: nil}).left_joins(:foo)` without receiver' do
+      expect_offense(<<~RUBY)
+        where(foos: { id: nil }).left_joins(:foo).where(bar: "bar")
+                                 ^^^^^^^^^^^^^^^^ Use `where.missing(:foo)` instead of `left_joins(:foo).where(foos: { id: nil })`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        where.missing(:foo).where(bar: "bar")
+      RUBY
+    end
+
     it 'registers an offense when using `where(foos: {id: nil}, bar: "bar").left_joins(:foo)`' do
       expect_offense(<<~RUBY)
         Foo.where(foos: { id: nil }, bar: "bar").left_joins(:foo)
@@ -54,6 +76,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereMissing, :config do
 
       expect_correction(<<~RUBY)
         Foo.where(bar: "bar").where.missing(:foo)
+      RUBY
+    end
+
+    it 'registers an offense when using `where(foos: {id: nil}, bar: "bar").left_joins(:foo)` without receiver' do
+      expect_offense(<<~RUBY)
+        where(foos: { id: nil }, bar: "bar").left_joins(:foo)
+                                             ^^^^^^^^^^^^^^^^ Use `where.missing(:foo)` instead of `left_joins(:foo).where(foos: { id: nil })`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        where(bar: "bar").where.missing(:foo)
       RUBY
     end
 


### PR DESCRIPTION
This only happens if `where` comes before `left_joins`. I added tests for both anyways.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
