### PR TITLE
Remove RuboCop < 1.52 compatibility code

### DIFF
--- a/lib/rubocop/cop/rails/action_order.rb
+++ b/lib/rubocop/cop/rails/action_order.rb
@@ -92,11 +92,7 @@ module RuboCop
         end
 
         def range_with_comments(node)
-          # rubocop:todo InternalAffairs/LocationExpression
-          # Using `RuboCop::Ext::Comment#source_range` requires RuboCop > 1.46,
-          # which introduces https://github.com/rubocop/rubocop/pull/11630.
-          ranges = [node, *processed_source.ast_with_comments[node]].map { |comment| comment.loc.expression }
-          # rubocop:enable InternalAffairs/LocationExpression
+          ranges = [node, *processed_source.ast_with_comments[node]].map(&:source_range)
           ranges.reduce do |result, range|
             add_range(result, range)
           end

--- a/lib/rubocop/cop/rails/active_record_callbacks_order.rb
+++ b/lib/rubocop/cop/rails/active_record_callbacks_order.rb
@@ -123,11 +123,7 @@ module RuboCop
         end
 
         def inline_comment?(comment)
-          # rubocop:todo InternalAffairs/LocationExpression
-          # Using `RuboCop::Ext::Comment#source_range` requires RuboCop > 1.46,
-          # which introduces https://github.com/rubocop/rubocop/pull/11630.
-          !comment_line?(comment.loc.expression.source_line)
-          # rubocop:enable InternalAffairs/LocationExpression
+          !comment_line?(comment.source_range.source_line)
         end
 
         def start_line_position(node)

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -3,35 +3,6 @@
 module RuboCop
   module Cop
     module Rails
-      # TODO: In the future, please support only RuboCop 1.52+ and use `RuboCop::Cop::AllowedReceivers`:
-      #       https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/cop/mixin/allowed_receivers.rb
-      #       At that time, this duplicated module implementation can be removed.
-      module AllowedReceivers
-        def allowed_receiver?(receiver)
-          receiver_name = receiver_name(receiver)
-
-          allowed_receivers.include?(receiver_name)
-        end
-
-        def receiver_name(receiver)
-          return receiver_name(receiver.receiver) if receiver.receiver && !receiver.receiver.const_type?
-
-          if receiver.send_type?
-            if receiver.receiver
-              "#{receiver_name(receiver.receiver)}.#{receiver.method_name}"
-            else
-              receiver.method_name.to_s
-            end
-          else
-            receiver.source
-          end
-        end
-
-        def allowed_receivers
-          cop_config.fetch('AllowedReceivers', [])
-        end
-      end
-
       # Detect redundant `all` used as a receiver for Active Record query methods.
       #
       # For the methods `delete_all` and `destroy_all`, this cop will only check cases where the receiver is a model.


### PR DESCRIPTION
The minimum required version right now is >= 1.52

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
