### PR TITLE
Fix `Rails/FilePath` cop error with rescued `Rails.root`

### DIFF
--- a/changelog/fix_rails_file_path_cop_error_with_rescued_rails_root.md
+++ b/changelog/fix_rails_file_path_cop_error_with_rescued_rails_root.md
@@ -1,0 +1,1 @@
+* [#1392](https://github.com/rubocop/rubocop-rails/pull/1392): Fix `Rails/FilePath` cop error with rescued `Rails.root`. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -76,6 +76,7 @@ module RuboCop
           rails_root_index = find_rails_root_index(node)
           slash_node = node.children[rails_root_index + 1]
           return unless slash_node&.str_type? && slash_node.source.start_with?(File::SEPARATOR)
+          return if node.children[rails_root_index].each_descendant(:rescue).any?
 
           register_offense(node, require_to_s: false) do |corrector|
             autocorrect_slash_after_rails_root_in_dstr(corrector, node, rails_root_index)

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -406,5 +406,13 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
         RUBY
       end
     end
+
+    context 'when rescued concat Rails.root' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          "#{Rails.root rescue '.'}/config"
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
```console
echo "\"#{Rails.root rescue '.'}/config\"" | rubocop --stdin bug.rb --only Rails/FilePath -d

An error occurred while Rails/FilePath cop was inspecting bug.rb:1:0.
undefined method `method?' for an instance of RuboCop::AST::RescueNode
lib/rubocop/cop/rails/file_path.rb:156:in `autocorrect_slash_after_rails_root_in_dstr'
lib/rubocop/cop/rails/file_path.rb:81:in `block in check_for_slash_after_rails_root_in_dstr'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [X] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
