### PR TITLE
Revert #1311 - false negatives for `Rails/ActionControllerFlashBeforeRender`

### DIFF
--- a/changelog/fix_revert_flash_before_render.md
+++ b/changelog/fix_revert_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#1269](https://github.com/rubocop/rubocop-rails/issues/1269): Fix false positives for `Rails/ActionControllerFlashBeforeRender` in combination with implicit returns. ([@earlopain][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -72,13 +72,13 @@ module RuboCop
           if (node = context.each_ancestor(:if, :rescue).first)
             return false if use_redirect_to?(context)
 
-            context = node.rescue_type? ? node.parent : node
+            context = node
+          elsif context.right_siblings.empty?
+            return true
           end
+          context = context.right_siblings
 
-          siblings = context.right_siblings
-          return true if siblings.empty?
-
-          siblings.compact.any? do |render_candidate|
+          context.compact.any? do |render_candidate|
             render?(render_candidate)
           end
         end


### PR DESCRIPTION
Relates to #1269.

This cop would need to do control flow analysis which it just doesn't do. RuboCop also has no mechanism for that.

So just reverting this for now to fix the newly introduces false positives. No "Fix" in the commit since the original problem from the issue still occurs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
