### PR TITLE
Change `Rails/EnvLocal` to handle negated conditions

### DIFF
--- a/changelog/change_env_local_to_handle_negated_conditions.md
+++ b/changelog/change_env_local_to_handle_negated_conditions.md
@@ -1,0 +1,1 @@
+* [#1374](https://github.com/rubocop/rubocop-rails/pull/1374): Change `Rails/EnvLocal` to handle negated conditions. ([@fatkodima][])

--- a/spec/rubocop/cop/rails/env_local_spec.rb
+++ b/spec/rubocop/cop/rails/env_local_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe RuboCop::Cop::Rails::EnvLocal, :config do
       RUBY
     end
 
+    it 'registers no offenses for non-local `!Rails.env._? && !Rails.env._?`' do
+      expect_no_offenses(<<~RUBY)
+        !Rails.env.development? && Rails.env.production?
+        !Rails.env.test? && Rails.env.production?
+        !Rails.env.production? && Rails.env.other?
+      RUBY
+    end
+
     it 'registers no offenses for single `Rails.env._?`' do
       expect_no_offenses(<<~RUBY)
         Rails.env.development?
@@ -35,6 +43,20 @@ RSpec.describe RuboCop::Cop::Rails::EnvLocal, :config do
       RUBY
     end
 
+    it 'registers an offense for `!Rails.env.development? && !Rails.env.test?`' do
+      expect_offense(<<~RUBY)
+        !Rails.env.development? && !Rails.env.test?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!Rails.env.local?` instead.
+        !Rails.env.test? && !Rails.env.development?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!Rails.env.local?` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        !Rails.env.local?
+        !Rails.env.local?
+      RUBY
+    end
+
     it 'registers no offenses for `Rails.env.local?`' do
       expect_no_offenses(<<~RUBY)
         Rails.env.local?
@@ -49,6 +71,13 @@ RSpec.describe RuboCop::Cop::Rails::EnvLocal, :config do
       expect_no_offenses(<<~RUBY)
         Rails.env.development? || Rails.env.test?
         Rails.env.test? || Rails.env.development?
+      RUBY
+    end
+
+    it 'registers no offenses for `!Rails.env.development? && !Rails.env.test?`' do
+      expect_no_offenses(<<~RUBY)
+        !Rails.env.development? && !Rails.env.test?
+        !Rails.env.test? && !Rails.env.development?
       RUBY
     end
 


### PR DESCRIPTION
Currently, `EnvLocal` cop does not detect `!Rails.env.development? && !Rails.env.test?` as an offense (`!Rails.env.local?`).

I found a few such cases in my project.