### PR TITLE
[Fix #1286] Mark `Rails/SkipsModelValidations` as unsafe

### DIFF
--- a/changelog/change_mark_rails_skips_model_validations_as_unsafe.md
+++ b/changelog/change_mark_rails_skips_model_validations_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#1286](https://github.com/rubocop/rubocop-rails/issues/1286): Mark `Rails/SkipsModelValidations` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1018,8 +1018,9 @@ Rails/SkipsModelValidations:
                  See reference for more information.
   Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: true
+  Safe: false
   VersionAdded: '0.47'
-  VersionChanged: '2.7'
+  VersionChanged: '<<next>>'
   ForbiddenMethods:
     - decrement!
     - decrement_counter

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -9,6 +9,9 @@ module RuboCop
       #
       # Methods may be ignored from this rule by configuring a `AllowedMethods`.
       #
+      # @safety
+      #   This cop is unsafe if the receiver object is not an Active Record object.
+      #
       # @example
       #   # bad
       #   Article.first.decrement!(:view_count)


### PR DESCRIPTION
Fixes #1286.

`Rails/SkipsModelValidations` cop is unsafe if the receiver object is not an Active Record object. So, this PR marks `SkipsModelValidations` as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
