### PR TITLE
Update `Rails/IndexBy` and `Rails/IndexWith` to support numbered block parameters

### DIFF
--- a/changelog/fix_index_by_index_with_numblock.md
+++ b/changelog/fix_index_by_index_with_numblock.md
@@ -1,0 +1,1 @@
+* [#1404](https://github.com/rubocop/rubocop-rails/pull/1404): Update `Rails/IndexBy` and `Rails/IndexWith` to support numbered block parameters. ([@eugeneius][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -6,7 +6,7 @@ module RuboCop
     module IndexMethod # rubocop:disable Metrics/ModuleLength
       RESTRICT_ON_SEND = %i[each_with_object to_h map collect []].freeze
 
-      def on_block(node) # rubocop:todo InternalAffairs/NumblockHandler
+      def on_block(node)
         on_bad_each_with_object(node) do |*match|
           handle_possible_offense(node, match, 'each_with_object')
         end
@@ -17,6 +17,8 @@ module RuboCop
           handle_possible_offense(node, match, 'to_h { ... }')
         end
       end
+
+      alias on_numblock on_block
 
       def on_send(node)
         on_bad_map_to_h(node) do |*match|
@@ -153,6 +155,8 @@ module RuboCop
         end
 
         def set_new_arg_name(transformed_argname, corrector)
+          return if block_node.numblock_type?
+
           corrector.replace(block_node.arguments, "|#{transformed_argname}|")
         end
 

--- a/lib/rubocop/cop/rails/index_by.rb
+++ b/lib/rubocop/cop/rails/index_by.rb
@@ -29,18 +29,28 @@ module RuboCop
         PATTERN
 
         def_node_matcher :on_bad_to_h, <<~PATTERN
-          (block
-            (call _ :to_h)
-            (args (arg $_el))
-            (array $_ (lvar _el)))
+          {
+            (block
+              (call _ :to_h)
+              (args (arg $_el))
+              (array $_ (lvar _el)))
+            (numblock
+              (call _ :to_h) $1
+              (array $_ (lvar :_1)))
+          }
         PATTERN
 
         def_node_matcher :on_bad_map_to_h, <<~PATTERN
           (call
-            (block
-              (call _ {:map :collect})
-              (args (arg $_el))
-              (array $_ (lvar _el)))
+            {
+              (block
+                (call _ {:map :collect})
+                (args (arg $_el))
+                (array $_ (lvar _el)))
+              (numblock
+                (call _ {:map :collect}) $1
+                (array $_ (lvar :_1)))
+            }
             :to_h)
         PATTERN
 
@@ -48,10 +58,16 @@ module RuboCop
           (send
             (const {nil? cbase} :Hash)
             :[]
-            (block
-              (call _ {:map :collect})
-              (args (arg $_el))
-              (array $_ (lvar _el))))
+            {
+              (block
+                (call _ {:map :collect})
+                (args (arg $_el))
+                (array $_ (lvar _el)))
+              (numblock
+                (call _ {:map :collect}) $1
+                (array $_ (lvar :_1)))
+            }
+          )
         PATTERN
 
         private

--- a/lib/rubocop/cop/rails/index_with.rb
+++ b/lib/rubocop/cop/rails/index_with.rb
@@ -32,18 +32,28 @@ module RuboCop
         PATTERN
 
         def_node_matcher :on_bad_to_h, <<~PATTERN
-          (block
-            (call _ :to_h)
-            (args (arg $_el))
-            (array (lvar _el) $_))
+          {
+            (block
+              (call _ :to_h)
+              (args (arg $_el))
+              (array (lvar _el) $_))
+            (numblock
+              (call _ :to_h) $1
+              (array (lvar :_1) $_))
+          }
         PATTERN
 
         def_node_matcher :on_bad_map_to_h, <<~PATTERN
           (call
-            (block
-              (call _ {:map :collect})
-              (args (arg $_el))
-              (array (lvar _el) $_))
+            {
+              (block
+                (call _ {:map :collect})
+                (args (arg $_el))
+                (array (lvar _el) $_))
+              (numblock
+                (call _ {:map :collect}) $1
+                (array (lvar :_1) $_))
+            }
             :to_h)
         PATTERN
 
@@ -51,10 +61,16 @@ module RuboCop
           (send
             (const {nil? cbase} :Hash)
             :[]
-            (block
-              (call _ {:map :collect})
-              (args (arg $_el))
-              (array (lvar _el) $_)))
+            {
+              (block
+                (call _ {:map :collect})
+                (args (arg $_el))
+                (array (lvar _el) $_))
+              (numblock
+                (call _ {:map :collect}) $1
+                (array (lvar :_1) $_))
+            }
+          )
         PATTERN
 
         private


### PR DESCRIPTION
Addresses one item from https://github.com/rubocop/rubocop-rails/issues/1315.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/