### PR TITLE
Modify `Rails/Pluck` to ignore `map/collect` when used inside blocks to prevent potential N+1 queries

### DIFF
--- a/changelog/change_modify_rails_pluck_to_ignore_map_collect.md
+++ b/changelog/change_modify_rails_pluck_to_ignore_map_collect.md
@@ -1,0 +1,1 @@
+* [#1388](https://github.com/rubocop/rubocop-rails/pull/1388): Modify `Rails/Pluck` to ignore `map/collect` when used inside blocks to prevent potential N+1 queries. ([@masato-bkn][])

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -128,6 +128,48 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
           end
         end
       end
+
+      context "when `#{method}` is used in block" do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            n.each do |x|
+              x.#{method} { |a| a[:foo] }
+            end
+          RUBY
+        end
+      end
+
+      context "when `#{method}` is used in block with other operations" do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            n.each do |x|
+              do_something
+              x.#{method} { |a| a[:foo] }
+            end
+          RUBY
+        end
+      end
+
+      context "when `#{method}` is used in numblock" do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            n.each do
+              _1.#{method} { |a| a[:foo] }
+            end
+          RUBY
+        end
+      end
+
+      context "when `#{method}` is used in numblock with other operations" do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            n.each do
+              do_something
+              _1.#{method} { |a| a[:foo] }
+            end
+          RUBY
+        end
+      end
     end
 
     context 'when using Rails 4.2 or older', :rails42 do


### PR DESCRIPTION
This PR modifies the `Rails/Pluck` cop to ignore `map/collect` when used inside blocks to prevent potential N+1 queries.

When the receiver's relation is not loaded and `pluck` is used inside an iteration, it can result in N+1 queries. This happens because ` pluck ` executes a database query on every iteration when the relation is not loaded.

### Example
```ruby
users = User.all
5.times do
  users.map { |user| user[:id] } # Only one query is executed
end
```

```ruby
users = User.all
5.times do
  users.pluck(:id) # A query is executed on every iteration
end
```

```ruby
users = User.all
users.load

5.times do
  users.pluck(:id) # Since the records are loaded, only one query is executed
end
```
As shown above, replacing `map/collect` with `pluck` in such cases can degrade performance due to the N+1 queries. To prevent this, it is better to ignore `map/collect` when used inside an iteration.

### Challenge
Since Ruby has numerous methods for performing iterations, it is difficult to list all of them. Therefore, this PR assumes that `map/collect` used inside blocks are likely part of an iteration and ignores offenses.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
