### PR TITLE
Rails/NotNullColumn: Inspect change_table calls for offenses

### DIFF
--- a/changelog/change_inspect_change_table_for_not_null_column.md
+++ b/changelog/change_inspect_change_table_for_not_null_column.md
@@ -1,0 +1,1 @@
+* [#1266](https://github.com/rubocop/rubocop-rails/pull/1266): Check `change_table` calls for offenses. ([@ccutrer][])

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -87,6 +87,126 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
     end
   end
 
+  context 'with change_table call' do
+    context 'with shortcut column call' do
+      context 'with null: false' do
+        it 'reports an offense' do
+          expect_offense(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.string :name, null: false
+                                ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+              end
+            end
+          RUBY
+        end
+
+        it 'reports multiple offenses' do
+          expect_offense(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.string :name, null: false
+                                ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+                t.string :address, null: false
+                                   ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'with default option' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.string :name, null: false, default: ""
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'without any options' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.string :name
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'with column call' do
+      context 'with null: false' do
+        it 'reports an offense' do
+          expect_offense(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.column :name, :string, null: false
+                                         ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'with default option' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.column :name, :string, null: false, default: ""
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'without any options' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.column :name, :string
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'with reference call' do
+      context 'with null: false' do
+        it 'reports an offense' do
+          expect_offense(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.references :address, null: false
+                                       ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'without any options' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def change
+              change_table :users do |t|
+                t.references :address
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+
   context 'with add_reference call' do
     context 'with null: false' do
       it 'reports an offense' do


### PR DESCRIPTION
I noticed this cop was not aware of columns added inside a `change_table` block, so added support for that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
