### PR TITLE
[Fix #1230] Fix a false positive for `Rails/SaveBang` if `persisted?` is checked on parenthesised expression.

### DIFF
--- a/changelog/fix_false_positive_for_rails_save_bang.md
+++ b/changelog/fix_false_positive_for_rails_save_bang.md
@@ -1,0 +1,1 @@
+* [#1230](https://github.com/rubocop/rubocop-rails/issues/1230): Fix a false positive for `Rails/SaveBang` if `persisted?` is checked on parenthesised expression. ([@earlopain][])

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -196,6 +196,8 @@ module RuboCop
         end
 
         def call_to_persisted?(node)
+          node = node.parent.condition if node.parenthesized_call? && node.parent.if_type?
+
           node.send_type? && node.method?(:persisted?)
         end
 

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -638,6 +638,38 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
       RUBY
     end
 
+    it "when using persisted? on the result of #{method} in if assignment" do
+      expect_no_offenses(<<~RUBY)
+        if (user = User.#{method}).persisted?
+          foo(user)
+        else
+          bar(user)
+        end
+      RUBY
+    end
+
+    it "when not using persisted? on the result of #{method} in if assignment" do
+      expect_offense(<<~RUBY, method: method)
+        if (user = User.#{method})
+                        ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked. Or check `persisted?` on model returned from `#{method}`.
+          foo(user)
+        else
+          bar(user)
+        end
+      RUBY
+    end
+
+    it "when using persisted? on the result of #{method} in elsif assignment" do
+      expect_no_offenses(<<~RUBY)
+        if something
+        elsif (user = User.#{method}).persisted?
+          foo(user)
+        else
+          bar(user)
+        end
+      RUBY
+    end
+
     it "when using #{method} with `||`" do
       expect_no_offenses(<<~RUBY)
         def find_or_create(**opts)


### PR DESCRIPTION
There are a few more cases I can think of that should potentially be handled, like

```rb
while (post = User.create(params).persisted?
  params = new_params
end
```

but I'd wait until someone actually complains. It doesn't look like very practical code to me.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
