### PR TITLE
Fix an error for `Rails/NotNullColumn` when the block for `change_table` is empty

### DIFF
--- a/changelog/fix_error_for_rails_not_null_column.md
+++ b/changelog/fix_error_for_rails_not_null_column.md
@@ -1,0 +1,1 @@
+* [#1299](https://github.com/rubocop/rubocop-rails/pull/1299): Fix an error for `Rails/NotNullColumn` when the block for `change_table` is empty. ([@earlopain][])

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -136,6 +136,8 @@ module RuboCop
 
         def check_change_table(node)
           change_table?(node) do |table|
+            next unless node.body
+
             children = node.body.begin_type? ? node.body.children : [node.body]
             children.each do |child|
               check_add_column_in_change_table(child, table)

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when the block is empty' do
+      expect_no_offenses(<<~RUBY)
+        class ExampleMigration < ActiveRecord::Migration[7.0]
+          def change
+            change_table :invoices do |t|
+            end
+          end
+        end
+      RUBY
+    end
   end
 
   context 'with change_table call' do


### PR DESCRIPTION
One more

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
