### PR TITLE
[Fix #1362] Fix false positives for `Rails/EnumSyntax`

### DIFF
--- a/changelog/fix_false_positives_for_rails_enum_syntax.md
+++ b/changelog/fix_false_positives_for_rails_enum_syntax.md
@@ -1,0 +1,1 @@
+* [#1362](https://github.com/rubocop/rubocop-rails/issues/1362): Fix false positives for `Rails/EnumSyntax` when using Ruby 2.7. ([@koic][])

--- a/lib/rubocop/cop/rails/enum_syntax.rb
+++ b/lib/rubocop/cop/rails/enum_syntax.rb
@@ -17,8 +17,10 @@ module RuboCop
       #
       class EnumSyntax < Base
         extend AutoCorrector
+        extend TargetRubyVersion
         extend TargetRailsVersion
 
+        minimum_target_ruby_version 3.0
         minimum_target_rails_version 7.0
 
         MSG = 'Enum defined with keyword arguments in `%<enum>s` enum declaration. Use positional arguments instead.'

--- a/spec/rubocop/cop/rails/enum_syntax_spec.rb
+++ b/spec/rubocop/cop/rails/enum_syntax_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::EnumSyntax, :config do
-  context 'Rails >= 7.0', :rails70 do
+  context 'Rails >= 7.0 and Ruby >= 3.0', :rails70, :ruby30 do
     context 'when keyword arguments are used' do
       context 'with %i[] syntax' do
         it 'registers an offense' do
@@ -144,6 +144,18 @@ RSpec.describe RuboCop::Cop::Rails::EnumSyntax, :config do
     context 'when enum with no arguments' do
       it 'does not register an offense' do
         expect_no_offenses('enum')
+      end
+    end
+  end
+
+  context 'Rails >= 7.0 and Ruby <= 2.7', :rails70, :ruby27, unsupported_on: :prism do
+    context 'when keyword arguments are used' do
+      context 'with %i[] syntax' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            enum status: %i[active archived], _prefix: true
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1362.

This PR fixes false positives for `Rails/EnumSyntax` when using Ruby 2.7.

The warning shown in https://github.com/rubocop/rubocop-rails/issues/1238 appears starting from Rails 7.2 (Requires Ruby 3.1+). On the other hand, if users use Ruby 2.7, the warning reported in https://github.com/rubocop/rubocop-rails/issues/1362 will be displayed.

Therefore, it would be appropriate to enable this cop only when analyzing Ruby 3.0+.

Nothing will happen when using Ruby 2.7 with Rails 7.0 or Rails 7.1, but the warning in https://github.com/rubocop/rubocop-rails/issues/1238 will not be displayed either. Meanwhile, in Rails 7.2, which requires Ruby 3.1+, Ruby 2.7 cannot be used, so there is no issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
