### PR TITLE
Fix an error for `Rails/RenderPlainText` when the content type is passed as a constant

### DIFF
--- a/changelog/fix_error_rails_render_plain_text_constant.md
+++ b/changelog/fix_error_rails_render_plain_text_constant.md
@@ -1,0 +1,1 @@
+* [#1325](https://github.com/rubocop/rubocop-rails/pull/1325): Fix an error for `Rails/RenderPlainText` when the content type is passed as a constant. ([@earlopain][])

--- a/lib/rubocop/cop/rails/render_plain_text.rb
+++ b/lib/rubocop/cop/rails/render_plain_text.rb
@@ -53,9 +53,12 @@ module RuboCop
           node.pairs.find { |p| p.key.value.to_sym == :content_type }
         end
 
-        def compatible_content_type?(node)
-          (node && node.value.value == 'text/plain') ||
-            (!node && !cop_config['ContentTypeCompatibility'])
+        def compatible_content_type?(pair_node)
+          if pair_node.nil?
+            !cop_config['ContentTypeCompatibility']
+          elsif pair_node.value.respond_to?(:value)
+            pair_node.value.value == 'text/plain'
+          end
         end
 
         def replacement(rest_options, option_value)

--- a/spec/rubocop/cop/rails/render_plain_text_spec.rb
+++ b/spec/rubocop/cop/rails/render_plain_text_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe RuboCop::Cop::Rails::RenderPlainText, :config do
       RUBY
     end
 
+    it 'does not register an offense when `content_type` is a constant' do
+      expect_no_offenses(<<~RUBY)
+        render text: 'Ruby!', content_type: Foo
+      RUBY
+    end
+
     it 'does not register an offense when using `render plain:`' do
       expect_no_offenses(<<~RUBY)
         render plain: 'Ruby!'


### PR DESCRIPTION
Or other nodes that don't respond to `value` like local variables

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
