### PR TITLE
Fix autocorrection for `Rails/IndexWith` when the value is a hash literal without braces

### DIFF
--- a/changelog/fix_index_with_hash_literal_without_braces.md
+++ b/changelog/fix_index_with_hash_literal_without_braces.md
@@ -1,0 +1,1 @@
+* [#1405](https://github.com/rubocop/rubocop-rails/pull/1405): Fix autocorrection for `Rails/IndexWith` when the value is a hash literal without braces. ([@koic][], [@eugeneius][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -161,7 +161,10 @@ module RuboCop
         end
 
         def set_new_body_expression(transforming_body_expr, corrector)
-          corrector.replace(block_node.body, transforming_body_expr.source)
+          body_source = transforming_body_expr.source
+          body_source = "{ #{body_source} }" if transforming_body_expr.hash_type? && !transforming_body_expr.braces?
+
+          corrector.replace(block_node.body, body_source)
         end
       end
     end

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -101,6 +101,32 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       end
     end
 
+    context 'when the value is a hash literal with braces' do
+      it 'registers an offense for `to_h { ... }`' do
+        expect_offense(<<~RUBY)
+          x.map { |el| [el, { value: el }] }.to_h
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `map { ... }.to_h`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.index_with { |el| { value: el } }
+        RUBY
+      end
+    end
+
+    context 'when the value is a hash literal without braces' do
+      it 'registers an offense for `to_h { ... }`' do
+        expect_offense(<<~RUBY)
+          x.map { |el| [el, value: el] }.to_h
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `map { ... }.to_h`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.index_with { |el| { value: el } }
+        RUBY
+      end
+    end
+
     context 'when to_h is not called on the result' do
       it 'does not register an offense for `map { ... }.to_h`' do
         expect_no_offenses('x.map { |el| [el, el.to_sym] }')


### PR DESCRIPTION
Addresses another item from https://github.com/rubocop/rubocop-rails/issues/1315.

This is the same fix that was applied to `Style/HashTransformValues` in https://github.com/rubocop/rubocop/pull/9941.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/