### PR TITLE
Restore skipped specs for Prism

### DIFF
--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Rails::Blank, :config do
   shared_examples 'offense' do |source, correction, message|
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense and corrects', broken_on: :prism do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY, source: source, message: message)
         #{source}
         ^{source} #{message}

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe RuboCop::Cop::Rails::Exit, :config do
     RUBY
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  it 'registers an offense for an exit! call with no receiver', broken_on: :prism do
+  it 'registers an offense for an exit! call with no receiver' do
     expect_offense(<<~RUBY)
       exit!
       ^^^^^ Do not use `exit` in Rails applications.

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Rails::Present, :config do
   shared_examples 'offense' do |source, correction, message|
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense and corrects', broken_on: :prism do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY, source: source, message: message)
         #{source}
         ^{source} #{message}

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -119,12 +119,7 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
         it_behaves_like 'autocorrect', 'try! with 2 parameters', '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
         it_behaves_like 'autocorrect', 'try! with multiple parameters',
                         '[1, 2].try!(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
-        # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-        # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-        context 'skip test when parser engine is prism', broken_on: :prism do
-          it_behaves_like 'autocorrect', 'try! without receiver', 'try!(:join)', 'self&.join'
-        end
-
+        it_behaves_like 'autocorrect', 'try! without receiver', 'try!(:join)', 'self&.join'
         it_behaves_like 'autocorrect', 'try! with a block',
                         ['[foo, bar].try!(:map) do |e|',
                          '  e.some_method',

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -74,9 +74,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
       end
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it "when using #{method} without arguments", broken_on: :prism do
+    it "when using #{method} without arguments" do
       expect_offense(<<~RUBY, method: method)
         #{method}
         ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -66,27 +66,21 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
         RUBY
       end
 
-      # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-      # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-      it "registers an offense for #{method} with `:returning` keyword argument", broken_on: :prism do
+      it "registers an offense for #{method} with `:returning` keyword argument" do
         expect_offense(<<~RUBY, method: method)
           %{method}(attributes, returning: false)
           ^{method} Avoid using `#{method}` because it skips validations.
         RUBY
       end
 
-      # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-      # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-      it "registers an offense for #{method} with `:unique_by` keyword argument", broken_on: :prism do
+      it "registers an offense for #{method} with `:unique_by` keyword argument" do
         expect_offense(<<~RUBY, method: method)
           %{method}(attributes, unique_by: :username)
           ^{method} Avoid using `#{method}` because it skips validations.
         RUBY
       end
 
-      # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-      # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-      it "registers an offense for #{method} with both `:returning` and `:unique_by` keyword arguments", broken_on: :prism do # rubocop:disable Layout/LineLength
+      it "registers an offense for #{method} with both `:returning` and `:unique_by` keyword arguments" do
         expect_offense(<<~RUBY, method: method)
           %{method}(attributes, returning: false, unique_by: :username)
           ^{method} Avoid using `#{method}` because it skips validations.

--- a/spec/rubocop/cop/rails/where_exists_spec.rb
+++ b/spec/rubocop/cop/rails/where_exists_spec.rb
@@ -59,9 +59,7 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense when using implicit receiver and arg', broken_on: :prism do
+    it 'registers an offense when using implicit receiver and arg' do
       expect_offense(<<~RUBY)
         where('name = ?', 'john').exists?
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(['name = ?', 'john'])` over `where('name = ?', 'john').exists?`.
@@ -155,9 +153,7 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense when using implicit receiver and arg', broken_on: :prism do
+    it 'registers an offense when using implicit receiver and arg' do
       expect_offense(<<~RUBY)
         exists?('name = ?', 'john')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where('name = ?', 'john').exists?` over `exists?('name = ?', 'john')`.


### PR DESCRIPTION
This PR restores skipped specs for Prism. They have already been resolved in Prism, so they can be tested.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
