### PR TITLE
Fix an error for `Rails/UniqBeforePluck` with `EnforcedStyle: aggressive` when no receiver

### DIFF
--- a/changelog/fix_an_error_for_rails_uniq_before_pluck.md
+++ b/changelog/fix_an_error_for_rails_uniq_before_pluck.md
@@ -1,0 +1,1 @@
+* [#1255](https://github.com/rubocop/rubocop-rails/pull/1255): Fix an error for `Rails/UniqBeforePluck` with `EnforcedStyle: aggressive` when no receiver. ([@earlopain][])

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -68,14 +68,22 @@ module RuboCop
           return unless uniq
 
           add_offense(node.loc.selector) do |corrector|
-            method = node.method_name
-
-            corrector.remove(dot_method_with_whitespace(method, node))
-            corrector.insert_before(node.receiver.loc.dot.begin, '.distinct')
+            autocorrect(corrector, node)
           end
         end
 
         private
+
+        def autocorrect(corrector, node)
+          method = node.method_name
+
+          corrector.remove(dot_method_with_whitespace(method, node))
+          if (dot = node.receiver.loc.dot)
+            corrector.insert_before(dot.begin, '.distinct')
+          else
+            corrector.insert_before(node.receiver, 'distinct.')
+          end
+        end
 
         def dot_method_with_whitespace(method, node)
           range_between(dot_method_begin_pos(method, node), node.loc.selector.end_pos)

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -113,5 +113,16 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
         instance.assoc.distinct.pluck(:name)
       RUBY
     end
+
+    it 'corrects uniq when used without a receiver' do
+      expect_offense(<<~RUBY)
+        pluck(:name).uniq
+                     ^^^^ Use `distinct` before `pluck`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        distinct.pluck(:name)
+      RUBY
+    end
   end
 end


### PR DESCRIPTION


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
