### PR TITLE
[Fix #1295] Covers validates_comparison_of in Rails/Validations

### DIFF
--- a/changelog/change_1295_covers_validates_comparison_of_in.md
+++ b/changelog/change_1295_covers_validates_comparison_of_in.md
@@ -1,0 +1,1 @@
+* [#1295](https://github.com/rubocop/rubocop-rails/issues/1295): Cover validates_comparison_of in `Rails/Validation`. ([@ChaelCodes][])

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -8,6 +8,7 @@ module RuboCop
       # @example
       #   # bad
       #   validates_acceptance_of :foo
+      #   validates_comparison_of :foo
       #   validates_confirmation_of :foo
       #   validates_exclusion_of :foo
       #   validates_format_of :foo
@@ -22,6 +23,7 @@ module RuboCop
       #   # good
       #   validates :foo, acceptance: true
       #   validates :foo, confirmation: true
+      #   validates :foo, comparison: true
       #   validates :foo, exclusion: true
       #   validates :foo, format: true
       #   validates :foo, inclusion: true
@@ -39,6 +41,7 @@ module RuboCop
 
         TYPES = %w[
           acceptance
+          comparison
           confirmation
           exclusion
           format

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -159,6 +159,18 @@ RSpec.describe RuboCop::Cop::Rails::Validation, :config do
       include_examples 'autocorrects'
     end
 
+    context 'with a proc' do
+      let(:autocorrected_source) do
+        'validates :a, :b, comparison: { greater_than: -> { Time.zone.today } }'
+      end
+
+      let(:source) do
+        'validates_comparison_of :a, :b, greater_than: -> { Time.zone.today }'
+      end
+
+      include_examples 'autocorrects'
+    end
+
     context 'with splat' do
       let(:autocorrected_source) do
         'validates :a, *b, numericality: true'


### PR DESCRIPTION
Fixes #1295 

[Rails/Validation](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsvalidation) covers replacing old-style attribute validation macros with newer, more flexible `validates` calls. However currently, it doesn't check for `validates_comparison_of`. This covers validates_comparison_of, and adds a new test case for procs as arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [-] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
