### PR TITLE
[Fix #237] Improve documentation for Rails/NotNullColumn

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -693,7 +693,7 @@ Rails/NegateInclude:
   VersionChanged: '2.9'
 
 Rails/NotNullColumn:
-  Description: 'Do not add a NOT NULL column without a default value.'
+  Description: 'Do not add a NOT NULL column without a default value to existing tables.'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '2.20'

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -3,13 +3,25 @@
 module RuboCop
   module Cop
     module Rails
-      # Checks for add_column call with NOT NULL constraint in migration file.
+      # Checks for add_column calls with a NOT NULL constraint without a default
+      # value.
       #
-      # `TEXT` can have default values in PostgreSQL, but not in MySQL.
-      # It will automatically detect an adapter from `development` environment
-      # in `config/database.yml` or the environment variable `DATABASE_URL`
-      # when the `Database` option is not set. If the database is MySQL,
-      # this cop ignores offenses for the `TEXT`.
+      # This cop only applies when adding a column to an existing table, since
+      # existing records will not have a value for the new column. New tables
+      # can freely use NOT NULL columns without defaults, since there are no
+      # records that could violate the constraint.
+      #
+      # If you need to add a NOT NULL column to an existing table, you must add
+      # it as nullable first, back-fill the data, and then use
+      # `change_column_null`. Alternatively, you could add the column with a
+      # default first to have the database automatically backfill existing rows,
+      # and then use `change_column_default` to remove the default.
+      #
+      # `TEXT` cannot have a default value in MySQL.
+      # The cop will automatically detect an adapter from `development`
+      # environment in `config/database.yml` or the environment variable
+      # `DATABASE_URL` when the `Database` option is not set. If the database
+      # is MySQL, this cop ignores offenses for `TEXT` columns.
       #
       # @example
       #   # bad
@@ -20,7 +32,7 @@ module RuboCop
       #   add_column :users, :name, :string, null: true
       #   add_column :users, :name, :string, null: false, default: ''
       #   add_reference :products, :category
-      #   add_reference :products, :category, null: false, default: 1
+      #   change_column_null :products, :category_id, false
       class NotNullColumn < Base
         include DatabaseTypeResolvable
 


### PR DESCRIPTION
Clarify that the cop is only for NOT NULL without a default, and only for existing tables. Also point users in the direction of how to add a NOT NULL column to an existing table.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
