### PR TITLE
Make `Lint/UselessAccessModifier` aware of `ActiveSupport::Concern`

### DIFF
--- a/changelog/change_lint_useless_access_modifier_as_concern.md
+++ b/changelog/change_lint_useless_access_modifier_as_concern.md
@@ -1,0 +1,1 @@
+* [#1385](https://github.com/rubocop/rubocop-rails/pull/1385): Make `Lint/UselessAccessModifier` aware of `ActiveSupport::Concern` and `Module#concerning`/`Module#concern` core extensions. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -73,6 +73,20 @@ Lint/SafeNavigationChain:
     - try!
     - in?
 
+Lint/UselessAccessModifier:
+  # Add methods from `ActiveSupport::Concern` and `Module::Concerning`:
+  # https://api.rubyonrails.org/classes/ActiveSupport/Concern.html
+  # https://api.rubyonrails.org/classes/Module/Concerning
+  inherit_mode:
+    merge:
+      - ContextCreatingMethods
+  ContextCreatingMethods:
+    - class_methods
+    - included
+    - prepended
+    - concern
+    - concerning
+
 Rails:
   Enabled: true
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails


### PR DESCRIPTION
Ref https://github.com/rubocop/rubocop/issues/7298

Allow code like this by default:
```rb

module Foo
  extend ActiveSupport::Concern

  private

  def private_instance_bar
  end

  class_methods do
    private

    def private_class_bar
    end
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
