### PR TITLE
Clarify the wording of the `Rails/PluckInWhere` cop

### DIFF
--- a/lib/rubocop/cop/rails/pluck_in_where.rb
+++ b/lib/rubocop/cop/rails/pluck_in_where.rb
@@ -7,17 +7,26 @@ module RuboCop
       # and can be replaced with `select`.
       #
       # Since `pluck` is an eager method and hits the database immediately,
-      # using `select` helps to avoid additional database queries.
+      # using `select` helps to avoid additional database queries by running as
+      # a subquery.
       #
-      # This cop has two different enforcement modes. When the `EnforcedStyle`
-      # is `conservative` (the default) then only calls to `pluck` on a constant
-      # (i.e. a model class) in the `where` is used as offenses.
+      # This cop has two modes of enforcement. When the `EnforcedStyle` is set
+      # to `conservative` (the default), only calls to `pluck` on a constant
+      # (e.g. a model class) within `where` are considered offenses.
       #
       # @safety
-      #   When the `EnforcedStyle` is `aggressive` then all calls to `pluck` in the
-      #   `where` is used as offenses. This may lead to false positives
-      #   as the cop cannot replace to `select` between calls to `pluck` on an
-      #   `ActiveRecord::Relation` instance vs a call to `pluck` on an `Array` instance.
+      #   When `EnforcedStyle` is set to `aggressive`, all calls to `pluck`
+      #   within `where` are considered offenses. This might lead to false
+      #   positives because the check cannot distinguish between calls to
+      #   `pluck` on an `ActiveRecord::Relation` instance and calls to `pluck`
+      #   on an `Array` instance.
+      #
+      #   Additionally, when using a subquery with the SQL `IN` operator,
+      #   databases like PostgreSQL and MySQL can't optimize complex queries as
+      #   well. They need to scan all records of the outer table against the
+      #   subquery result sequentially, rather than using an index. This can
+      #   cause significant performance issues compared to writing the query
+      #   differently or using `pluck`.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Clarifies the existing wording to be easier to understand and adds an additional paragraph about possible performance implications of this cop.

These implications have been mentioned before in https://github.com/rubocop/rubocop-rails/issues/310#issuecomment-1151687469, but weren't explicitly mentioned in the cop's documentation.

---

The linked issue mentions MySQL and I have found the same issue multiple times showing up in MySQL on Stack Overflow, but I ran into it on PostgreSQL today. The query was something along the lines of this, albeit a bit more complicated:

```rb
query = %{
  (type = ? AND model_id IN (?)) OR
  (type = ? AND model_id IN (?))
}

Foo.where(query, 'bar', bar_ids,
                 'baz', Baz.where(condition: true).pluck(:id))
```

The `pluck` in the last line was replaced with a `select`, which caused the `Baz` query to be ran as a subquery instead of eagerly. This resulted in major database load, as `Foo`s table in this case is around 200GB in size and the query was now using sequential scanning, rather than index scanning.

Some research led us to find the related description in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/functions-subquery.html#FUNCTIONS-SUBQUERY-IN):
> The right-hand side is a parenthesized subquery, which must return exactly one column. **The left-hand expression is evaluated and compared to each row of the subquery result.**

This means that queries such as `SELECT * FROM foo WHERE model_id IN (subquery)` use sequential scanning to match against the `model_id`, rather than index scanning. Eager loading in this case was much faster, as it allowed an index lookup against the static list provided to the query.

Note to future readers: Rather than using `column IN (subquery)` you can use `column = ANY(ARRAY(subquery))`, which causes the subquery to be executed first and allows for an index scan.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
