### PR TITLE
Make Rails/HttpStatus aware of Rails specific response assertions

### DIFF
--- a/changelog/change_make_rails_http_status_aware_of_rails_specific_response_assertions.md
+++ b/changelog/change_make_rails_http_status_aware_of_rails_specific_response_assertions.md
@@ -1,0 +1,1 @@
+* [#1267](https://github.com/rubocop/rubocop-rails/pull/1267): Make `Rails/HttpStatus` aware of Rails-specific response assertions. ([@tldn0718][])

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -13,6 +13,8 @@ module RuboCop
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
       #   head 200
+      #   assert_response 200
+      #   assert_redirected_to '/some/path', status: 301
       #
       #   # good
       #   render :foo, status: :ok
@@ -20,6 +22,8 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #   head :ok
+      #   assert_response :ok
+      #   assert_redirected_to '/some/path', status: :moved_permanently
       #
       # @example EnforcedStyle: numeric
       #   # bad
@@ -28,6 +32,8 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #   head :ok
+      #   assert_response :ok
+      #   assert_redirected_to '/some/path', status: :moved_permanently
       #
       #   # good
       #   render :foo, status: 200
@@ -35,18 +41,22 @@ module RuboCop
       #   render plain: 'foo/bar', status: 304
       #   redirect_to root_url, status: 301
       #   head 200
+      #   assert_response 200
+      #   assert_redirected_to '/some/path', status: 301
       #
       class HttpStatus < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector
 
-        RESTRICT_ON_SEND = %i[render redirect_to head].freeze
+        RESTRICT_ON_SEND = %i[render redirect_to head assert_response assert_redirected_to].freeze
 
         def_node_matcher :http_status, <<~PATTERN
           {
             (send nil? {:render :redirect_to} _ $hash)
             (send nil? {:render :redirect_to} $hash)
-            (send nil? :head ${int sym} ...)
+            (send nil? {:head :assert_response} ${int sym} ...)
+            (send nil? :assert_redirected_to _ $hash ...)
+            (send nil? :assert_redirected_to $hash ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
              ^^^ Prefer `:ok` over `200` to define HTTP status code.
         head 200, location: 'accounts'
              ^^^ Prefer `:ok` over `200` to define HTTP status code.
+        assert_response 200
+                        ^^^ Prefer `:ok` over `200` to define HTTP status code.
+        assert_response 404, 'message'
+                        ^^^ Prefer `:not_found` over `404` to define HTTP status code.
+        assert_redirected_to '/some/path', status: 301
+                                                   ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
+        assert_redirected_to action: 'index', status: 301
+                                                      ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
+        assert_redirected_to '/some/path', { status: 301 }, 'message'
+                                                     ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -36,6 +46,11 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
         head :ok
         head :ok, location: 'accounts'
+        assert_response :ok
+        assert_response :not_found, 'message'
+        assert_redirected_to '/some/path', status: :moved_permanently
+        assert_redirected_to action: 'index', status: :moved_permanently
+        assert_redirected_to '/some/path', { status: :moved_permanently }, 'message'
       RUBY
     end
 
@@ -58,6 +73,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: :moved_permanently
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: :moved_permanently
         head :ok
+        assert_response :ok
+        assert_response :not_found, 'message'
+        assert_redirected_to '/some/path', status: :moved_permanently
+        assert_redirected_to action: 'index', status: :moved_permanently
       RUBY
     end
 
@@ -69,6 +88,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 550
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 550
         head 550
+        assert_response 550
+        assert_response 550, 'message'
+        assert_redirected_to '/some/path', status: 550
+        assert_redirected_to action: 'index', status: 550
       RUBY
     end
 
@@ -102,6 +125,16 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
              ^^^ Prefer `200` over `:ok` to define HTTP status code.
         head :ok, location: 'accounts'
              ^^^ Prefer `200` over `:ok` to define HTTP status code.
+        assert_response :ok
+                        ^^^ Prefer `200` over `:ok` to define HTTP status code.
+        assert_response :not_found, 'message'
+                        ^^^^^^^^^^ Prefer `404` over `:not_found` to define HTTP status code.
+        assert_redirected_to '/some/path', status: :moved_permanently
+                                                   ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
+        assert_redirected_to action: 'index', status: :moved_permanently
+                                                      ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
+        assert_redirected_to '/some/path', { status: :moved_permanently }, 'message'
+                                                     ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -114,6 +147,11 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
         head 200
         head 200, location: 'accounts'
+        assert_response 200
+        assert_response 404, 'message'
+        assert_redirected_to '/some/path', status: 301
+        assert_redirected_to action: 'index', status: 301
+        assert_redirected_to '/some/path', { status: 301 }, 'message'
       RUBY
     end
 
@@ -125,6 +163,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 301
         redirect_to root_path(utm_source: :pr, utm_medium: :web), status: 301
         head 200
+        assert_response 200
+        assert_response 404, 'message'
+        assert_redirected_to '/some/path', status: 301
+        assert_redirected_to action: 'index', status: 301
       RUBY
     end
 
@@ -134,6 +176,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         render :foo, status: :success
         render :foo, status: :missing
         render :foo, status: :redirect
+        assert_response :error
+        assert_response :success
+        assert_response :missing
+        assert_response :redirect
       RUBY
     end
 


### PR DESCRIPTION
This PR makes the `HttpStatus` Cop aware of the Rails-specific assertions  that test responses from Rails applications, such as `assert_response` and `assert_redirect_to`.

This Cop enforces a consistent method of specifying HTTP status in `render`, `redirect_to`, and `head`, either symbolic or numeric. However, it did not account for `assert_response` and `assert_redirect_to` used in testing, which also accepts HTTP status as a parameter in a manner consistent with those methods.

This PR ensures that the `HttpStatus` Cop can enforce a uniform way of specifying HTTP status in both application and testing code. Specifically, it addresses the previously possible inconsistency in specifying HTTP Status when using `assert_response` and `assert_redirect_to`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
