### PR TITLE
[Fix #1278] Fix a false positivie for Rails/SkipsModelValidations

### DIFF
--- a/changelog/fix_safe_navigator_for_skips_model_validation.md
+++ b/changelog/fix_safe_navigator_for_skips_model_validation.md
@@ -1,0 +1,1 @@
+* [#1278](https://github.com/rubocop/rubocop-rails/issues/1278): Fix a false positive for `Rails/SkipsModelValidations` when using `insert` or `insert!` with a safe navigator. ([@tldn0718][])

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -63,7 +63,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :good_insert?, <<~PATTERN
-          (send _ {:insert :insert!} _ {
+          (call _ {:insert :insert!} _ {
             !(hash ...)
             (hash <(pair (sym !{:returning :unique_by}) _) ...>)
           } ...)

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -57,12 +57,14 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
       it "does not register an offense for #{method} that looks like String#insert" do
         expect_no_offenses(<<~RUBY)
           string.#{method}(0, 'b')
+          string&.#{method}(0, 'b')
         RUBY
       end
 
       it "does not register an offense for #{method} that looks like Array#insert" do
         expect_no_offenses(<<~RUBY)
           array.#{method}(1, :a, :b)
+          array&.#{method}(1, :a, :b)
         RUBY
       end
 


### PR DESCRIPTION
Fixes #1278.

This PR fixes a false positive for `Rails/SkipsModelValidations` when using `insert` or `insert!` with a safe navigator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
