### PR TITLE
Fix wrong autocorrect for `Rails/FilePath` when passing an array to `File.join`

### DIFF
--- a/changelog/fix_wrong_autocorrect_for_rails_file_path.md
+++ b/changelog/fix_wrong_autocorrect_for_rails_file_path.md
@@ -1,0 +1,1 @@
+* [#1326](https://github.com/rubocop/rubocop-rails/pull/1326): Fix wrong autocorrect for `Rails/FilePath` when passing an array to `File.join`. ([@earlopain][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -97,7 +97,7 @@ module RuboCop
           return unless node.arguments.any? { |e| rails_root_nodes?(e) }
 
           register_offense(node, require_to_s: true) do |corrector|
-            autocorrect_file_join(corrector, node)
+            autocorrect_file_join(corrector, node) unless node.first_argument.array_type?
           end
         end
 

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -114,6 +114,26 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when using File.join with an array' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          File.join([Rails.root, 'foo'])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for nested arrays' do
+        expect_offense(<<~RUBY)
+          File.join([Rails.root, 'foo', ['bar']])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
     context 'when using Rails.root.join with slash separated path string' do
       it 'does not register an offense' do
         expect_no_offenses("Rails.root.join('app/models/goober')")


### PR DESCRIPTION
`File.join` actually accepts nested arrays and will unflatten them as necessary.

Don't bother implementing autocorrect for these cases, seems complicated and not worth the effort.

The current correction for these testcases look like this:
```rb
Rails.root.join().to_s
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
