### PR TITLE
[Fix #1199] Make `Rails/WhereEquals` aware of `where.not(...)`

### DIFF
--- a/changelog/fix_make_rails_where_equals_aware_of_not.md
+++ b/changelog/fix_make_rails_where_equals_aware_of_not.md
@@ -1,0 +1,1 @@
+* [#1199](https://github.com/rubocop/rubocop-rails/issues/1199): Make `Rails/WhereEquals` aware of `where.not(...)`. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1185,12 +1185,12 @@ Rails/Validation:
     - app/models/**/*.rb
 
 Rails/WhereEquals:
-  Description: 'Pass conditions to `where` as a hash instead of manually constructing SQL.'
+  Description: 'Pass conditions to `where` and `where.not` as a hash instead of manually constructing SQL.'
   StyleGuide: 'https://rails.rubystyle.guide/#hash-conditions'
   Enabled: 'pending'
   SafeAutoCorrect: false
   VersionAdded: '2.9'
-  VersionChanged: '2.10'
+  VersionChanged: <<next>>
 
 Rails/WhereExists:
   Description: 'Prefer `exists?(...)` over `where(...).exists?`.'

--- a/spec/rubocop/cop/rails/where_equals_spec.rb
+++ b/spec/rubocop/cop/rails/where_equals_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `=` and anonymous placeholder with not' do
+    expect_offense(<<~RUBY)
+      User.where.not('name = ?', 'Gabe')
+                 ^^^^^^^^^^^^^^^^^^^^^^^ Use `not(name: 'Gabe')` instead of manually constructing SQL.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User.where.not(name: 'Gabe')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `=` and anonymous placeholder with safe navigation' do
     expect_offense(<<~RUBY)
       User&.where('name = ?', 'Gabe')
@@ -198,6 +209,12 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals, :config do
   it 'does not register an offense when using `IN` and the second argument has no content' do
     expect_no_offenses(<<~RUBY)
       User.where("name IN (:names)", )
+    RUBY
+  end
+
+  it 'does not register an offense when using `not` not preceded by `where`' do
+    expect_no_offenses(<<~RUBY)
+      users.not('name = ?', 'Gabe')
     RUBY
   end
 end


### PR DESCRIPTION
Fix #1199

This copies a bit of logic from `WhereRange` but they need slighly different handling and it doesn't seem worth to extract yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
