### PR TITLE
Introduce `AllCops: MigratedSchemaVersion` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ gems.locked file to find the version of Rails that has been bound to the
 application. If neither of those files exist, RuboCop will use Rails 5.0
 as the default.
 
+### `AllCops: MigratedSchemaVersion`
+
+By specifying the `MigratedSchemaVersion` option, migration files that have already been run can be ignored.
+When `MigratedSchemaVersion: '20241225000000'` is set, migration files lower than or equal to '20241225000000' will be ignored.
+For example, to ignore db/migrate/20241225000000_create_articles.rb and earlier migrations you would configure it the following way:
+
+```yaml
+AllCops
+  MigratedSchemaVersion: '20241225000000'
+```
+
+This prevents inspecting schema settings for already applied migration files.
+Changing already applied migrations should be avoided because it can lead to the schema getting out of sync
+between your local copy and what it actually is in production, depending on when `bin/rails db:migrate` was executed.
+If you want to modify your schema to comply with the cops, you should instead create new migrations.
+
 ## Rails configuration tip
 
 In Rails 6.1+, add the following `config.generators.after_generate` setting to

--- a/changelog/new_intro_migrated_schema_version.md
+++ b/changelog/new_intro_migrated_schema_version.md
@@ -1,0 +1,1 @@
+* [#1383](https://github.com/rubocop/rubocop-rails/pull/1383): Introduce `AllCops: MigratedSchemaVersion` config. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,10 @@ AllCops:
   # application. If neither of those files exist, RuboCop will use Rails 5.0
   # as the default.
   TargetRailsVersion: ~
+  # By specifying `MigratedSchemaVersion` option, migration files that have been migrated can be ignored.
+  # When `MigratedSchemaVersion: '20241231000000'` is set. Migration files lower than or equal to '20250101000000' will be ignored.
+  # For example, this is the timestamp in db/migrate/20250101000000_create_articles.rb.
+  MigratedSchemaVersion: ~
 
 Lint/NumberConversion:
   # Add Rails' duration methods to the ignore list for `Lint/NumberConversion`

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -52,6 +52,23 @@ gems.locked file to find the version of Rails that has been bound to the
 application. If neither of those files exist, RuboCop will use Rails 5.0
 as the default.
 
+=== `AllCops: MigratedSchemaVersion`
+
+By specifying the `MigratedSchemaVersion` option, migration files that have already been run can be ignored.
+When `MigratedSchemaVersion: '20241225000000'` is set, migration files lower than or equal to '20241225000000' will be ignored.
+For example, to ignore db/migrate/20241225000000_create_articles.rb and earlier migrations you would configure it the following way:
+
+[source,yaml]
+----
+AllCops
+  MigratedSchemaVersion: '20241225000000'
+----
+
+This prevents inspecting schema settings for already applied migration files.
+Changing already applied migrations should be avoided because it can lead to the schema getting out of sync
+between your local copy and what it actually is in production, depending on when `bin/rails db:migrate` was executed.
+If you want to modify your schema to comply with the cops, you should instead create new migrations.
+
 == Rails configuration tip
 
 In Rails 6.1+, add the following `config.generators.after_generate` setting to

--- a/lib/rubocop/cop/mixin/migrations_helper.rb
+++ b/lib/rubocop/cop/mixin/migrations_helper.rb
@@ -21,6 +21,35 @@ module RuboCop
           migration_class?(class_node)
         end
       end
+
+      # rubocop:disable Style/DocumentDynamicEvalDefinition
+      %i[on_send on_csend on_block on_numblock on_class].each do |method|
+        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          def #{method}(node)
+            return if already_migrated_file?
+
+            super if method(__method__).super_method
+          end
+        RUBY
+      end
+      # rubocop:enable Style/DocumentDynamicEvalDefinition
+
+      private
+
+      def already_migrated_file?
+        return false unless migrated_schema_version
+
+        match_data = File.basename(processed_source.file_path).match(/(?<timestamp>\d{14})/)
+        schema_version = match_data['timestamp'] if match_data
+
+        return false unless schema_version
+
+        schema_version <= migrated_schema_version.to_s # Ignore applied migration files.
+      end
+
+      def migrated_schema_version
+        config.for_all_cops.fetch('MigratedSchemaVersion', nil)
+      end
     end
   end
 end

--- a/lib/rubocop/cop/rails/add_column_index.rb
+++ b/lib/rubocop/cop/rails/add_column_index.rb
@@ -19,6 +19,7 @@ module RuboCop
       class AddColumnIndex < Base
         extend AutoCorrector
         include RangeHelp
+        prepend MigrationsHelper
 
         MSG = '`add_column` does not accept an `index` key, use `add_index` instead.'
         RESTRICT_ON_SEND = %i[add_column].freeze

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -65,6 +65,7 @@ module RuboCop
       #   end
       class BulkChangeTable < Base
         include DatabaseTypeResolvable
+        prepend MigrationsHelper
 
         MSG_FOR_CHANGE_TABLE = <<~MSG.chomp
           You can combine alter queries using `bulk: true` options.

--- a/lib/rubocop/cop/rails/dangerous_column_names.rb
+++ b/lib/rubocop/cop/rails/dangerous_column_names.rb
@@ -14,6 +14,8 @@ module RuboCop
       #   # good
       #   add_column :users, :saved
       class DangerousColumnNames < Base # rubocop:disable Metrics/ClassLength
+        prepend MigrationsHelper
+
         COLUMN_TYPE_METHOD_NAMES = %i[
           bigint
           binary

--- a/lib/rubocop/cop/rails/migration_class_name.rb
+++ b/lib/rubocop/cop/rails/migration_class_name.rb
@@ -20,7 +20,7 @@ module RuboCop
       #
       class MigrationClassName < Base
         extend AutoCorrector
-        include MigrationsHelper
+        prepend MigrationsHelper
 
         MSG = 'Replace with `%<camelized_basename>s` that matches the file name.'
 

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -41,6 +41,7 @@ module RuboCop
       #   change_column_null :products, :category_id, false
       class NotNullColumn < Base
         include DatabaseTypeResolvable
+        prepend MigrationsHelper
 
         MSG = 'Do not add a NOT NULL column without a default value.'
         RESTRICT_ON_SEND = %i[add_column add_reference].freeze

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -151,7 +151,7 @@ module RuboCop
       #     remove_index :users, column: :email
       #   end
       class ReversibleMigration < Base
-        include MigrationsHelper
+        prepend MigrationsHelper
 
         MSG = '%<action>s is not reversible.'
 

--- a/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
+++ b/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
@@ -43,7 +43,7 @@ module RuboCop
       #     end
       #   end
       class ReversibleMigrationMethodDefinition < Base
-        include MigrationsHelper
+        prepend MigrationsHelper
 
         MSG = 'Migrations must contain either a `change` method, or both an `up` and a `down` method.'
 

--- a/lib/rubocop/cop/rails/schema_comment.rb
+++ b/lib/rubocop/cop/rails/schema_comment.rb
@@ -23,6 +23,7 @@ module RuboCop
       #
       class SchemaComment < Base
         include ActiveRecordMigrationsHelper
+        prepend MigrationsHelper
 
         COLUMN_MSG = 'New database column without `comment`.'
         TABLE_MSG = 'New database table without `comment`.'

--- a/lib/rubocop/cop/rails/three_state_boolean_column.rb
+++ b/lib/rubocop/cop/rails/three_state_boolean_column.rb
@@ -18,8 +18,9 @@ module RuboCop
       #   t.boolean :active, default: true, null: false
       #
       class ThreeStateBooleanColumn < Base
-        MSG = 'Boolean columns should always have a default value and a `NOT NULL` constraint.'
+        prepend MigrationsHelper
 
+        MSG = 'Boolean columns should always have a default value and a `NOT NULL` constraint.'
         RESTRICT_ON_SEND = %i[add_column column boolean].freeze
 
         def_node_matcher :three_state_boolean?, <<~PATTERN

--- a/spec/rubocop/cop/rails/add_column_index_spec.rb
+++ b/spec/rubocop/cop/rails/add_column_index_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
+  let(:config) do
+    RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => '20240101010101' })
+  end
+
   it 'registers an offense and corrects when an `add_column` call has `index: true`' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
       add_column :table, :column, :integer, default: 0, index: true
                                                         ^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
     RUBY
@@ -14,7 +18,7 @@ RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
   end
 
   it 'registers an offense and corrects when an `add_column` call has `index:` with a hash' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
       add_column :table, :column, :integer, default: 0, index: { unique: true, name: 'my_unique_index' }
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
     RUBY
@@ -26,7 +30,7 @@ RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
   end
 
   it 'registers an offense and corrects with there is another hash key after `index`' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
       add_column :table, :column, :integer, index: true, default: 0
                                             ^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
     RUBY
@@ -38,7 +42,7 @@ RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
   end
 
   it 'registers an offense and corrects with string keys' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
       add_column :table, :column, :integer, 'index' => true, default: 0
                                             ^^^^^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
     RUBY
@@ -50,7 +54,7 @@ RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
   end
 
   it 'registers an offense and corrects when on multiple lines' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
       add_column :table, :column, :integer,
                  index: true,
                  ^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
@@ -65,7 +69,7 @@ RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
   end
 
   it 'can correct multiple `add_column` calls' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
       add_column :table, :column, :integer, default: 0, index: true
                                                         ^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
       add_column :table, :column2, :integer, default: 0, index: true
@@ -84,5 +88,23 @@ RSpec.describe RuboCop::Cop::Rails::AddColumnIndex, :config do
     expect_no_offenses(<<~RUBY)
       add_column :table, :column, :integer, default: 0
     RUBY
+  end
+
+  context '`MigratedSchemaVersion` is an integer' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => 20240101010101 }) # rubocop:disable Style/NumericLiterals
+    end
+
+    it 'registers an offense and corrects when an `add_column` call has `index: true`' do
+      expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
+        add_column :table, :column, :integer, default: 0, index: true
+                                                          ^^^^^^^^^^^ `add_column` does not accept an `index` key, use `add_index` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        add_column :table, :column, :integer, default: 0
+        add_index :table, :column
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/rails/dangerous_column_names_spec.rb
+++ b/spec/rubocop/cop/rails/dangerous_column_names_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::DangerousColumnNames, :config do
+  let(:config) do
+    RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => '20240101010101' })
+  end
+
   context 'with non-dangerous column name' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
@@ -18,6 +22,14 @@ RSpec.describe RuboCop::Cop::Rails::DangerousColumnNames, :config do
     end
   end
 
+  context 'with dangerous column name on `add_column` when migration file was migrated' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '20190101010101_add_save_to_users.rb')
+        add_column :users, :save, :string
+      RUBY
+    end
+  end
+
   context 'with dangerous column name on `rename_column`' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
@@ -29,7 +41,7 @@ RSpec.describe RuboCop::Cop::Rails::DangerousColumnNames, :config do
 
   context 'with dangerous column name on `t.string`' do
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users do |t|
           t.string :save
                    ^^^^^ Avoid dangerous column names.
@@ -40,7 +52,7 @@ RSpec.describe RuboCop::Cop::Rails::DangerousColumnNames, :config do
 
   context 'with dangerous column name on `t.rename`' do
     it 'registers an offense' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users do |t|
           t.rename :name, :save
                           ^^^^^ Avoid dangerous column names.

--- a/spec/rubocop/cop/rails/migration_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/migration_class_name_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::MigrationClassName, :config do
-  let(:filename) { 'db/migrate/20220101050505_create_users.rb' }
+  let(:config) do
+    RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => '20240101010101' })
+  end
+  let(:filename) { 'db/migrate/20250101010101_create_users.rb' }
 
   context 'when the class name matches its file name' do
     it 'does not register an offense' do
@@ -85,7 +88,7 @@ RSpec.describe RuboCop::Cop::Rails::MigrationClassName, :config do
   # end
   #
   context 'when `ActiveSupport::Inflector` is applied to the class name and the case is different' do
-    let(:filename) { 'db/migrate/20210623095243_remove_unused_oauth_scope_grants.rb' }
+    let(:filename) { 'db/migrate/20250101010101_remove_unused_oauth_scope_grants.rb' }
 
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY, filename)

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
+  let(:config) do
+    RuboCop::Config.new(
+      'AllCops' => { 'MigratedSchemaVersion' => '20240101010101', 'TargetRailsVersion' => rails_version }
+    )
+  end
   let(:source) do
     <<~RUBY
       class ExampleMigration < ActiveRecord::Migration[7.0]
@@ -312,7 +317,7 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
 
   context 'when multiple databases' do
     it 'does not register an offense for reversible operation' do
-      expect_no_offenses(<<~RUBY, 'db/animals_migrate/20211007000002_create_animals.rb')
+      expect_no_offenses(<<~RUBY, 'db/animals_migrate/20250101010101_create_animals.rb')
         class CreateAnimals < ActiveRecord::Migration[7.0]
           def change
             create_table :animals
@@ -322,7 +327,7 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     end
 
     it 'registers an offense for irreversible operation' do
-      expect_offense(<<~RUBY, 'db/animals_migrate/20211007000002_remove_animals.rb')
+      expect_offense(<<~RUBY, 'db/animals_migrate/20250101010101_remove_animals.rb')
         class RemoveAnimals < ActiveRecord::Migration[7.0]
           def change
             drop_table :animals
@@ -331,11 +336,21 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense for irreversible operation when migration file was migrated' do
+      expect_no_offenses(<<~RUBY, 'db/animals_migrate/20190101010101_remove_animals.rb')
+        class RemoveAnimals < ActiveRecord::Migration[7.0]
+          def change
+            drop_table :animals
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when irreversible operation is used in `::` prefixed class definition' do
     it 'registers an offense' do
-      expect_offense(<<~RUBY, 'db/migrate/20211007000002_remove_animals.rb')
+      expect_offense(<<~RUBY, 'db/migrate/20250101010101_remove_animals.rb')
         class ::RemoveAnimals < ActiveRecord::Migration[7.0]
           def change
             drop_table :animals

--- a/spec/rubocop/cop/rails/schema_comment_spec.rb
+++ b/spec/rubocop/cop/rails/schema_comment_spec.rb
@@ -1,30 +1,40 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
+  let(:config) do
+    RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => '20240101010101' })
+  end
+
   context 'when send add_column' do
     it 'registers an offense when `add_column` has no `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
         add_column :table, :column, :integer
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
       RUBY
     end
 
+    it 'does not register an offense when `add_column` has no `comment` option when migration file was migrated' do
+      expect_no_offenses(<<~RUBY, '20190101010101_add_column_to_table.rb')
+        add_column :table, :column, :integer
+      RUBY
+    end
+
     it 'registers an offense when `add_column` has no `comment` option, but other options' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
         add_column :table, :column, :integer, default: 0
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
       RUBY
     end
 
     it 'registers an offense when `add_column` has a nil `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
         add_column :table, :column, :integer, comment: nil
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
       RUBY
     end
 
     it 'registers an offense when `add_column` has an empty `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_column_to_table.rb')
         add_column :table, :column, :integer, comment: ''
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
       RUBY
@@ -45,7 +55,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
 
   context 'when send create_table' do
     it 'registers an offense when `create_table` has no `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users do |t|
         ^^^^^^^^^^^^^^^^^^^ New database table without `comment`.
         end
@@ -53,7 +63,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
     end
 
     it 'registers an offense when `create_table` has a nil `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users, comment: nil do |t|
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database table without `comment`.
         end
@@ -61,7 +71,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
     end
 
     it 'registers an offense when `create_table` has a empty `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users, comment: '' do |t|
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database table without `comment`.
 
@@ -70,7 +80,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
     end
 
     it 'registers an offense when `t.column` has no `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users, comment: 'Table' do |t|
           t.column :column, :integer
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
@@ -79,7 +89,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
     end
 
     it 'registers an offense when `t.integer` has no `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users, comment: 'Table' do |t|
           t.integer :column
           ^^^^^^^^^^^^^^^^^ New database column without `comment`.
@@ -88,7 +98,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
     end
 
     it 'registers two offenses when two `t.column` have no `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users, comment: 'Table' do |t|
           t.column :column1, :integer
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ New database column without `comment`.
@@ -99,7 +109,7 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
     end
 
     it 'registers two offenses when two `t.integer` have no `comment` option' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_create_users.rb')
         create_table :users, comment: 'Table' do |t|
           t.integer :column1
           ^^^^^^^^^^^^^^^^^^ New database column without `comment`.

--- a/spec/rubocop/cop/rails/three_state_boolean_column_spec.rb
+++ b/spec/rubocop/cop/rails/three_state_boolean_column_spec.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
+  let(:config) do
+    RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => '20240101010101' })
+  end
+
   describe '#add_column' do
     it 'registers an offense with three state boolean' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_active_to_users.rb')
         add_column :users, :active, :boolean
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
         add_column :users, :active, :boolean, default: true
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
         add_column :users, :active, :boolean, default: true, null: true
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
+      RUBY
+    end
+
+    it 'does not register an offense with three state boolean when migration file was migrated' do
+      expect_no_offenses(<<~RUBY, '20190101010101_add_active_to_users.rb')
+        add_column :users, :active, :boolean
+        add_column :users, :active, :boolean, default: true
+        add_column :users, :active, :boolean, default: true, null: true
       RUBY
     end
 
@@ -44,7 +56,7 @@ RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
     end
 
     it 'registers an offense when using `#change_column_null` for other table or column' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_active_to_users.rb')
         def change
           add_column :users, :active, :boolean
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
@@ -58,7 +70,7 @@ RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
 
   describe '#column' do
     it 'registers an offense with three state boolean' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_active_to_users.rb')
         t.column :active, :boolean
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
         t.column :active, :boolean, default: true
@@ -119,7 +131,7 @@ RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
 
   describe '#boolean' do
     it 'registers an offense for three state boolean' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_active_to_users.rb')
         t.boolean :active
         ^^^^^^^^^^^^^^^^^ Boolean columns should always have a default value and a `NOT NULL` constraint.
         t.boolean :active, default: true
@@ -168,7 +180,7 @@ RSpec.describe RuboCop::Cop::Rails::ThreeStateBooleanColumn, :config do
     end
 
     it 'registers an offense when using `#change_column_null` for other table or column' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, '20250101010101_add_active_to_users.rb')
         def change
           create_table(:users) do |t|
             t.boolean :active


### PR DESCRIPTION
This PR introduces `AllCops: MigratedSchemaVersion` config.

By specifying `MigratedSchemaVersion` option, migration files that have been migrated can be ignored. When `MigratedSchemaVersion: '20241231000000'` is set. Migration files lower than or equal to '20250101000000' will be ignored. For example, this is the timestamp in db/migrate/20250101000000_create_articles.rb.

```yaml
AllCops
  MigratedSchemaVersion: 20250101000000
```

This prevents inspecting schema settings for already applied migration files and avoids having different database schemas depending on when `bin/rails db:migrate` is executed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
