### PR TITLE
[Fix #1288] Let LinkToBlank find violations in link_to_if and link_to_unless

### DIFF
--- a/changelog/change_add_link_to_if_and_unless_to_link_blank.md
+++ b/changelog/change_add_link_to_if_and_unless_to_link_blank.md
@@ -1,0 +1,1 @@
+* [#1288](https://github.com/rubocop/rubocop-rails/issues/1288): Let `Rails/LinkToBlank` look into `link_to_if` and `link_to_unless`, too. ([@fwolfst][])

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Rails
-      # Checks for calls to `link_to` that contain a
+      # Checks for calls to `link_to`, `link_to_if`, and `link_to_unless` methods that contain a
       # `target: '_blank'` but no `rel: 'noopener'`. This can be a security
       # risk as the loaded page will have control over the previous page
       # and could change its location for phishing purposes.
@@ -24,7 +24,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Specify a `:rel` option containing noopener.'
-        RESTRICT_ON_SEND = %i[link_to].freeze
+        RESTRICT_ON_SEND = %i[link_to link_to_if link_to_unless].freeze
 
         def_node_matcher :blank_target?, <<~PATTERN
           (pair {(sym :target) (str "target")} {(str "_blank") (sym :_blank)})

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -1,149 +1,451 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::LinkToBlank, :config do
-  context 'when not using target _blank' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        link_to 'Click here', 'https://www.example.com'
-      RUBY
-    end
-
-    it 'does not register an offense when passing options' do
-      expect_no_offenses(<<~RUBY)
-        link_to 'Click here', 'https://www.example.com', class: 'big'
-      RUBY
-    end
-
-    it 'does not register an offense when using the block syntax' do
-      expect_no_offenses(<<~RUBY)
-        link_to 'https://www.example.com', class: 'big' do
-          "Click Here"
-        end
-      RUBY
-    end
-  end
-
-  context 'when using target_blank' do
-    context 'when using no rel' do
-      it 'registers and corrects an offense' do
-        expect_offense(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', target: '_blank'
-                                                           ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener'
+  context 'when using link_to' do
+    context 'when not using target _blank' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          link_to 'Click here', 'https://www.example.com'
         RUBY
       end
 
-      it 'registers an offense when using a string for the target key' do
-        expect_offense(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', "target" => '_blank'
-                                                           ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+      it 'does not register an offense when passing options' do
+        expect_no_offenses(<<~RUBY)
+          link_to 'Click here', 'https://www.example.com', class: 'big'
         RUBY
       end
 
-      it 'registers an offense when using a symbol for the target value' do
-        expect_offense(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', target: :_blank
-                                                           ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
-        RUBY
-      end
-
-      it 'registers an offense and autocorrects when using the block syntax' do
-        expect_offense(<<~RUBY)
-          link_to 'https://www.example.com', target: '_blank' do
-                                             ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
-            "Click here"
+      it 'does not register an offense when using the block syntax' do
+        expect_no_offenses(<<~RUBY)
+          link_to 'https://www.example.com', class: 'big' do
+            "Click Here"
           end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          link_to 'https://www.example.com', target: '_blank', rel: 'noopener' do
-            "Click here"
-          end
-        RUBY
-      end
-
-      it 'autocorrects with a new rel when using the block syntax with parenthesis' do
-        new_source = autocorrect_source(<<~RUBY)
-          link_to('https://www.example.com', target: '_blank') do
-            "Click here"
-          end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          link_to('https://www.example.com', target: '_blank', rel: 'noopener') do
-            "Click here"
-          end
-        RUBY
-      end
-
-      it 'autocorrects with a new rel when using a symbol for the target value' do
-        new_source = autocorrect_source(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', target: :_blank
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
-        RUBY
-      end
-
-      it 'registers and corrects an offense when using hash brackets for the option' do
-        expect_offense(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', { target: :_blank }
-                                                             ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          link_to 'Click here', 'https://www.example.com', { target: :_blank, rel: :noopener }
         RUBY
       end
     end
 
-    context 'when using rel' do
-      context 'when the rel does not contain noopener' do
-        it 'registers an offense and corrects' do
+    context 'when using target_blank' do
+      context 'when using no rel' do
+        it 'registers and corrects an offense' do
           expect_offense(<<~RUBY)
-            link_to 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated'
-                                                             ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+            link_to 'Click here', 'https://www.example.com', target: '_blank'
+                                                             ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
           RUBY
 
           expect_correction(<<~RUBY)
-            link_to 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated noopener'
+            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener'
           RUBY
         end
-      end
 
-      context 'when the rel contains noopener' do
-        it 'register no offense' do
-          expect_no_offenses(<<~RUBY)
-            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener unrelated'
+        it 'registers an offense when using a string for the target key' do
+          expect_offense(<<~RUBY)
+            link_to 'Click here', 'https://www.example.com', "target" => '_blank'
+                                                             ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
           RUBY
         end
-      end
 
-      context 'when the rel contains noreferrer' do
-        it 'register no offense' do
-          expect_no_offenses(<<~RUBY)
-            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'unrelated noreferrer'
+        it 'registers an offense when using a symbol for the target value' do
+          expect_offense(<<~RUBY)
+            link_to 'Click here', 'https://www.example.com', target: :_blank
+                                                             ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
           RUBY
         end
-      end
 
-      context 'when the rel contains noopener and noreferrer' do
-        it 'register no offense' do
-          expect_no_offenses(<<~RUBY)
-            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener noreferrer'
+        it 'registers an offense and autocorrects when using the block syntax' do
+          expect_offense(<<~RUBY)
+            link_to 'https://www.example.com', target: '_blank' do
+                                               ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+              "Click here"
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to 'https://www.example.com', target: '_blank', rel: 'noopener' do
+              "Click here"
+            end
           RUBY
         end
-      end
 
-      context 'when the rel is symbol noopener' do
-        it 'register no offense' do
-          expect_no_offenses(<<~RUBY)
+        it 'autocorrects with a new rel when using the block syntax with parenthesis' do
+          new_source = autocorrect_source(<<~RUBY)
+            link_to('https://www.example.com', target: '_blank') do
+              "Click here"
+            end
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
+            link_to('https://www.example.com', target: '_blank', rel: 'noopener') do
+              "Click here"
+            end
+          RUBY
+        end
+
+        it 'autocorrects with a new rel when using a symbol for the target value' do
+          new_source = autocorrect_source(<<~RUBY)
+            link_to 'Click here', 'https://www.example.com', target: :_blank
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
             link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
           RUBY
+        end
+
+        it 'registers and corrects an offense when using hash brackets for the option' do
+          expect_offense(<<~RUBY)
+            link_to 'Click here', 'https://www.example.com', { target: :_blank }
+                                                               ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to 'Click here', 'https://www.example.com', { target: :_blank, rel: :noopener }
+          RUBY
+        end
+      end
+
+      context 'when using rel' do
+        context 'when the rel does not contain noopener' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              link_to 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated'
+                                                               ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              link_to 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated noopener'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noopener' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener unrelated'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noreferrer' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'unrelated noreferrer'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noopener and noreferrer' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener noreferrer'
+            RUBY
+          end
+        end
+
+        context 'when the rel is symbol noopener' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context 'when using link_to_if' do
+    context 'when not using target _blank' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          link_to_if condition?, 'Click here', 'https://www.example.com'
+        RUBY
+      end
+
+      it 'does not register an offense when passing options' do
+        expect_no_offenses(<<~RUBY)
+          link_to_if condition?, 'Click here', 'https://www.example.com', class: 'big'
+        RUBY
+      end
+
+      it 'does not register an offense when using the block syntax' do
+        expect_no_offenses(<<~RUBY)
+          link_to_if condition?, 'https://www.example.com', class: 'big' do
+            "Click Here"
+          end
+        RUBY
+      end
+    end
+
+    context 'when using target_blank' do
+      context 'when using no rel' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', target: '_blank'
+                                                                            ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener'
+          RUBY
+        end
+
+        it 'registers an offense when using a string for the target key' do
+          expect_offense(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', "target" => '_blank'
+                                                                            ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+        end
+
+        it 'registers an offense when using a symbol for the target value' do
+          expect_offense(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', target: :_blank
+                                                                            ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when using the block syntax' do
+          expect_offense(<<~RUBY)
+            link_to_if condition?, 'https://www.example.com', target: '_blank' do
+                                                              ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+              "Click here"
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to_if condition?, 'https://www.example.com', target: '_blank', rel: 'noopener' do
+              "Click here"
+            end
+          RUBY
+        end
+
+        it 'autocorrects with a new rel when using the block syntax with parenthesis' do
+          new_source = autocorrect_source(<<~RUBY)
+            link_to_if(condition?, 'https://www.example.com', target: '_blank') do
+              "Click here"
+            end
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
+            link_to_if(condition?, 'https://www.example.com', target: '_blank', rel: 'noopener') do
+              "Click here"
+            end
+          RUBY
+        end
+
+        it 'autocorrects with a new rel when using a symbol for the target value' do
+          new_source = autocorrect_source(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', target: :_blank
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+          RUBY
+        end
+
+        it 'registers and corrects an offense when using hash brackets for the option' do
+          expect_offense(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', { target: :_blank }
+                                                                              ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to_if condition?, 'Click here', 'https://www.example.com', { target: :_blank, rel: :noopener }
+          RUBY
+        end
+      end
+
+      context 'when using rel' do
+        context 'when the rel does not contain noopener' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              link_to_if condition?, 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated'
+                                                                              ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              link_to_if condition?, 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated noopener'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noopener' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_if condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener unrelated'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noreferrer' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_if condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'unrelated noreferrer'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noopener and noreferrer' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_if condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener noreferrer'
+            RUBY
+          end
+        end
+
+        context 'when the rel is symbol noopener' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_if condition?, 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context 'when using link_to_unless' do
+    context 'when not using target _blank' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          link_to_unless condition?, 'Click here', 'https://www.example.com'
+        RUBY
+      end
+
+      it 'does not register an offense when passing options' do
+        expect_no_offenses(<<~RUBY)
+          link_to_unless condition?, 'Click here', 'https://www.example.com', class: 'big'
+        RUBY
+      end
+
+      it 'does not register an offense when using the block syntax' do
+        expect_no_offenses(<<~RUBY)
+          link_to_unless condition?, 'https://www.example.com', class: 'big' do
+            "Click Here"
+          end
+        RUBY
+      end
+    end
+
+    context 'when using target_blank' do
+      context 'when using no rel' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', target: '_blank'
+                                                                                ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener'
+          RUBY
+        end
+
+        it 'registers an offense when using a string for the target key' do
+          expect_offense(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', "target" => '_blank'
+                                                                                ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+        end
+
+        it 'registers an offense when using a symbol for the target value' do
+          expect_offense(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', target: :_blank
+                                                                                ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when using the block syntax' do
+          expect_offense(<<~RUBY)
+            link_to_unless condition?, 'https://www.example.com', target: '_blank' do
+                                                                  ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+              "Click here"
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to_unless condition?, 'https://www.example.com', target: '_blank', rel: 'noopener' do
+              "Click here"
+            end
+          RUBY
+        end
+
+        it 'autocorrects with a new rel when using the block syntax with parenthesis' do
+          new_source = autocorrect_source(<<~RUBY)
+            link_to_unless(condition?, 'https://www.example.com', target: '_blank') do
+              "Click here"
+            end
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
+            link_to_unless(condition?, 'https://www.example.com', target: '_blank', rel: 'noopener') do
+              "Click here"
+            end
+          RUBY
+        end
+
+        it 'autocorrects with a new rel when using a symbol for the target value' do
+          new_source = autocorrect_source(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', target: :_blank
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+          RUBY
+        end
+
+        it 'registers and corrects an offense when using hash brackets for the option' do
+          expect_offense(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', { target: :_blank }
+                                                                                  ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            link_to_unless condition?, 'Click here', 'https://www.example.com', { target: :_blank, rel: :noopener }
+          RUBY
+        end
+      end
+
+      context 'when using rel' do
+        context 'when the rel does not contain noopener' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              link_to_unless condition?, 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated'
+                                                                                  ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              link_to_unless condition?, 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated noopener'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noopener' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_unless condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener unrelated'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noreferrer' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_unless condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'unrelated noreferrer'
+            RUBY
+          end
+        end
+
+        context 'when the rel contains noopener and noreferrer' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_unless condition?, 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener noreferrer'
+            RUBY
+          end
+        end
+
+        context 'when the rel is symbol noopener' do
+          it 'register no offense' do
+            expect_no_offenses(<<~RUBY)
+              link_to_unless condition?, 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+            RUBY
+          end
         end
       end
     end


### PR DESCRIPTION
Fix #1288 (but not adding link_to_unless_current) by adding respective methods to the `RESTRICT_ON_SEND` list, hoping that this is the right approach.

I sketched an approach for the specs, but it would mean executing very similar specs three times - see relevant commit for a very brief discussion: 70db8e4f498ee3f3af4e23e5022717b4fa2d28e7 . What do you think?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
