### PR TITLE
Fix an error for `Rails/ActiveSupportOnLoad` when calling without arguments

### DIFF
--- a/changelog/fix_error_for_rails_active_support_load_hook.md
+++ b/changelog/fix_error_for_rails_active_support_load_hook.md
@@ -1,0 +1,1 @@
+* [#1256](https://github.com/rubocop/rubocop-rails/pull/1256): Fix an error for `Rails/ActiveSupportOnLoad` when calling without arguments. ([@earlopain][])

--- a/lib/rubocop/cop/rails/active_support_on_load.rb
+++ b/lib/rubocop/cop/rails/active_support_on_load.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         def on_send(node)
           receiver, method, arguments = *node # rubocop:disable InternalAffairs/NodeDestructuring
-          return unless receiver && (hook = LOAD_HOOKS[receiver.const_name])
+          return unless arguments && (hook = LOAD_HOOKS[receiver&.const_name])
 
           preferred = "ActiveSupport.on_load(:#{hook}) { #{method} #{arguments.source} }"
           add_offense(node, message: format(MSG, prefer: preferred, current: node.source)) do |corrector|

--- a/spec/rubocop/cop/rails/active_support_on_load_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_on_load_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe(RuboCop::Cop::Rails::ActiveSupportOnLoad, :config) do
     RUBY
   end
 
+  it 'does not add offense for include without arguments' do
+    expect_no_offenses(<<~RUBY)
+      ActiveRecord::Base.include
+    RUBY
+  end
+
   it 'adds offense and corrects when trying to extend a framework class with prepend' do
     expect_offense(<<~RUBY)
       ActiveRecord::Base.prepend(MyClass)


### PR DESCRIPTION


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
