### PR TITLE
Add missing tests for `Rails/CompactBlank` when receiver is a hash

### DIFF
--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `reject { |k, v| v.blank? }`' do
+      expect_offense(<<~RUBY)
+        collection.reject { |k, v| v.blank? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `delete_if { |e| e.blank? }`' do
       expect_offense(<<~RUBY)
         collection.delete_if { |e| e.blank? }
@@ -39,6 +50,17 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       expect_offense(<<~RUBY)
         collection.delete_if(&:blank?)
                    ^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank!
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `delete_if { |k, v| v.blank? }`' do
+      expect_offense(<<~RUBY)
+        collection.delete_if { |k, v| v.blank? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -91,6 +113,17 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `select { |k, v| v.present? }`' do
+      expect_offense(<<~RUBY)
+        collection.select { |k, v| v.present? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `keep_if { |e| e.present? }`' do
       expect_offense(<<~RUBY)
         collection.keep_if { |e| e.present? }
@@ -106,6 +139,17 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       expect_offense(<<~RUBY)
         collection.keep_if(&:present?)
                    ^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank!
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `keep_if { |k, v| v.present? }`' do
+      expect_offense(<<~RUBY)
+        collection.keep_if { |k, v| v.present? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank!` instead.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
This PR adds missing tests for `Rails/CompactBlank` when the receiver is a hash.
https://github.com/rubocop/rubocop-rails/blob/master/lib/rubocop/cop/rails/compact_blank.rb#L25

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~~* [] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
~~* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~~
~~* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
