### PR TITLE
Fix an error for `Rails/ExpandedDateRange` when passing an argument only to the first method call

### DIFF
--- a/changelog/fix_and_error_for_rails_expanded_date_range.md
+++ b/changelog/fix_and_error_for_rails_expanded_date_range.md
@@ -1,0 +1,1 @@
+* [#1254](https://github.com/rubocop/rubocop-rails/pull/1254): Fix an error for `Rails/ExpandedDateRange` when passing an argument only to the first method call for weeks. ([@earlopain][])

--- a/lib/rubocop/cop/rails/expanded_date_range.rb
+++ b/lib/rubocop/cop/rails/expanded_date_range.rb
@@ -51,7 +51,7 @@ module RuboCop
           return if allow?(begin_node, end_node)
 
           preferred_method = preferred_method(begin_node)
-          if begin_node.method?(:beginning_of_week) && begin_node.arguments.one?
+          if begin_node.method?(:beginning_of_week) && begin_node.arguments.one? && end_node.arguments.one?
             return unless same_argument?(begin_node, end_node)
 
             preferred_method << "(#{begin_node.first_argument.source})"

--- a/spec/rubocop/cop/rails/expanded_date_range_spec.rb
+++ b/spec/rubocop/cop/rails/expanded_date_range_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe RuboCop::Cop::Rails::ExpandedDateRange, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `date.beginning_of_week(:sunday)..date.end_of_week`' do
+      expect_no_offenses(<<~RUBY)
+        date.beginning_of_week(:sunday)..date.end_of_week
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `date.beginning_of_year..date.end_of_year`' do
       expect_offense(<<~RUBY)
         date.beginning_of_year..date.end_of_year


### PR DESCRIPTION
`:monday` is the default, however this can be set per request/overwritten in the config so an offense is not possible here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
