### PR TITLE
[`Rails/Blank` & `Rails/Present` cops] new cop configs allowing `return unless` `present?`|`blank?` for multiple `unless` guard clauses

### DIFF
--- a/changelog/change_rails_blank_and_rails_present_cops.md
+++ b/changelog/change_rails_blank_and_rails_present_cops.md
@@ -1,0 +1,1 @@
+* [#1327](https://github.com/rubocop/rubocop-rails/pull/1327): [`Rails/Blank` & `Rails/Present` cops] add AllowUnlessPresentAmongMultipleGuardClauses & AllowUnlessBlankAmongMultipleGuardClauses rules. ([@RDeckard][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -258,6 +258,7 @@ Rails/Blank:
   NotPresent: true
   # Convert usages of `unless present?` to `if blank?`
   UnlessPresent: true
+  AllowMultipleUnlessPresentGuardClauses: false
 
 Rails/BulkChangeTable:
   Description: 'Check whether alter queries are combinable.'
@@ -792,6 +793,7 @@ Rails/Present:
   NotBlank: true
   # Convert usages of `unless blank?` to `if present?`
   UnlessBlank: true
+  AllowMultipleUnlessBlankGuardClauses: false
 
 Rails/RakeEnvironment:
   Description: 'Include `:environment` as a dependency for all Rake tasks.'


### PR DESCRIPTION
# Proposition

## TL;DR

Both [`Rails/Blank` cop](https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/Blank) and [`Rails/Present` cop](https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/Present) are really useful, but their `UnlessPresent` and `UnlessBlank` rules can be frustrating when dealing with multiple `return unless` guard clauses, so **we should have some _cop configs_ allowing those `return unless foo.present?`/`return unless foo.blank?` ONLY in this very specific case (i.e. in multiple `unless` guard clauses)**.

## Context

**Here the current targeted rules in a guard clause context:**
``` ruby
# bad
return unless foo.present?

# good
return if foo.blank?
```
(_This is related to the `Rails/Blank` cop here, but that's the same inverted logic for `Rails/Present`._)

## Specific case this PR aims to address

Those rules are simple and legit in most cases 👌, but **we should be able to disable them specifically on multiple `return unless` guard clauses** like in this example:
``` ruby
return unless foo.active?
return unless bar.present? # <= here the case that we want be able to allow through a new cop config
return unless baz.enable?
```

## New _cop configs_

In order to address the case described just above ☝️, **this PR propose those two new optional _cop configs_:** (which of course should stay `false` by default to avoid any changed behaviors)
``` yaml
Rails/Blank:
  AllowMultipleUnlessPresentGuardClauses: true

Rails/Present:
  AllowMultipleUnlessBlankGuardClauses: true
```

## Reasoning

**Arguments in favor of these two new _cop configs_:**
- `return unless a_condition` is a very common idiom in _guard clauses_, as it simply means that `a_condition` is required in order to go further.
- In the example above ⬆️⬆️, the second line (**`return unless bar.present?`**) triggers the `UnlessPresent` rule, which suggests changing the code to `return if bar.blank?`. But IMO:
  - This change would disrupt the reading flow in this very common list of _guard clauses_.
  - As a get around, we could actually just omit `.present?` in some cases, which is not good for explicitness, and therefore a counterproductive incentive.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] ~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~

[1]: https://chris.beams.io/posts/git-commit/