### PR TITLE
Warn about subqueries when replacing pluck with pick

### DIFF
--- a/lib/rubocop/cop/rails/pick.rb
+++ b/lib/rubocop/cop/rails/pick.rb
@@ -9,6 +9,10 @@ module RuboCop
       # `pick` avoids. When called on an Active Record relation, `pick` adds a
       # limit to the query so that only one value is fetched from the database.
       #
+      # Note that when `pick` is added to a relation with an existing limit, it
+      # causes a subquery to be added. In most cases this is undesirable, and
+      # care should be taken while resolving this violation.
+      #
       # @safety
       #   This cop is unsafe because `pluck` is defined on both `ActiveRecord::Relation` and `Enumerable`,
       #   whereas `pick` is only defined on `ActiveRecord::Relation` in Rails 6.0. This was addressed


### PR DESCRIPTION
The `RuboCop::Cop::Rails::Pick` cop "Enforces the use of ‘pick` over `pluck(…).first`."

When using this cop on an existing code base, it's not possible for the cop to detect whether the relation already has a limit applied.

In these cases, following the advice will cause a subquery to be added to the resulting query.

`Model.limit(100).pluck(:a).first` is not equivalent to `Model.limit(100).pick(:a)`. The former generates a SQL query with a `LIMIT 100`. The latter generates a query with `LIMIT 1` and subquery with `LIMIT 100`.

This proposed documentation update highlights the scenario so the developer can better judge when to obey the cop.

Example: https://gitlab.com/gitlab-org/gitlab/-/issues/455116

Note: I haven't updated `docs/modules/ROOT/pages/cops_rails.adoc` as I believe this is done when a new version of the gem is cut.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
