### PR TITLE
Fix `Rails/TimeZone` should not report offense on `String#to_time` with timezone specifier

### DIFF
--- a/changelog/fix_rails_time_zone_string_to_time_with_specifier.md
+++ b/changelog/fix_rails_time_zone_string_to_time_with_specifier.md
@@ -1,0 +1,1 @@
+* [#1367](https://github.com/rubocop/rubocop-rails/pull/1367): Fix `Rails/TimeZone` should not report offense on `String#to_time` with timezone specifier. ([@armandmgt][])

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -28,6 +28,8 @@ module RuboCop
       #   Time.zone.now
       #   Time.zone.parse('2015-03-02T19:05:37')
       #   Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone specifier.
+      #   Time.parse('2015-03-02T19:05:37Z') # Also respects ISO 8601
+      #   '2015-03-02T19:05:37Z'.to_time # Also respects ISO 8601
       #
       # @example EnforcedStyle: flexible (default)
       #   # `flexible` allows usage of `in_time_zone` instead of `zone`.
@@ -67,6 +69,7 @@ module RuboCop
 
         def on_send(node)
           return if !node.receiver&.str_type? || !node.method?(:to_time)
+          return if attach_timezone_specifier?(node.receiver)
 
           add_offense(node.loc.selector, message: MSG_STRING_TO_TIME) do |corrector|
             corrector.replace(node, "Time.zone.parse(#{node.receiver.source})") unless node.csend_type?

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -144,6 +144,12 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       expect_no_corrections
     end
 
+    it 'does not register an offense for `to_time` when attaching timezone specifier `Z`' do
+      expect_no_offenses(<<~RUBY)
+        "2012-03-02T16:05:37Z".to_time
+      RUBY
+    end
+
     it 'does not register an offense for `to_time` without receiver' do
       expect_no_offenses(<<~RUBY)
         to_time


### PR DESCRIPTION
As `Time.parse("2012-03-02T16:05:37Z")` is allowed, `"2012-03-02T16:05:37Z".to_time` should also be allowed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
