### PR TITLE
Fix an incorrect autocorrect for `Rails/SelectMap` when `select` has no receiver and method chains are used

### DIFF
--- a/changelog/fix_fix_an_incorrect_autocorrect_for.md
+++ b/changelog/fix_fix_an_incorrect_autocorrect_for.md
@@ -1,0 +1,1 @@
+* [#1390](https://github.com/rubocop/rubocop-rails/pull/1390): Fix an incorrect autocorrect for `Rails/SelectMap` when `select` has no receiver and method chains are used. ([@masato-bkn][])

--- a/lib/rubocop/cop/rails/select_map.rb
+++ b/lib/rubocop/cop/rails/select_map.rb
@@ -54,7 +54,7 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize
         def autocorrect(corrector, select_node, node, preferred_method)
-          corrector.remove(select_node.loc.dot || node.loc.dot)
+          corrector.remove(select_node.parent.loc.dot)
           corrector.remove(select_node.loc.selector.begin.join(select_node.source_range.end))
           corrector.replace(node.loc.selector.begin.join(node.source_range.end), preferred_method)
         end

--- a/spec/rubocop/cop/rails/select_map_spec.rb
+++ b/spec/rubocop/cop/rails/select_map_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Rails::SelectMap, :config do
     RUBY
   end
 
-  it 'registers an offense when using `select(:column_name).map(&:column_name)` without receiver model' do
+  it 'registers an offense when using `select(:column_name).map(&:column_name)` without receiver' do
     expect_offense(<<~RUBY)
       select(:column_name).map(&:column_name)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `pluck(:column_name)` instead of `select` with `map`.
@@ -53,6 +53,17 @@ RSpec.describe RuboCop::Cop::Rails::SelectMap, :config do
 
     expect_correction(<<~RUBY)
       pluck(:column_name)
+    RUBY
+  end
+
+  it 'registers an offense when using `select(:column_name).where(conditions).map(&:column_name)` without receiver' do
+    expect_offense(<<~RUBY)
+      select(:column_name).where(conditions).map(&:column_name)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `pluck(:column_name)` instead of `select` with `map`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      where(conditions).pluck(:column_name)
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Rails/SelectMap` when `select` has no receiver and method chains are used between `select` and `map`.

 For example: `select(:column_name).where(conditions).map(&:column_name)`

### Expected Behavior
```
where(conditions).pluck(:column_name)
```

### Actual Behavior
```ruby
.where(conditions)pluck(:column_name)
```

### Steps to reproduce the problem
Run `bundle ex rubocop -A --only Rails/SelectMap` on the code below:
```
select(:column_name).where(conditions).map(&:column_name)
```

### RuboCop version
```
1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.2, running on ruby 3.2.0) [x86_64-darwin21]
  - rubocop-rails 2.27.0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
