### PR TITLE
Fix an error for `Rails/WhereNot` without second argument

### DIFF
--- a/changelog/fix_error_rails_where_not_no_second_argument.md
+++ b/changelog/fix_error_rails_where_not_no_second_argument.md
@@ -1,0 +1,1 @@
+* [#1330](https://github.com/rubocop/rubocop-rails/pull/1330): Fix an error for `Rails/WhereNot` when using placeholder without second argument. ([@earlopain][])

--- a/lib/rubocop/cop/rails/where_not.rb
+++ b/lib/rubocop/cop/rails/where_not.rb
@@ -43,10 +43,10 @@ module RuboCop
 
             range = offense_range(node)
 
-            column_and_value = extract_column_and_value(template_node, value_node)
-            return unless column_and_value
+            column, value = extract_column_and_value(template_node, value_node)
+            return unless value
 
-            good_method = build_good_method(node.loc.dot&.source, *column_and_value)
+            good_method = build_good_method(node.loc.dot&.source, column, value)
             message = format(MSG, good_method: good_method)
 
             add_offense(range, message: message) do |corrector|
@@ -72,9 +72,9 @@ module RuboCop
           value =
             case template_node.value
             when NOT_EQ_ANONYMOUS_RE, NOT_IN_ANONYMOUS_RE
-              value_node.source
+              value_node&.source
             when NOT_EQ_NAMED_RE, NOT_IN_NAMED_RE
-              return unless value_node.hash_type?
+              return unless value_node&.hash_type?
 
               pair = value_node.pairs.find { |p| p.key.value.to_sym == Regexp.last_match(2).to_sym }
               pair.value.source

--- a/spec/rubocop/cop/rails/where_not_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot, :config do
     RUBY
   end
 
+  it 'registers no offense when using `!=` and anonymous placeholder without second argument' do
+    expect_no_offenses(<<~RUBY)
+      User.where('name != ?')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `!=` and anonymous placeholder with safe navigation' do
     expect_offense(<<~RUBY)
       User&.where('name != ?', 'Gabe')
@@ -86,6 +92,12 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot, :config do
 
     expect_correction(<<~RUBY)
       User.where.not(name: ['john', 'jane'])
+    RUBY
+  end
+
+  it 'registers no offense when using `NOT IN` and named placeholder without second argument' do
+    expect_no_offenses(<<~RUBY)
+      User.where("name NOT IN (:names)")
     RUBY
   end
 


### PR DESCRIPTION
This is basically #401 again, and a bit of #1321

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
