### PR TITLE
[Fix #727] Disable `Rails/TransactionExitStatement` on Rails >= 7.2

### DIFF
--- a/changelog/change_disable_transaction_exit_rails_7.2.md
+++ b/changelog/change_disable_transaction_exit_rails_7.2.md
@@ -1,0 +1,1 @@
+* [#727](https://github.com/rubocop/rubocop-rails/issues/727): Disable `Rails/TransactionExitStatement` on Rails >= 7.2. ([@earlopain][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -15,6 +15,10 @@ module RuboCop
       #
       # If you are defining custom transaction methods, you can configure it with `TransactionMethods`.
       #
+      # NOTE: This cop is disabled on Rails >= 7.2 because transactions were restored
+      # to their historical behavior. In Rails 7.1, the behavior is controlled with
+      # the config `active_record.commit_transaction_on_non_local_return`.
+      #
       # @example
       #   # bad
       #   ApplicationRecord.transaction do
@@ -76,6 +80,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if target_rails_version >= 7.2
           return unless in_transaction_block?(node)
 
           exit_statements(node.parent.body).each do |statement_node|

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -114,4 +114,14 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
 
     it_behaves_like 'flags transaction exit statements', :writable_transaction
   end
+
+  context 'Rails >= 7.2', :rails72 do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        ApplicationRecord.transaction do
+          return if user.active?
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -31,3 +31,7 @@ end
 RSpec.shared_context 'with Rails 7.1', :rails71 do
   let(:rails_version) { 7.1 }
 end
+
+RSpec.shared_context 'with Rails 7.2', :rails72 do
+  let(:rails_version) { 7.2 }
+end


### PR DESCRIPTION
Fix #727

On Rails 7.2, the behavior is exactly like it was in earlier Rails. On Rails 7.1, it is controlled by `active_record.commit_transaction_on_non_local_return`.

https://github.com/rails/rails/commit/eccc6061f4f3abdfdeb9a363987a898418d9498f
https://github.com/rails/rails/pull/48600

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
