### PR TITLE
Change `Rails/EnumSyntax` to autocorrect underscored options

### DIFF
--- a/changelog/change_enum_syntax_to_autoccorect_underscored_options.md
+++ b/changelog/change_enum_syntax_to_autoccorect_underscored_options.md
@@ -1,0 +1,1 @@
+* [#1350](https://github.com/rubocop/rubocop-rails/pull/1350): Change `Rails/EnumSyntax` to autocorrect underscored options. ([@fatkodima][])

--- a/lib/rubocop/cop/rails/enum_syntax.rb
+++ b/lib/rubocop/cop/rails/enum_syntax.rb
@@ -57,7 +57,11 @@ module RuboCop
         def check_enum_options(node)
           enum_with_options?(node) do |key, _, options|
             options.children.each do |option|
-              add_offense(option.key, message: format(MSG_OPTIONS, enum: enum_name_value(key))) if option_key?(option)
+              next unless option_key?(option)
+
+              add_offense(option.key, message: format(MSG_OPTIONS, enum: enum_name_value(key))) do |corrector|
+                corrector.replace(option.key, option.key.source.delete_prefix('_'))
+              end
             end
           end
         end

--- a/spec/rubocop/cop/rails/enum_syntax_spec.rb
+++ b/spec/rubocop/cop/rails/enum_syntax_spec.rb
@@ -47,11 +47,15 @@ RSpec.describe RuboCop::Cop::Rails::EnumSyntax, :config do
       end
 
       context 'with options prefixed with `_`' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<~RUBY)
             enum :status, { active: 0, archived: 1 }, _prefix: true, _suffix: true
                                                                      ^^^^^^^ Enum defined with deprecated options in `status` enum declaration. Remove the `_` prefix.
                                                       ^^^^^^^ Enum defined with deprecated options in `status` enum declaration. Remove the `_` prefix.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, { active: 0, archived: 1 }, prefix: true, suffix: true
           RUBY
         end
       end


### PR DESCRIPTION
Currently, the cop only suggests that the outdated syntax for options is used, but it does not autocorrect.