### PR TITLE
Fix an error for `Style/WhereEquals` when the second argument is not yet typed

### DIFF
--- a/changelog/fix_where_equals_error.md
+++ b/changelog/fix_where_equals_error.md
@@ -1,0 +1,1 @@
+* [#1321](https://github.com/rubocop/rubocop-rails/pull/1321): Fix an error for `Rails/WhereEquals` when the second argument is not yet typed (`where("foo = ?", )`). ([@earlopain][])

--- a/lib/rubocop/cop/rails/where_equals.rb
+++ b/lib/rubocop/cop/rails/where_equals.rb
@@ -44,10 +44,10 @@ module RuboCop
 
             range = offense_range(node)
 
-            column_and_value = extract_column_and_value(template_node, value_node)
-            return unless column_and_value
+            column, value = extract_column_and_value(template_node, value_node)
+            return unless value
 
-            good_method = build_good_method(*column_and_value)
+            good_method = build_good_method(column, value)
             message = format(MSG, good_method: good_method)
 
             add_offense(range, message: message) do |corrector|
@@ -73,7 +73,7 @@ module RuboCop
           value =
             case template_node.value
             when EQ_ANONYMOUS_RE, IN_ANONYMOUS_RE
-              value_node.source
+              value_node&.source
             when EQ_NAMED_RE, IN_NAMED_RE
               return unless value_node&.hash_type?
 

--- a/spec/rubocop/cop/rails/where_equals_spec.rb
+++ b/spec/rubocop/cop/rails/where_equals_spec.rb
@@ -188,4 +188,16 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals, :config do
       User.where("id IN (#{sql})", name: 'Lastname').first
     RUBY
   end
+
+  it 'does not register an offense when using `=` and the second argument has no content' do
+    expect_no_offenses(<<~RUBY)
+      User.where('name = ?', )
+    RUBY
+  end
+
+  it 'does not register an offense when using `IN` and the second argument has no content' do
+    expect_no_offenses(<<~RUBY)
+      User.where("name IN (:names)", )
+    RUBY
+  end
 end


### PR DESCRIPTION
See title

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
