### PR TITLE
Enable `InternalAffairs/UndefinedConfig`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,10 +19,6 @@ AllCops:
 InternalAffairs/NodeMatcherDirective:
   Enabled: false
 
-# FIXME: Workaround for a false positive caused by this cop when using `bundle exec rake`.
-InternalAffairs/UndefinedConfig:
-  Enabled: false
-
 Naming/InclusiveLanguage:
   Enabled: true
   CheckStrings: true

--- a/lib/rubocop/cop/rails/present.rb
+++ b/lib/rubocop/cop/rails/present.rb
@@ -98,8 +98,6 @@ module RuboCop
         end
 
         def on_or(node)
-          return unless cop_config['NilOrEmpty']
-
           exists_and_not_empty?(node) do |var1, var2|
             return unless var1 == var2
 

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -100,7 +100,8 @@ module RuboCop
         end
 
         def forbidden_methods
-          obsolete_result = cop_config['Blacklist']
+          # TODO: Remove when RuboCop Rails 3 releases.
+          obsolete_result = cop_config['Blacklist'] # rubocop:disable InternalAffairs/UndefinedConfig
           if obsolete_result
             warn '`Blacklist` has been renamed to `ForbiddenMethods`.' unless @displayed_forbidden_warning
             @displayed_forbidden_warning = true
@@ -111,7 +112,8 @@ module RuboCop
         end
 
         def allowed_methods
-          obsolete_result = cop_config['Whitelist']
+          # TODO: Remove when RuboCop Rails 3 releases.
+          obsolete_result = cop_config['Whitelist'] # rubocop:disable InternalAffairs/UndefinedConfig
           if obsolete_result
             warn '`Whitelist` has been renamed to `AllowedMethods`.' unless @displayed_allowed_warning
             @displayed_allowed_warning = true


### PR DESCRIPTION
This works fine right now.

I did a bit of spelunking for `NilOrEmpty` in `Rails/Present` and I believe it is a copy-paste error. Added together with `Rails/Blank` in https://github.com/rubocop/rubocop/pull/4133/ which does contain this config value. There are no tests or docs for this config value.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
