### PR TITLE
Fix `Rails/CompactBlank` to avoid reporting offense for `filter` in Ruby versions below 2.6

### DIFF
--- a/lib/rubocop/cop/rails/compact_blank.rb
+++ b/lib/rubocop/cop/rails/compact_blank.rb
@@ -80,6 +80,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if target_ruby_version < 2.6 && node.method?(:filter)
           return unless bad_method?(node)
 
           range = offense_range(node)

--- a/spec/rubocop/cop/rails/compact_blank_spec.rb
+++ b/spec/rubocop/cop/rails/compact_blank_spec.rb
@@ -257,6 +257,27 @@ RSpec.describe RuboCop::Cop::Rails::CompactBlank, :config do
         collection.filter { |e| e.blank? }
       RUBY
     end
+
+    context 'target_ruby_version >= 2.6', :ruby26 do
+      it 'registers and corrects an offense when using `filter { |e| e.present? }`' do
+        expect_offense(<<~RUBY)
+          collection.filter { |e| e.present? }
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact_blank` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          collection.compact_blank
+        RUBY
+      end
+    end
+
+    context 'target_ruby_version < 2.6', :ruby25, unsupported_on: :prism do
+      it 'does not register an offense when using `filter { |e| e.present? }`' do
+        expect_no_offenses(<<~RUBY)
+          collection.filter { |e| e.present? }
+        RUBY
+      end
+    end
   end
 
   context 'Rails <= 6.0', :rails60 do


### PR DESCRIPTION
This PR fixes `Rails/CompactBlank` to avoid reporting offense for `filter` in Ruby versions below 2.6.

This change is related to https://github.com/rubocop/rubocop-rails/pull/1359. Apologies for the confusion earlier, as I initially mixed up the runtime version with the analysis version when considering Rubocop's supported versions.

`Rails/CompactBlank` applies to [Rails 6.1 and above, where the required Ruby version is 2.5](https://rubygems.org/gems/rails/versions/6.1.0). However, since `filter` method was introduced in Ruby 2.6, using `filter` in environments running Ruby 2.5 may result in false positives.

Additionally, since https://github.com/rubocop/rubocop-rails/pull/1359 is still unreleased, I am unsure whether this change should be added to the changelog. I would appreciate any feedback, including thoughts on other aspects of this PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
~~* [] If this is a new cop, consider making a corresponding update to the [Rails Style Guide]~~(https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
