### PR TITLE
Fix an error for `Rails/BulkChangeTable` when the block for `change_table` is empty

### DIFF
--- a/changelog/fix_error_rails_bulk_change_table.md
+++ b/changelog/fix_error_rails_bulk_change_table.md
@@ -1,0 +1,1 @@
+* [#1335](https://github.com/rubocop/rubocop-rails/pull/1335): Fix an error for `Rails/BulkChangeTable` when the block for `change_table` is empty. ([@earlopain][])

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -140,9 +140,9 @@ module RuboCop
           return unless support_bulk_alter?
           return unless node.command?(:change_table)
           return if include_bulk_options?(node)
-          return unless node.block_node
+          return unless (body = node.block_node&.body)
 
-          send_nodes = send_nodes_from_change_table_block(node.block_node.body)
+          send_nodes = send_nodes_from_change_table_block(body)
 
           add_offense_for_change_table(node) if count_transformations(send_nodes) > 1
         end

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
     end
   end
 
+  shared_examples 'wrong arguments' do
+    it 'does not register an offense for `change_table` with no block' do
+      expect_no_offenses(<<~RUBY)
+        def up
+          change_table(:users)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `change_table` with empty block' do
+      expect_no_offenses(<<~RUBY)
+        def up
+          change_table(:users) do
+          end
+        end
+      RUBY
+    end
+  end
+
   shared_examples 'no offense' do
     it 'does not register an offense when including combinable transformations' do
       expect_no_offenses(<<~RUBY)
@@ -45,6 +64,8 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
     end
+
+    it_behaves_like 'wrong arguments'
   end
 
   shared_examples 'offense for mysql' do
@@ -91,6 +112,8 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
     end
+
+    it_behaves_like 'wrong arguments'
   end
 
   shared_examples 'offense for postgresql' do
@@ -153,6 +176,8 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
     end
+
+    it_behaves_like 'wrong arguments'
   end
 
   it_behaves_like 'no offense'


### PR DESCRIPTION
The error only occurs when the block is empty, the test for no block at all is just to make sure.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
