### PR TITLE
Fix test cases for `*` and `**` arguments in `Rails/SaveBang`

### DIFF
--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         RUBY
       else
         expect_offense(<<~RUBY, method: method)
-          object.#{method}(variable)
+          object.#{method}(*variable)
                  ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
         RUBY
 
         expect_correction(<<~RUBY)
-          object.#{method}!(variable)
+          object.#{method}!(*variable)
         RUBY
       end
     end
@@ -64,12 +64,12 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         RUBY
       else
         expect_offense(<<~RUBY, method: method)
-          object.#{method}(variable)
+          object.#{method}(**variable)
                  ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
         RUBY
 
         expect_correction(<<~RUBY)
-          object.#{method}!(variable)
+          object.#{method}!(**variable)
         RUBY
       end
     end


### PR DESCRIPTION
I found test cases without `*` and `**` arguments  in `Rails/SaveBang` and fixed them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
