### PR TITLE
Fix `Rails/FilePath` cop error on `join` method with implicit receiver

### DIFF
--- a/changelog/fix_merge_pull_request_1392_from.md
+++ b/changelog/fix_merge_pull_request_1392_from.md
@@ -1,0 +1,1 @@
+* [#1397](https://github.com/rubocop/rubocop-rails/pull/1397): Fix `Rails/FilePath` cop error on `join` method with implicit receiver. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -66,6 +66,8 @@ module RuboCop
 
         def on_send(node)
           check_for_file_join_with_rails_root(node)
+          return unless node.receiver
+
           check_for_rails_root_join_with_slash_separated_path(node)
           check_for_rails_root_join_with_string_arguments(node)
         end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -236,6 +236,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
         RUBY
       end
     end
+
+    context 'with `join` method with implicit receiver' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          join(Rails.root, path)
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is `arguments`' do
@@ -417,6 +425,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'does not register an offense for `rescue`' do
         expect_no_offenses(<<~'RUBY')
           "#{Rails.root rescue '.'}/config"
+        RUBY
+      end
+    end
+
+    context 'with `join` method with implicit receiver' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          join(Rails.root, path)
         RUBY
       end
     end


### PR DESCRIPTION
```console
echo 'join(Rails.root, path)' | rubocop --only Rails/FilePath  --stdin bug.rb -d

n error occurred while Rails/FilePath cop was inspecting bug.rb:1:0.
undefined method `each_node' for nil
lib/rubocop/cop/rails/file_path.rb:54:in `rails_root_nodes?'
lib/rubocop/cop/rails/file_path.rb:60:in `rails_root_join_nodes?'
lib/rubocop/cop/rails/file_path.rb:108:in `check_for_rails_root_join_with_string_arguments'
lib/rubocop/cop/rails/file_path.rb:70:in `on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [X] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
