### PR TITLE
[Fix #1281] Fix `WhereRange` autocorrect for complex expressions

### DIFF
--- a/changelog/fix_where_range_complex_expressions.md
+++ b/changelog/fix_where_range_complex_expressions.md
@@ -1,0 +1,1 @@
+* [#1281](https://github.com/rubocop/rubocop-rails/issues/1281): Fix `WhereRange` autocorrect for complex expressions. ([@fatkodima][])

--- a/spec/rubocop/cop/rails/where_range_spec.rb
+++ b/spec/rubocop/cop/rails/where_range_spec.rb
@@ -159,6 +159,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereRange, :config do
           foo.not('column >= ?', value)
         RUBY
       end
+
+      it 'wraps complex expressions by parentheses' do
+        expect_offense(<<~RUBY)
+          Model.where('column >= ?', true ? 1 : 2)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where(column: (true ? 1 : 2)..)` instead of manually constructing SQL.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Model.where(column: (true ? 1 : 2)..)
+        RUBY
+      end
     end
 
     context 'Ruby >= 2.6', :ruby26, unsupported_on: :prism do


### PR DESCRIPTION
Fixes #1281.

We can't for sure tell when we not need parentheses (without reimplementing `Style/RedundantParentheses` cop), so I excluded the most popular and obvious variants.