### PR TITLE
Support Rails 7 syntax for Rails/EnumHash cop

### DIFF
--- a/changelog/new_support_rails_7_syntax_for_rails_enum_hash_cop.md
+++ b/changelog/new_support_rails_7_syntax_for_rails_enum_hash_cop.md
@@ -1,0 +1,1 @@
+* [#1309](https://github.com/rubocop/rubocop-rails/pull/1309): Support Rails 7 syntax for `Rails/EnumHash` cop. ([@ytjmt][])

--- a/spec/rubocop/cop/rails/enum_hash_spec.rb
+++ b/spec/rubocop/cop/rails/enum_hash_spec.rb
@@ -1,162 +1,375 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::EnumHash, :config do
-  context 'when array syntax is used' do
-    context 'with %i[] syntax' do
-      it 'registers an offense' do
+  context 'when Rails 7 syntax is used', :rails70 do
+    context 'when array syntax is used' do
+      context 'with %i[] syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum :status, %i[active archived]
+                          ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'with %w[] syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum :status, %w[active archived]
+                          ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, {"active" => 0, "archived" => 1}
+          RUBY
+        end
+      end
+
+      context 'with %i() syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum :status, %i(active archived)
+                          ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'with %w() syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum :status, %w(active archived)
+                          ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, {"active" => 0, "archived" => 1}
+          RUBY
+        end
+      end
+
+      context 'with [] syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum :status, [:active, :archived]
+                          ^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'when the enum name is a string' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum "status", %i[active archived]
+                           ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum "status", {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'when the enum name is not a literal' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum KEY, %i[active archived]
+                      ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `KEY` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum KEY, {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      it 'autocorrects' do
         expect_offense(<<~RUBY)
-          enum status: %i[active archived]
-                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          enum :status, [:old, :"very active", "is archived", 42]
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {:old => 0, :"very active" => 1, "is archived" => 2, 42 => 3}
+        RUBY
+      end
+
+      it 'autocorrects constants' do
+        expect_offense(<<~RUBY)
+          enum :status, [OLD, ACTIVE]
+                        ^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {OLD => 0, ACTIVE => 1}
+        RUBY
+      end
+
+      it 'autocorrects nested constants' do
+        expect_offense(<<~RUBY)
+          enum :status, [STATUS::OLD, STATUS::ACTIVE]
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {STATUS::OLD => 0, STATUS::ACTIVE => 1}
+        RUBY
+      end
+
+      it 'autocorrects %w[] syntax' do
+        expect_offense(<<~RUBY)
+          enum :status, %w[active archived]
+                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {"active" => 0, "archived" => 1}
+        RUBY
+      end
+
+      it 'autocorrect %w() syntax' do
+        expect_offense(<<~RUBY)
+          enum :status, %w(active archived)
+                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {"active" => 0, "archived" => 1}
+        RUBY
+      end
+
+      it 'autocorrect %i[] syntax' do
+        expect_offense(<<~RUBY)
+          enum :status, %i[active archived]
+                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {:active => 0, :archived => 1}
+        RUBY
+      end
+
+      it 'autocorrect %i() syntax' do
+        expect_offense(<<~RUBY)
+          enum :status, %i(active archived)
+                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum :status, {:active => 0, :archived => 1}
         RUBY
       end
     end
 
-    context 'with %w[] syntax' do
-      it 'registers an offense' do
+    context 'when hash syntax is used' do
+      it 'does not register an offense' do
+        expect_no_offenses('enum :status, { active: 0, archived: 1 }')
+      end
+    end
+  end
+
+  context 'when old syntax is used' do
+    context 'when array syntax is used' do
+      context 'with %i[] syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: %i[active archived]
+                         ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum status: {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'with %w[] syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: %w[active archived]
+                         ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum status: {"active" => 0, "archived" => 1}
+          RUBY
+        end
+      end
+
+      context 'with %i() syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: %i(active archived)
+                         ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum status: {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'with %w() syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: %w(active archived)
+                         ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum status: {"active" => 0, "archived" => 1}
+          RUBY
+        end
+      end
+
+      context 'with [] syntax' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: [:active, :archived]
+                         ^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum status: {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'when the enum name is a string' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum "status" => %i[active archived]
+                             ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum "status" => {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'when the enum name is not a literal' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum KEY => %i[active archived]
+                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `KEY` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum KEY => {:active => 0, :archived => 1}
+          RUBY
+        end
+      end
+
+      context 'with multiple enum definition for a `enum` method call' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum status: %i[active archived],
+                         ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+                 role: %i[owner member guest]
+                       ^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `role` enum declaration. Use hash syntax instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum status: {:active => 0, :archived => 1},
+                 role: {:owner => 0, :member => 1, :guest => 2}
+          RUBY
+        end
+      end
+
+      it 'autocorrects' do
+        expect_offense(<<~RUBY)
+          enum status: [:old, :"very active", "is archived", 42]
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum status: {:old => 0, :"very active" => 1, "is archived" => 2, 42 => 3}
+        RUBY
+      end
+
+      it 'autocorrects constants' do
+        expect_offense(<<~RUBY)
+          enum status: [OLD, ACTIVE]
+                       ^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum status: {OLD => 0, ACTIVE => 1}
+        RUBY
+      end
+
+      it 'autocorrects nested constants' do
+        expect_offense(<<~RUBY)
+          enum status: [STATUS::OLD, STATUS::ACTIVE]
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum status: {STATUS::OLD => 0, STATUS::ACTIVE => 1}
+        RUBY
+      end
+
+      it 'autocorrects %w[] syntax' do
         expect_offense(<<~RUBY)
           enum status: %w[active archived]
                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
         RUBY
-      end
-    end
 
-    context 'with %i() syntax' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          enum status: %i(active archived)
-                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        expect_correction(<<~RUBY)
+          enum status: {"active" => 0, "archived" => 1}
         RUBY
       end
-    end
 
-    context 'with %w() syntax' do
-      it 'registers an offense' do
+      it 'autocorrect %w() syntax' do
         expect_offense(<<~RUBY)
           enum status: %w(active archived)
                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
         RUBY
-      end
-    end
 
-    context 'with [] syntax' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          enum status: [:active, :archived]
-                       ^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        expect_correction(<<~RUBY)
+          enum status: {"active" => 0, "archived" => 1}
         RUBY
       end
-    end
 
-    context 'when the enum name is a string' do
-      it 'registers an offense' do
+      it 'autocorrect %i[] syntax' do
         expect_offense(<<~RUBY)
-          enum "status" => %i[active archived]
-                           ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-        RUBY
-      end
-    end
-
-    context 'when the enum name is not a literal' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          enum KEY => %i[active archived]
-                      ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `KEY` enum declaration. Use hash syntax instead.
-        RUBY
-      end
-    end
-
-    context 'with multiple enum definition for a `enum` method call' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          enum status: %i[active archived],
+          enum status: %i[active archived]
                        ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-               role: %i[owner member guest]
-                     ^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `role` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum status: {:active => 0, :archived => 1}
+        RUBY
+      end
+
+      it 'autocorrect %i() syntax' do
+        expect_offense(<<~RUBY)
+          enum status: %i(active archived)
+                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          enum status: {:active => 0, :archived => 1}
         RUBY
       end
     end
 
-    it 'autocorrects' do
-      expect_offense(<<~RUBY)
-        enum status: [:old, :"very active", "is archived", 42]
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {:old => 0, :"very active" => 1, "is archived" => 2, 42 => 3}
-      RUBY
-    end
-
-    it 'autocorrects constants' do
-      expect_offense(<<~RUBY)
-        enum status: [OLD, ACTIVE]
-                     ^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {OLD => 0, ACTIVE => 1}
-      RUBY
-    end
-
-    it 'autocorrects nested constants' do
-      expect_offense(<<~RUBY)
-        enum status: [STATUS::OLD, STATUS::ACTIVE]
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {STATUS::OLD => 0, STATUS::ACTIVE => 1}
-      RUBY
-    end
-
-    it 'autocorrects %w[] syntax' do
-      expect_offense(<<~RUBY)
-        enum status: %w[active archived]
-                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {"active" => 0, "archived" => 1}
-      RUBY
-    end
-
-    it 'autocorrect %w() syntax' do
-      expect_offense(<<~RUBY)
-        enum status: %w(active archived)
-                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {"active" => 0, "archived" => 1}
-      RUBY
-    end
-
-    it 'autocorrect %i[] syntax' do
-      expect_offense(<<~RUBY)
-        enum status: %i[active archived]
-                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {:active => 0, :archived => 1}
-      RUBY
-    end
-
-    it 'autocorrect %i() syntax' do
-      expect_offense(<<~RUBY)
-        enum status: %i(active archived)
-                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        enum status: {:active => 0, :archived => 1}
-      RUBY
-    end
-  end
-
-  context 'when hash syntax is used' do
-    it 'does not register an offense' do
-      expect_no_offenses('enum status: { active: 0, archived: 1 }')
+    context 'when hash syntax is used' do
+      it 'does not register an offense' do
+        expect_no_offenses('enum status: { active: 0, archived: 1 }')
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 7.0 introduced a new enum syntax ( https://github.com/rails/rails/pull/41328 ):

```ruby
enum :status, [:active, :archived]
enum :status, { active: 0, archived: 1 }
```

[Rails/EnumHash](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsenumhash) cop does't support the new syntax yet. This PR adds the new syntax support.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
