### PR TITLE
Fix false positives for `Rails/CompactBlank`

### DIFF
--- a/changelog/fix_false_positive_for_rails_compact_blank.md
+++ b/changelog/fix_false_positive_for_rails_compact_blank.md
@@ -1,0 +1,1 @@
+* [#1313](https://github.com/rubocop/rubocop-rails/pull/1313): Fix false positives for `Rails/CompactBlank` when using `collection.reject!`. ([@koic][])

--- a/lib/rubocop/cop/rails/compact_blank.rb
+++ b/lib/rubocop/cop/rails/compact_blank.rb
@@ -16,7 +16,6 @@ module RuboCop
       #   And `compact_blank!` has different implementations for `Array`, `Hash`, and
       #   `ActionController::Parameters`.
       #   `Array#compact_blank!`, `Hash#compact_blank!` are equivalent to `delete_if(&:blank?)`.
-      #   `ActionController::Parameters#compact_blank!` is equivalent to `reject!(&:blank?)`.
       #   If the cop makes a mistake, autocorrected code may get unexpected behavior.
       #
       # @example
@@ -33,8 +32,6 @@ module RuboCop
       #   # bad
       #   collection.delete_if(&:blank?)            # Same behavior as `Array#compact_blank!` and `Hash#compact_blank!`
       #   collection.delete_if { |_k, v| v.blank? } # Same behavior as `Array#compact_blank!` and `Hash#compact_blank!`
-      #   collection.reject!(&:blank?)              # Same behavior as `ActionController::Parameters#compact_blank!`
-      #   collection.reject! { |_k, v| v.blank? }   # Same behavior as `ActionController::Parameters#compact_blank!`
       #   collection.keep_if(&:present?)            # Same behavior as `Array#compact_blank!` and `Hash#compact_blank!`
       #   collection.keep_if { |_k, v| v.present? } # Same behavior as `Array#compact_blank!` and `Hash#compact_blank!`
       #
@@ -47,20 +44,20 @@ module RuboCop
         extend TargetRailsVersion
 
         MSG = 'Use `%<preferred_method>s` instead.'
-        RESTRICT_ON_SEND = %i[reject delete_if reject! select keep_if].freeze
+        RESTRICT_ON_SEND = %i[reject delete_if select keep_if].freeze
 
         minimum_target_rails_version 6.1
 
         def_node_matcher :reject_with_block?, <<~PATTERN
           (block
-            (send _ {:reject :delete_if :reject!})
+            (send _ {:reject :delete_if})
             $(args ...)
             (send
               $(lvar _) :blank?))
         PATTERN
 
         def_node_matcher :reject_with_block_pass?, <<~PATTERN
-          (send _ {:reject :delete_if :reject!}
+          (send _ {:reject :delete_if}
             (block_pass
               (sym :blank?)))
         PATTERN

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -46,25 +46,15 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `reject! { |e| e.blank? }`' do
-      expect_offense(<<~RUBY)
+    it 'does not registers an offense when using `reject! { |e| e.blank? }`' do
+      expect_no_offenses(<<~RUBY)
         collection.reject! { |e| e.blank? }
-                   ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank!
       RUBY
     end
 
-    it 'registers and corrects an offense when using `reject!(&:blank?)`' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense when using `reject!(&:blank?)`' do
+      expect_no_offenses(<<~RUBY)
         collection.reject!(&:blank?)
-                   ^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        collection.compact_blank!
       RUBY
     end
 


### PR DESCRIPTION
This PR fixes false positives for `Rails/CompactBlank` when using `collection.reject!`.

`reject!(&:blank?)` is not equivalent to `compact_blank!`:

```ruby
{}.reject!(&:blank?)            # => nil
{}.reject! { |_k, v| v.blank? } # => nil
{}.compact_blank!               # => {}
```

This PR prioritizes safer behavior with plain hashes and arrays.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
