### PR TITLE
[Fix #1340] Fix a false positive for `Rails/WhereEquals` when qualifying the database name

### DIFF
--- a/changelog/fix_false_positive_database_qualified.md
+++ b/changelog/fix_false_positive_database_qualified.md
@@ -1,0 +1,1 @@
+* [#1340](https://github.com/rubocop/rubocop-rails/issues/1340): Fix a false positive for `Rails/WhereEquals`, `Rails/WhereNot`, and `Rails/WhereRange` when qualifying the database name. ([@earlopain][])

--- a/lib/rubocop/cop/rails/where_equals.rb
+++ b/lib/rubocop/cop/rails/where_equals.rb
@@ -74,6 +74,7 @@ module RuboCop
           range_between(node.loc.selector.begin_pos, node.source_range.end_pos)
         end
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         def extract_column_and_value(template_node, value_node)
           value =
             case template_node.value
@@ -90,8 +91,12 @@ module RuboCop
               return
             end
 
-          [Regexp.last_match(1), value]
+          column_qualifier = Regexp.last_match(1)
+          return if column_qualifier.count('.') > 1
+
+          [column_qualifier, value]
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
         def build_good_method(method_name, column, value)
           if column.include?('.')

--- a/lib/rubocop/cop/rails/where_not.rb
+++ b/lib/rubocop/cop/rails/where_not.rb
@@ -68,6 +68,7 @@ module RuboCop
           range_between(node.loc.selector.begin_pos, node.source_range.end_pos)
         end
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         def extract_column_and_value(template_node, value_node)
           value =
             case template_node.value
@@ -84,8 +85,12 @@ module RuboCop
               return
             end
 
-          [Regexp.last_match(1), value]
+          column_qualifier = Regexp.last_match(1)
+          return if column_qualifier.count('.') > 1
+
+          [column_qualifier, value]
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
         def build_good_method(dot, column, value)
           dot ||= '.'

--- a/lib/rubocop/cop/rails/where_range.rb
+++ b/lib/rubocop/cop/rails/where_range.rb
@@ -140,6 +140,8 @@ module RuboCop
                 rhs = pair2.value
               end
             end
+          else
+            return
           end
 
           if lhs
@@ -150,7 +152,10 @@ module RuboCop
             rhs_source = parentheses_needed?(rhs) ? "(#{rhs.source})" : rhs.source
           end
 
-          [Regexp.last_match(1), "#{lhs_source}#{operator}#{rhs_source}"] if operator
+          column_qualifier = Regexp.last_match(1)
+          return if column_qualifier.count('.') > 1
+
+          [column_qualifier, "#{lhs_source}#{operator}#{rhs_source}"] if operator
         end
         # rubocop:enable Metrics
 

--- a/spec/rubocop/cop/rails/where_equals_spec.rb
+++ b/spec/rubocop/cop/rails/where_equals_spec.rb
@@ -217,4 +217,10 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals, :config do
       users.not('name = ?', 'Gabe')
     RUBY
   end
+
+  it 'does not register an offense when qualifying the database' do
+    expect_no_offenses(<<~RUBY)
+      User.where('database.users.name = ?', 'Gabe')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rails/where_not_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_spec.rb
@@ -275,4 +275,10 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot, :config do
       User.where('name <> ? AND age <> ?', 'john', 19)
     RUBY
   end
+
+  it 'does not register an offense when qualifying the database' do
+    expect_no_offenses(<<~RUBY)
+      User.where('database.users.name != ?', 'Gabe')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rails/where_range_spec.rb
+++ b/spec/rubocop/cop/rails/where_range_spec.rb
@@ -221,6 +221,12 @@ RSpec.describe RuboCop::Cop::Rails::WhereRange, :config do
           Model.where(column: ...value)
         RUBY
       end
+
+      it 'does not register an offense when qualifying the database' do
+        expect_no_offenses(<<~RUBY)
+          Model.where('database.table.column >= ?', value)
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
And `Rails/WhereNot`/`Rails/WhereRange` as well. Fixes #1340

I'd like to extract some of this logic to a module sometime since it is looking rather similar.

The original issue mentions Redshift, and I know that MSSQL allows cross-database queries as well

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
