### PR TITLE
[Fix #1260] Fix performance regression caused by `Rails/UnknownEnv` on rails 7.1

### DIFF
--- a/changelog/fix_unknown_env_causing_cache_issues.md
+++ b/changelog/fix_unknown_env_causing_cache_issues.md
@@ -1,0 +1,1 @@
+* [#1260](https://github.com/rubocop/rubocop-rails/issues/1260): Fix a performance regression caused by `Rails/UnknownEnv` when using Rails 7.1. ([@lukasfroehlich1][])

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -87,7 +87,7 @@ module RuboCop
 
         def environments
           @environments ||= begin
-            environments = cop_config['Environments'] || []
+            environments = cop_config['Environments'].dup || []
             environments << 'local' if target_rails_version >= 7.1
             environments
           end

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
       RUBY
     end
 
+    it 'does not mutate the cop config' do
+      expect_no_offenses(<<~RUBY)
+        Rails.env.local?
+        Rails.env == 'local'
+      RUBY
+
+      expect(cop_config['Environments'].include?('local')).to be(false)
+    end
+
     context 'when `Environments` is nil' do
       let(:cop_config) do
         {


### PR DESCRIPTION
After upgrading to Rails 7.1 we noticed a significant slowdown of RuboCop (52s -> 3m 52s).

We found that the cache file path for certain files was changing throughout the RuboCop execution, resulting in cache misses. One of the components of the cache file path is the [cop config](https://github.com/rubocop/rubocop/blob/f9b3b1ed1ddb6129cd5bf7c16824261041f107d5/lib/rubocop/result_cache.rb#L160). 

When diffing the cop config throughout RuboCops execution we find that "Rails/UnknownEnv"."Environments"  is changing: 
![Screenshot 2024-03-26 at 12 29 52 AM](https://github.com/rubocop/rubocop-rails/assets/5376892/f7963bc7-3cc9-4549-a47a-48c735fe3fbb)

When Rails/UnknownEnv runs as part of the [warm_cache](https://github.com/rubocop/rubocop/blob/f9b3b1ed1ddb6129cd5bf7c16824261041f107d5/lib/rubocop/runner.rb#L72) step in RuboCop it mutates the config, which subsequently modifies the file checksums. When RuboCop runs [inspect_files](https://github.com/rubocop/rubocop/blob/f9b3b1ed1ddb6129cd5bf7c16824261041f107d5/lib/rubocop/runner.rb#L73) it results in cache misses because the cop config is no longer the same.

The code causing the issue:

```
def environments
  @environments ||= begin
    environments = cop_config['Environments'] || []
    environments << 'local' if target_rails_version >= 7.1
    environments
  end
```

In this case `cop_config['Environments']` is mutated when `environments << 'local'` runs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
