### PR TITLE
Fix an incorrect autocorrect for `Rails/TimeZone` when Time.new has a string argument

### DIFF
--- a/changelog/fix_fix_an_incorrect_autocorrect_for_rails_timezone_when_time_new_has_a_string_augument.md
+++ b/changelog/fix_fix_an_incorrect_autocorrect_for_rails_timezone_when_time_new_has_a_string_augument.md
@@ -1,0 +1,1 @@
+* [#1397](https://github.com/rubocop/rubocop-rails/pull/1397): Fix an incorrect autocorrect for `Rails/TimeZone` when Time.new has a string argument. ([@mterada1228][])

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -97,11 +97,9 @@ module RuboCop
         end
 
         def autocorrect_time_new(node, corrector)
-          if node.arguments?
-            corrector.replace(node.loc.selector, 'local')
-          else
-            corrector.replace(node.loc.selector, 'now')
-          end
+          replacement = replacement(node)
+
+          corrector.replace(node.loc.selector, replacement)
         end
 
         # remove redundant `.in_time_zone` from `Time.zone.now.in_time_zone`
@@ -183,7 +181,7 @@ module RuboCop
 
         def safe_method(method_name, node)
           if %w[new current].include?(method_name)
-            node.arguments? ? 'local' : 'now'
+            replacement(node)
           else
             method_name
           end
@@ -258,6 +256,12 @@ module RuboCop
             options.each_pair.any? do |pair|
               pair.key.sym_type? && pair.key.value == :in && !pair.value.nil_type?
             end
+        end
+
+        def replacement(node)
+          return 'now' unless node.arguments?
+
+          node.first_argument.str_type? ? 'parse' : 'local'
         end
       end
     end

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       RUBY
     end
 
+    it 'registers an offense for Time.new with string argument' do
+      expect_offense(<<~RUBY)
+        Time.new("2012-06-10 10:12:00")
+             ^^^ Do not use `Time.new` without zone. Use `Time.zone.parse` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Time.zone.parse("2012-06-10 10:12:00")
+      RUBY
+    end
+
     it 'does not register an offense when a .new method is called independently of the Time class' do
       expect_no_offenses(<<~RUBY)
         Range.new(1, Time.class.to_s)


### PR DESCRIPTION
This PR fixes incorrect autocorrect for Rails/TimeZone when `Time.new` has a string argument.

## Expected Behavior

```ruby
# Before autocorrect
Time.new("2024-12-21 12:00:00")

# After autocorrect
Time.zone.parse("2024-12-21 12:00:00")
```

## Actual Behavior

```ruby
# Before autocorrect
Time.new("2024-12-21 12:00:00")

# After autocorrect
Time.zone.local("2024-12-21 12:00:00")
```

Autocorrected code doesn't work.

```ruby
irb(main):002> Time.zone.local("2024-12-21 12:00:00")
(irb):2:in `<main>': invalid value for Integer(): "2024-12-21 12:00:00" (ArgumentError)

      time = Time.utc(*args)
                      ^^^^^
```

## Steps to reproduce the problem

Run `bundle ex rubocop -a --only Rails/TimeZone` on the code below:

```ruby
Time.new("2024-12-21 12:00:00")
```

## RuboCop version

``` console
❯ rubocop -v
1.68.0
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
