### PR TITLE
[Fix #1319] Fix false positive for `RedundantPresenceValidationOnBelongsTo`

### DIFF
--- a/changelog/fix_false_positive_for_rails_redundant_presence_validation_on_belongs_to.md
+++ b/changelog/fix_false_positive_for_rails_redundant_presence_validation_on_belongs_to.md
@@ -1,0 +1,1 @@
+* [#1319](https://github.com/rubocop/rubocop-rails/issues/1319): Fix a false positive for `Rails/RedundantPresenceValidationOnBelongsTo` when removing `presence` would leave other non-validation options like `allow_blank` without validations. ([@earlopain][])

--- a/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_presence_validation_on_belongs_to_spec.rb
@@ -278,6 +278,13 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
       RUBY
     end
 
+    it 'does not register an offense with `if` and other validation option' do
+      expect_no_offenses(<<~RUBY)
+        belongs_to :user
+        validates :user, presence: true, if: -> { condition }, numericality: true
+      RUBY
+    end
+
     it 'does not register an offense with `unless` option' do
       expect_no_offenses(<<~RUBY)
         belongs_to :user
@@ -296,6 +303,13 @@ RSpec.describe RuboCop::Cop::Rails::RedundantPresenceValidationOnBelongsTo, :con
       expect_no_offenses(<<~RUBY)
         belongs_to :user
         validates :user, presence: true, strict: MissingUserError
+      RUBY
+    end
+
+    it 'does not register an offense when other options are present but none are validations' do
+      expect_no_offenses(<<~RUBY)
+        belongs_to :user
+        validates :user, presence: true, allow_blank: false
       RUBY
     end
   end


### PR DESCRIPTION
If presence is the only validation option and other non-validation options are present, removing it will cause rails to error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
