### PR TITLE
[Fix #1283] Mark `WhereRange` as unsafe autocorrect

### DIFF
--- a/changelog/change_where_range_unsafe_autocorrect.md
+++ b/changelog/change_where_range_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#1283](https://github.com/rubocop/rubocop-rails/issues/1283): Mark `WhereRange` as unsafe autocorrect. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1227,6 +1227,7 @@ Rails/WhereRange:
   Description: 'Use ranges in `where` instead of manually constructing SQL.'
   StyleGuide: 'https://rails.rubystyle.guide/#where-ranges'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '2.25'
 
 # Accept `redirect_to(...) and return` and similar cases.

--- a/lib/rubocop/cop/rails/where_range.rb
+++ b/lib/rubocop/cop/rails/where_range.rb
@@ -6,6 +6,14 @@ module RuboCop
       # Identifies places where manually constructed SQL
       # in `where` can be replaced with ranges.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because it can change the query
+      #   by explicitly attaching the column to the wrong table.
+      #   For example, `Booking.joins(:events).where('end_at < ?', Time.current)` will correctly
+      #   implicitly attach the `end_at` column to the `events` table. But when autocorrected to
+      #   `Booking.joins(:events).where(end_at: ...Time.current)`, it will now be incorrectly
+      #   explicitly attached to the `bookings` table.
+      #
       # @example
       #   # bad
       #   User.where('age >= ?', 18)


### PR DESCRIPTION
Fixes #1283.