### PR TITLE
Support Rails 7 enum syntax for Rails/EnumUniqueness cop

### DIFF
--- a/changelog/new_support_rails_7_syntax_for_rails_enum_uniqueness_cop.md
+++ b/changelog/new_support_rails_7_syntax_for_rails_enum_uniqueness_cop.md
@@ -1,0 +1,1 @@
+* [#1298](https://github.com/rubocop/rubocop-rails/pull/1298): Support Rails 7 syntax for `Rails/EnumUniqueness` cop. ([@ytjmt][])

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -1,115 +1,269 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::EnumUniqueness, :config do
-  context 'when array syntax is used' do
-    context 'with a single duplicated enum value' do
+  context 'when Rails 7 syntax is used' do
+    context 'when array syntax is used' do
+      context 'without options' do
+        context 'with a single duplicated enum value' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              enum :status, [:active, :archived, :active]
+                                                 ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with several duplicated enum values' do
+          it 'registers two offenses' do
+            expect_offense(<<~RUBY)
+              enum :status, [:active, :archived, :active, :active]
+                                                          ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+                                                 ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with no duplicated enum values' do
+          it 'does not register an offense for unique enum values' do
+            expect_no_offenses('enum :status, [:active, :archived]')
+          end
+        end
+      end
+
+      context 'with options' do
+        context 'with a single duplicated enum value' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              enum :status, [:active, :archived, :active], default: :active, prefix: true
+                                                 ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with several duplicated enum values' do
+          it 'registers two offenses' do
+            expect_offense(<<~RUBY)
+              enum :status, [:active, :archived, :active, :active], default: :active, prefix: true
+                                                          ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+                                                 ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with no duplicated enum values' do
+          it 'does not register an offense for unique enum values' do
+            expect_no_offenses('enum :status, [:active, :archived], default: :active, prefix: true')
+          end
+        end
+      end
+    end
+
+    context 'when hash syntax is used' do
+      context 'without options' do
+        context 'with a single duplicated enum value' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              enum :status, { active: 0, archived: 0 }
+                                                   ^ Duplicate value `0` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with several duplicated enum values' do
+          it 'registers two offenses' do
+            expect_offense(<<~RUBY)
+              enum :status, { active: 0, pending: 0, archived: 0 }
+                                                               ^ Duplicate value `0` found in `status` enum declaration.
+                                                  ^ Duplicate value `0` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with no duplicated enum values' do
+          it 'does not register an offense' do
+            expect_no_offenses('enum status: { active: 0, pending: 1 }')
+          end
+        end
+      end
+
+      context 'with options' do
+        context 'with a single duplicated enum value' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              enum :status, { active: 0, archived: 0 }, default: :active, prefix: true
+                                                   ^ Duplicate value `0` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with several duplicated enum values' do
+          it 'registers two offenses' do
+            expect_offense(<<~RUBY)
+              enum :status, { active: 0, pending: 0, archived: 0 }, default: :active, prefix: true
+                                                               ^ Duplicate value `0` found in `status` enum declaration.
+                                                  ^ Duplicate value `0` found in `status` enum declaration.
+            RUBY
+          end
+        end
+
+        context 'with no duplicated enum values' do
+          it 'does not register an offense' do
+            expect_no_offenses('enum status: { active: 0, pending: 1 }, default: :active, prefix: true')
+          end
+        end
+      end
+    end
+
+    context 'when receiving a hash without literal values' do
+      context 'when value is a variable' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum :status, statuses')
+        end
+      end
+
+      context 'when value is a method chain' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum :status, User.statuses.keys')
+        end
+      end
+
+      context 'when value is a constant' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum :status, STATUSES')
+        end
+      end
+    end
+
+    context 'when the enum name is a string' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
-          enum status: [:active, :archived, :active]
-                                            ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
-        RUBY
-      end
-    end
-
-    context 'with several duplicated enum values' do
-      it 'registers two offenses' do
-        expect_offense(<<~RUBY)
-          enum status: [:active, :archived, :active, :active]
-                                                     ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
-                                            ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
-        RUBY
-      end
-    end
-
-    context 'with no duplicated enum values' do
-      it 'does not register an offense for unique enum values' do
-        expect_no_offenses('enum status: [:active, :archived]')
-      end
-    end
-  end
-
-  context 'when hash syntax is used' do
-    context 'with a single duplicated enum value' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          enum status: { active: 0, archived: 0 }
-                                              ^ Duplicate value `0` found in `status` enum declaration.
-        RUBY
-      end
-    end
-
-    context 'with several duplicated enum values' do
-      it 'registers two offenses' do
-        expect_offense(<<~RUBY)
-          enum status: { active: 0, pending: 0, archived: 0 }
-                                                          ^ Duplicate value `0` found in `status` enum declaration.
-                                             ^ Duplicate value `0` found in `status` enum declaration.
-        RUBY
-      end
-    end
-
-    context 'with no duplicated enum values' do
-      it 'does not register an offense' do
-        expect_no_offenses('enum status: { active: 0, pending: 1 }')
-      end
-    end
-  end
-
-  context 'when receiving a variable' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        var = { status: { active: 0, archived: 1 } }
-        enum var
-      RUBY
-    end
-  end
-
-  context 'when receiving a hash without literal values' do
-    context 'when value is a variable' do
-      it 'does not register an offense' do
-        expect_no_offenses('enum status: statuses')
-      end
-    end
-
-    context 'when value is a method chain' do
-      it 'does not register an offense' do
-        expect_no_offenses('enum status: User.statuses.keys')
-      end
-    end
-
-    context 'when value is a constant' do
-      it 'does not register an offense' do
-        expect_no_offenses('enum status: STATUSES')
-      end
-    end
-  end
-
-  context 'when the enum name is a string' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        enum "status" => [:active, :archived, :active]
+          enum "status", [:active, :archived, :active]
                                               ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
-      RUBY
+        RUBY
+      end
     end
-  end
 
-  context 'when the enum name is not a literal' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        enum KEY => [:active, :archived, :active]
+    context 'when the enum name is not a literal' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum KEY, [:active, :archived, :active]
                                          ^^^^^^^ Duplicate value `:active` found in `KEY` enum declaration.
-      RUBY
+        RUBY
+      end
     end
   end
 
-  context 'with multiple enum definition for a `enum` method call' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        enum status: [:active, :archived, :active],
-                                          ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
-             role: [:owner, :member, :guest, :member]
-                                             ^^^^^^^ Duplicate value `:member` found in `role` enum declaration.
-      RUBY
+  context 'when old syntax is used' do
+    context 'when array syntax is used' do
+      context 'with a single duplicated enum value' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: [:active, :archived, :active]
+                                              ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+          RUBY
+        end
+      end
+
+      context 'with several duplicated enum values' do
+        it 'registers two offenses' do
+          expect_offense(<<~RUBY)
+            enum status: [:active, :archived, :active, :active]
+                                                       ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+                                              ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+          RUBY
+        end
+      end
+
+      context 'with no duplicated enum values' do
+        it 'does not register an offense for unique enum values' do
+          expect_no_offenses('enum status: [:active, :archived]')
+        end
+      end
+    end
+
+    context 'when hash syntax is used' do
+      context 'with a single duplicated enum value' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: { active: 0, archived: 0 }
+                                                ^ Duplicate value `0` found in `status` enum declaration.
+          RUBY
+        end
+      end
+
+      context 'with several duplicated enum values' do
+        it 'registers two offenses' do
+          expect_offense(<<~RUBY)
+            enum status: { active: 0, pending: 0, archived: 0 }
+                                                            ^ Duplicate value `0` found in `status` enum declaration.
+                                               ^ Duplicate value `0` found in `status` enum declaration.
+          RUBY
+        end
+      end
+
+      context 'with no duplicated enum values' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum status: { active: 0, pending: 1 }')
+        end
+      end
+    end
+
+    context 'when receiving a variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          var = { status: { active: 0, archived: 1 } }
+          enum var
+        RUBY
+      end
+    end
+
+    context 'when receiving a hash without literal values' do
+      context 'when value is a variable' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum status: statuses')
+        end
+      end
+
+      context 'when value is a method chain' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum status: User.statuses.keys')
+        end
+      end
+
+      context 'when value is a constant' do
+        it 'does not register an offense' do
+          expect_no_offenses('enum status: STATUSES')
+        end
+      end
+    end
+
+    context 'when the enum name is a string' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum "status" => [:active, :archived, :active]
+                                                ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+        RUBY
+      end
+    end
+
+    context 'when the enum name is not a literal' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum KEY => [:active, :archived, :active]
+                                           ^^^^^^^ Duplicate value `:active` found in `KEY` enum declaration.
+        RUBY
+      end
+    end
+
+    context 'with multiple enum definition for a `enum` method call' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum status: [:active, :archived, :active],
+                                            ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+              role: [:owner, :member, :guest, :member]
+                                              ^^^^^^^ Duplicate value `:member` found in `role` enum declaration.
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 7.0 introduced a new enum syntax ( https://github.com/rails/rails/pull/41328 ):

```ruby
enum :status, [:active, :archived]
```

Rails/EnumUniqueness cop does't support the new syntax yet. This PR adds the new syntax support.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
