### PR TITLE
[Fix #1270] Fix an incorrect autocorrect for `Rails/Validation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_validation.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_validation.md
@@ -1,0 +1,1 @@
+* [#1270](https://github.com/rubocop/rubocop-rails/issues/1270): Fix an incorrect autocorrect for `Rails/Validation` when using `validates_size_of`. ([@koic][])

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -29,7 +29,7 @@ module RuboCop
       #   validates :foo, numericality: true
       #   validates :foo, presence: true
       #   validates :foo, absence: true
-      #   validates :foo, size: true
+      #   validates :foo, length: true
       #   validates :foo, uniqueness: true
       #
       class Validation < Base
@@ -120,7 +120,9 @@ module RuboCop
         end
 
         def validate_type(node)
-          node.method_name.to_s.split('_')[1]
+          type = node.method_name.to_s.split('_')[1]
+
+          type == 'size' ? 'length' : type
         end
 
         def frozen_array_argument?(argument)

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
     described_class::TYPES.each do |type|
       context "with validates_#{type}_of" do
         let(:autocorrected_source) do
+          type = 'length' if type == 'size'
+
           "validates :full_name, :birth_date, #{type}: true"
         end
 
@@ -40,6 +42,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
 
       context "with validates_#{type}_of when method arguments are enclosed in parentheses" do
         let(:autocorrected_source) do
+          type = 'length' if type == 'size'
+
           "validates(:full_name, :birth_date, #{type}: true)"
         end
 
@@ -52,6 +56,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
 
       context "with validates_#{type}_of when attributes are specified with array literal" do
         let(:autocorrected_source) do
+          type = 'length' if type == 'size'
+
           "validates :full_name, :birth_date, #{type}: true"
         end
 
@@ -64,6 +70,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
 
       context "with validates_#{type}_of when attributes are specified with frozen array literal" do
         let(:autocorrected_source) do
+          type = 'length' if type == 'size'
+
           "validates :full_name, :birth_date, #{type}: true"
         end
 
@@ -76,6 +84,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
 
       context "with validates_#{type}_of when attributes are specified with symbol array literal" do
         let(:autocorrected_source) do
+          type = 'length' if type == 'size'
+
           "validates :full_name, :birth_date, #{type}: true"
         end
 
@@ -88,6 +98,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
 
       context "with validates_#{type}_of when attributes are specified with frozen symbol array literal" do
         let(:autocorrected_source) do
+          type = 'length' if type == 'size'
+
           "validates :full_name, :birth_date, #{type}: true"
         end
 


### PR DESCRIPTION
Fixes #1270.

This PR fixes an incorrect autocorrect for `Rails/Validation` when using `validates_size_of`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
