### PR TITLE
Allow `params` receiver by default for `Style/CollectionMethods`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
               -e "/gem 'rubocop-performance',/d" \
               -e "/gem 'rubocop-rspec',/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.33.0' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.52.0' # Specify the oldest supported RuboCop version
           EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1

--- a/changelog/fix_make_style_collection_compact_aware_of_params.md
+++ b/changelog/fix_make_style_collection_compact_aware_of_params.md
@@ -1,0 +1,1 @@
+* [#1302](https://github.com/rubocop/rubocop-rails/pull/1302): Allow `params` receiver by default for `Style/CollectionMethods`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1234,6 +1234,10 @@ Rails/WhereRange:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+Style/CollectionCompact:
+  AllowedReceivers:
+    - params
+
 Style/FormatStringToken:
   AllowedMethods:
     - redirect

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |s|
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_dependency 'rack', '>= 1.1'
-  s.add_dependency 'rubocop', '>= 1.33.0', '< 2.0'
+  s.add_dependency 'rubocop', '>= 1.52.0', '< 2.0'
   s.add_dependency 'rubocop-ast', '>= 1.31.1', '< 2.0'
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11909 and fixes https://github.com/rubocop/rubocop/issues/11908.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
