### PR TITLE
Make `Rails/PluralizationGrammar` aware of byte methods

### DIFF
--- a/changelog/fix_make_pluralization_grammar_aware_of_bytes.md
+++ b/changelog/fix_make_pluralization_grammar_aware_of_bytes.md
@@ -1,0 +1,1 @@
+* [#1306](https://github.com/rubocop/rubocop-rails/pull/1306): Make `Rails/PluralizationGrammar` aware of byte methods. ([@earlopain][])

--- a/lib/rubocop/cop/rails/pluralization_grammar.rb
+++ b/lib/rubocop/cop/rails/pluralization_grammar.rb
@@ -10,25 +10,39 @@ module RuboCop
       #   # bad
       #   3.day.ago
       #   1.months.ago
+      #   5.megabyte
+      #   1.gigabyte
       #
       #   # good
       #   3.days.ago
       #   1.month.ago
+      #   5.megabytes
+      #   1.gigabyte
       class PluralizationGrammar < Base
         extend AutoCorrector
 
-        SINGULAR_DURATION_METHODS = { second: :seconds,
-                                      minute: :minutes,
-                                      hour: :hours,
-                                      day: :days,
-                                      week: :weeks,
-                                      fortnight: :fortnights,
-                                      month: :months,
-                                      year: :years }.freeze
+        SINGULAR_METHODS = {
+          second: :seconds,
+          minute: :minutes,
+          hour: :hours,
+          day: :days,
+          week: :weeks,
+          fortnight: :fortnights,
+          month: :months,
+          year: :years,
+          byte: :bytes,
+          kilobyte: :kilobytes,
+          megabyte: :megabytes,
+          gigabyte: :gigabytes,
+          terabyte: :terabytes,
+          petabyte: :petabytes,
+          exabyte: :exabytes,
+          zettabyte: :zettabytes
+        }.freeze
 
-        RESTRICT_ON_SEND = SINGULAR_DURATION_METHODS.keys + SINGULAR_DURATION_METHODS.values
+        RESTRICT_ON_SEND = SINGULAR_METHODS.keys + SINGULAR_METHODS.values
 
-        PLURAL_DURATION_METHODS = SINGULAR_DURATION_METHODS.invert.freeze
+        PLURAL_METHODS = SINGULAR_METHODS.invert.freeze
 
         MSG = 'Prefer `%<number>s.%<correct>s`.'
 
@@ -86,15 +100,15 @@ module RuboCop
         end
 
         def pluralize(method_name)
-          SINGULAR_DURATION_METHODS.fetch(method_name.to_sym).to_s
+          SINGULAR_METHODS.fetch(method_name.to_sym).to_s
         end
 
         def singularize(method_name)
-          PLURAL_DURATION_METHODS.fetch(method_name.to_sym).to_s
+          PLURAL_METHODS.fetch(method_name.to_sym).to_s
         end
 
         def duration_method?(method_name)
-          SINGULAR_DURATION_METHODS.key?(method_name) || PLURAL_DURATION_METHODS.key?(method_name)
+          SINGULAR_METHODS.key?(method_name) || PLURAL_METHODS.key?(method_name)
         end
       end
     end

--- a/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
+++ b/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
@@ -83,4 +83,12 @@ RSpec.describe RuboCop::Cop::Rails::PluralizationGrammar, :config do
   it_behaves_like 'enforces pluralization grammar', 'fortnight'
   it_behaves_like 'enforces pluralization grammar', 'month'
   it_behaves_like 'enforces pluralization grammar', 'year'
+  it_behaves_like 'enforces pluralization grammar', 'byte'
+  it_behaves_like 'enforces pluralization grammar', 'kilobyte'
+  it_behaves_like 'enforces pluralization grammar', 'megabyte'
+  it_behaves_like 'enforces pluralization grammar', 'gigabyte'
+  it_behaves_like 'enforces pluralization grammar', 'terabyte'
+  it_behaves_like 'enforces pluralization grammar', 'petabyte'
+  it_behaves_like 'enforces pluralization grammar', 'exabyte'
+  it_behaves_like 'enforces pluralization grammar', 'zettabyte'
 end


### PR DESCRIPTION
These methods are also singular/pluralized, see https://api.rubyonrails.org/classes/Numeric.html

```rb
# good
1.byte
2.bytes

# bad
1.bytes
2.byte
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
