### PR TITLE
Fix false negatives for Rails/ActionControllerFlashBeforeRender when using implicit render or rescue block

### DIFF
--- a/changelog/fix_false_negatives_for_action_controller_flash_before_render.md
+++ b/changelog/fix_false_negatives_for_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#1311](https://github.com/rubocop/rubocop-rails/pull/1311): Fix false negatives for `Rails/ActionControllerFlashBeforeRender` when using implicit render or rescue blocks. ([@tldn0718][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -72,13 +72,13 @@ module RuboCop
           if (node = context.each_ancestor(:if, :rescue).first)
             return false if use_redirect_to?(context)
 
-            context = node
-          elsif context.right_siblings.empty?
-            return true
+            context = node.rescue_type? ? node.parent : node
           end
-          context = context.right_siblings
 
-          context.compact.any? do |render_candidate|
+          siblings = context.right_siblings
+          return true if siblings.empty?
+
+          siblings.compact.any? do |render_candidate|
             render?(render_candidate)
           end
         end


### PR DESCRIPTION
This PR fixes two false negatives in `Rails/ActionControllerFlashBeforeRender`. One pertains to implicit render with branch blocks, and the other to rescue blocks.

## Branch Block with Implicit Render
### Expected Behavior
The cop should register an offense when `flash` is used within an if block or rescue block, and the action ends without an explicit call to render or redirect_to, resulting in an implicit render.
```
class HomeController < ActionController::Base
  def create
    flash[:alert] = "msg" if condition
    ^^^^^ Use `flash.now` before `render`.
  end
end
```
```
class HomeController < ActionController::Base
  def create
    begin
      do_something
      flash[:alert] = "msg in begin"
      ^^^^^ Use `flash.now` before `render`.
    rescue
      flash[:alert] = "msg in rescue"
      ^^^^^ Use `flash.now` before `render`.
    end
  end
end
```
### Actual Behavior
No offenses are registered.
## Rescue Block with Explicit Render
### Expected Behavior
The cop should register an offense when `flash` is used within a begin-rescue block if an explicit render is called outside the block.
```
class HomeController < ActionController::Base
  def create
    begin
      do_something
      flash[:alert] = "msg in begin"
      ^^^^^ Use `flash.now` before `render`.
    rescue
      flash[:alert] = "msg in rescue"
      ^^^^^ Use `flash.now` before `render`.
    end

    render :index
  end
end
```
### Actual Behavior
No offenses are registered.
## Changes
This PR fixes the two types of false negatives and adds extensive testing. The fixes related to implicit render affected existing tests, necessitating the inclusion of the rescue block-related fix in the same PR. Please understand that I could not submit these fixes as separate PRs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
