### PR TITLE
[Fix #1343] False negatives for `Rails/EnumSyntax`

### DIFF
--- a/changelog/fix_false_negatives_enum_syntax.md
+++ b/changelog/fix_false_negatives_enum_syntax.md
@@ -1,0 +1,1 @@
+* [#1343](https://github.com/rubocop/rubocop-rails/issues/1343): Fix false negatives for `Rails/EnumSyntax` for non-literal mappings. ([@earlopain][])

--- a/spec/rubocop/cop/rails/enum_syntax_spec.rb
+++ b/spec/rubocop/cop/rails/enum_syntax_spec.rb
@@ -82,6 +82,32 @@ RSpec.describe RuboCop::Cop::Rails::EnumSyntax, :config do
         end
       end
 
+      context 'when the enum name is underscored' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum :_key => { active: 0, archived: 1 }, _prefix: true
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined with keyword arguments in `_key` enum declaration. Use positional arguments instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :_key, { active: 0, archived: 1 }, prefix: true
+          RUBY
+        end
+      end
+
+      context 'when the enum value is not a literal' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            enum key: %i[foo bar].map.with_index { |v, i| [v, i] }.to_h
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined with keyword arguments in `key` enum declaration. Use positional arguments instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :key, %i[foo bar].map.with_index { |v, i| [v, i] }.to_h
+          RUBY
+        end
+      end
+
       it 'autocorrects' do
         expect_offense(<<~RUBY)
           enum status: { active: 0, archived: 1 }
@@ -95,12 +121,12 @@ RSpec.describe RuboCop::Cop::Rails::EnumSyntax, :config do
 
       it 'autocorrects options too' do
         expect_offense(<<~RUBY)
-          enum status: { active: 0, archived: 1 }, _prefix: true, _suffix: true, _default: :active, _scopes: true
+          enum status: { active: 0, archived: 1 }, _prefix: true, _suffix: true, _default: :active, _scopes: true, _instance_methods: true
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined with keyword arguments in `status` enum declaration. Use positional arguments instead.
         RUBY
 
         expect_correction(<<~RUBY)
-          enum :status, { active: 0, archived: 1 }, prefix: true, suffix: true, default: :active, scopes: true
+          enum :status, { active: 0, archived: 1 }, prefix: true, suffix: true, default: :active, scopes: true, instance_methods: true
         RUBY
       end
     end


### PR DESCRIPTION
Fix #1343. I don't believe there is any issue with just looking at all value types. It just translates `foo: bar` into `:foo, bar`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
