### PR TITLE
Fix false negatives for `Rails/RedundantActiveRecordAllMethod` when using `POSSIBLE_ENUMERABLE_BLOCK_METHODS` in a block

### DIFF
--- a/changelog/fix_fix_false_negatives_for_ rails_redundant_active_record_all_method.md
+++ b/changelog/fix_fix_false_negatives_for_ rails_redundant_active_record_all_method.md
@@ -1,0 +1,1 @@
+* [#1382](https://github.com/rubocop/rubocop-rails/pull/1382): Fix false negatives for `Rails/RedundantActiveRecordAllMethod` when using `all` method in block. ([@masato-bkn][])

--- a/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
+++ b/lib/rubocop/cop/rails/redundant_active_record_all_method.rb
@@ -174,7 +174,7 @@ module RuboCop
           parent = node.parent
           return false unless POSSIBLE_ENUMERABLE_BLOCK_METHODS.include?(parent.method_name)
 
-          parent.parent&.block_type? || parent.parent&.numblock_type? || parent.first_argument&.block_pass_type?
+          parent.block_literal? || parent.first_argument&.block_pass_type?
         end
 
         def sensitive_association_method?(node)

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -334,6 +334,13 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
           User.all.#{method}(&:do_something)
         RUBY
       end
+
+      it "registers an offense when using `#{method}` in block" do
+        expect_offense(<<~RUBY)
+          do_something { User.all.#{method} }
+                              ^^^ Redundant `all` detected.
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes false negatives for `Rails/RedundantActiveRecordAllMethod` when methods in `POSSIBLE_ENUMERABLE_BLOCK_METHODS` are used in a block.

### Expected Behavior
```
expect { subject }.to change { User.all.count }
                                    ^^^ Redundant `all` detected.
```

### Actual Behavior
No offenses are registered.

### Steps to reproduce the problem
Run `bundle ex rubocop --only Rails/RedundantActiveRecordAllMethod` on the code below:
```
expect { subject }.to change { User.all.count }
```

### RuboCop version
```
1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.2, running on ruby 3.2.0) [x86_64-darwin21]
  - rubocop-rails 2.27.0
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
