### PR TITLE
Support `filter` in `Rails/CompactBlank`

### DIFF
--- a/changelog/change_support_filter_in_rails_compact_blank.md
+++ b/changelog/change_support_filter_in_rails_compact_blank.md
@@ -1,0 +1,1 @@
+* [#1359](https://github.com/rubocop/rubocop-rails/pull/1359): Support `filter` in `Rails/CompactBlank`. ([@masato-bkn][])

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -124,6 +124,39 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using `filter { |e| e.present? }`' do
+      expect_offense(<<~RUBY)
+        collection.filter { |e| e.present? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `filter(&:present?)`' do
+      expect_offense(<<~RUBY)
+        collection.filter(&:present?)
+                   ^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `filter { |k, v| v.present? }`' do
+      expect_offense(<<~RUBY)
+        collection.filter { |k, v| v.present? }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.compact_blank
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `keep_if { |e| e.present? }`' do
       expect_offense(<<~RUBY)
         collection.keep_if { |e| e.present? }
@@ -169,6 +202,18 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `filter! { |e| e.present? }`' do
+      expect_no_offenses(<<~RUBY)
+        collection.filter! { |e| e.present? }
+      RUBY
+    end
+
+    it 'does not register an offense when using `filter!(&:present?)`' do
+      expect_no_offenses(<<~RUBY)
+        collection.filter!(&:present?)
+      RUBY
+    end
+
     it 'does not register an offense when using `compact_blank`' do
       expect_no_offenses(<<~RUBY)
         collection.compact_blank
@@ -206,6 +251,12 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
         collection.select { |e| e.blank? }
       RUBY
     end
+
+    it 'does not register an offense when using `filter { |e| e.blank? }`' do
+      expect_no_offenses(<<~RUBY)
+        collection.filter { |e| e.blank? }
+      RUBY
+    end
   end
 
   context 'Rails <= 6.0', :rails60 do
@@ -224,6 +275,12 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
     it 'does not register an offense when using `select { |e| e.present? }`' do
       expect_no_offenses(<<~RUBY)
         collection.select { |e| e.present? }
+      RUBY
+    end
+
+    it 'does not register an offense when using `filter { |e| e.present? }`' do
+      expect_no_offenses(<<~RUBY)
+        collection.filter { |e| e.present? }
       RUBY
     end
   end


### PR DESCRIPTION
This PR modifies `Rails/CompactBlank` to support `filter`.
Since `filter` is an alias for `select` in both Array and Hash, I think it can be handled in the same way as `select`. 

- https://docs.ruby-lang.org/en/3.3/Array.html#method-i-filter
- https://docs.ruby-lang.org/en/3.3/Hash.html#method-i-filter

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* ~~[ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~

[1]: https://chris.beams.io/posts/git-commit/
