### PR TITLE
[Fix #1377] Fix an error for `Rails/EnumSyntax`

### DIFF
--- a/changelog/fix_an_error_for_rails_enum_syntax.md
+++ b/changelog/fix_an_error_for_rails_enum_syntax.md
@@ -1,0 +1,1 @@
+* [#1377](https://github.com/rubocop/rubocop-rails/issues/1377): Fix an error for `Rails/EnumSyntax` when positional arguments are used and options are not passed as keyword arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/enum_syntax.rb
+++ b/lib/rubocop/cop/rails/enum_syntax.rb
@@ -106,6 +106,8 @@ module RuboCop
         end
 
         def option_key?(pair)
+          return false unless pair.respond_to?(:key)
+
           UNDERSCORED_OPTION_NAMES.include?(pair.key.source)
         end
 

--- a/spec/rubocop/cop/rails/enum_syntax_spec.rb
+++ b/spec/rubocop/cop/rails/enum_syntax_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe RuboCop::Cop::Rails::EnumSyntax, :config do
         expect_no_offenses('enum')
       end
     end
+
+    context 'when positional arguments are used and options are not passed as keyword arguments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          enum :status, { active: 0, archived: 1 }, prefix
+        RUBY
+      end
+    end
   end
 
   context 'Rails >= 7.0 and Ruby <= 2.7', :rails70, :ruby27, unsupported_on: :prism do


### PR DESCRIPTION
Fixes #1377

This PR fixes an error for `Rails/EnumSyntax` when positional arguments are used and options are not passed as keyword arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
