### PR TITLE
Make `Rails/EagerEvaluationLogMessage` enabled by default

### DIFF
--- a/changelog/change_rails_eager_evaluation_log_message_default.md
+++ b/changelog/change_rails_eager_evaluation_log_message_default.md
@@ -1,0 +1,1 @@
+* [#1364](https://github.com/rubocop/rubocop-rails/pull/1364): Make `Rails/EagerEvaluationLogMessage` enabled by default. ([@Uaitt][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -415,8 +415,9 @@ Rails/DynamicFindBy:
 Rails/EagerEvaluationLogMessage:
   Description: 'Checks that blocks are used for interpolated strings passed to `Rails.logger.debug`.'
   Reference: 'https://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.11'
+  VersionChanged: '2.26'
 
 Rails/EnumHash:
   Description: 'Prefer hash syntax over array syntax when defining enums.'


### PR DESCRIPTION
On issue #1355 we had some discussions about the `Rails/EagerEvaluationLogMessage` cop. In particular, @Earlopain did some useful benchmarks of some possible scenarios.

After seeing the benchmarks, it's pretty obvious to note that offenses that this cop reports (that is, interpolated strings passed to `Rails.logger.debug` ) are very slow compared to the form that the cop allows (that is, blocks passed to `Rails.logger.debug`).

With that being said, considering that the performance hit is now clear between the 2 forms, we might as well enable this cop by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
