### PR TITLE
[Fix #1345] Improve offense message for `Rails/RootPathnameMethods`

### DIFF
--- a/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
+++ b/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       it "registers an offense when using `#{receiver}.#{method}(Rails.public_path)` (if arity exists)" do
         expect_offense(<<~RUBY, receiver: receiver, method: method)
           %{receiver}.%{method}(Rails.public_path)
-          ^{receiver}^^{method}^^^^^^^^^^^^^^^^^^^ `Rails.public_path` is a `Pathname` so you can just append `#%{method}`.
+          ^{receiver}^^{method}^^^^^^^^^^^^^^^^^^^ `Rails.public_path` is a `Pathname`, so you can use `Rails.public_path.%{method}`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       it "registers an offense when using `::#{receiver}.#{method}(::Rails.root.join(...))` (if arity exists)" do
         expect_offense(<<~RUBY, receiver: receiver, method: method)
           ::%{receiver}.%{method}(::Rails.root.join('db', 'schema.rb'))
-          ^^^{receiver}^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::Rails.root` is a `Pathname` so you can just append `#%{method}`.
+          ^^^{receiver}^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::Rails.root` is a `Pathname`, so you can use `::Rails.root.join('db', 'schema.rb').%{method}`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       it "registers an offense when using `::#{receiver}.#{method}(::Rails.root.join(...), ...)` (if arity exists)" do
         expect_offense(<<~RUBY, receiver: receiver, method: method)
           ::%{receiver}.%{method}(::Rails.root.join('db', 'schema.rb'), 20, 5)
-          ^^^{receiver}^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::Rails.root` is a `Pathname` so you can just append `#%{method}`.
+          ^^^{receiver}^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::Rails.root` is a `Pathname`, so you can use `::Rails.root.join('db', 'schema.rb').%{method}(20, 5)`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it "registers an offense when using `Dir.glob(Rails.root.join('**/*.rb'))`" do
       expect_offense(<<~RUBY)
         Dir.glob(Rails.root.join('**/*.rb'))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob('**/*.rb')`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it "registers an offense when using `::Dir.glob(Rails.root.join('**/*.rb'))`" do
       expect_offense(<<~RUBY)
         ::Dir.glob(Rails.root.join('**/*.rb'))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob('**/*.rb')`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it "registers an offense when using `Dir.glob(Rails.root.join('**/\#{path}/*.rb'))`" do
       expect_offense(<<~'RUBY')
         Dir.glob(Rails.root.join("**/#{path}/*.rb"))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob("**/#{path}/*.rb")`.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it "registers an offense when using `Dir.glob(Rails.root.join('**', '*.rb'))`" do
       expect_offense(<<~RUBY)
         Dir.glob(Rails.root.join('**', '*.rb'))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob('**/*.rb')`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       it "registers an offense when using `Dir.glob(Rails.root.join('**', '*.rb'))`" do
         expect_offense(<<~RUBY)
           Dir.glob(Rails.root.join('**', '*.rb'))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob("**/*.rb")`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it "registers an offense when using `Dir.glob(Rails.root.join('**', \"\#{path}\", '*.rb'))`" do
       expect_offense(<<~'RUBY')
         Dir.glob(Rails.root.join('**', "#{path}", '*.rb'))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob("**/#{path}/*.rb")`.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it 'registers an offense when using `Rails.env` argument within `Dir.glob`' do
       expect_offense(<<~RUBY)
         Dir.glob(Rails.root.join("db", "seeds", Rails.env, "*.rb")).sort.each do |file|
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#glob`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob("db/seeds/\#{Rails.env}/*.rb")`.
           load file
         end
       RUBY
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
     it 'registers offense when using `Dir[Rails.root.join(...)]`' do
       expect_offense(<<~RUBY)
         Dir[Rails.root.join('spec/support/**/*.rb')]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#[]`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.glob('spec/support/**/*.rb')`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
   it 'registers an offense when using `File.open(Rails.root.join(...), ...)` inside an iterator' do
     expect_offense(<<~RUBY)
       files.map { |file| File.open(Rails.root.join('db', file), 'wb') }
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#open`.
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join('db', file).open('wb')`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -203,7 +203,7 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
   it 'registers an offense when using `File.open Rails.root.join ...` without parens' do
     expect_offense(<<~RUBY)
       file = File.open Rails.root.join 'docs', 'invoice.pdf'
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname` so you can just append `#open`.
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join('docs', 'invoice.pdf').open`.
     RUBY
 
     expect_correction(<<~RUBY)


### PR DESCRIPTION
Fix #1345

The current message is confusing/nonsensical for `Dir[]`.  Let's display the correct code instead to show what needs to be done.

I also added the Dir offenses to the example section.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
