### PR TITLE
Fix autocorrection for `Rails/IndexBy` and `Rails/IndexWith` when `map { ... }.to_h` is enclosed in another block

### DIFF
--- a/changelog/fix_index_by_index_with_enclosing_block.md
+++ b/changelog/fix_index_by_index_with_enclosing_block.md
@@ -1,0 +1,1 @@
+* [#1406](https://github.com/rubocop/rubocop-rails/pull/1406): Fix autocorrection for `Rails/IndexBy` and `Rails/IndexWith` when `map { ... }.to_h` is enclosed in another block. ([@franzliedke][], [@eugeneius][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -124,9 +124,9 @@ module RuboCop
         end
 
         def self.from_map_to_h(node, match)
-          strip_trailing_chars = 0
-
-          unless node.parent&.block_type?
+          if node.block_literal?
+            strip_trailing_chars = 0
+          else
             map_range = node.children.first.source_range
             node_range = node.source_range
             strip_trailing_chars = node_range.end_pos - map_range.end_pos

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -134,6 +134,27 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     end
   end
 
+  context 'when enclosed in another block' do
+    it 'registers an offense for `map { ... }.to_h`' do
+      expect_offense(<<~RUBY)
+        wrapping do
+          x.map do |el|
+          ^^^^^^^^^^^^^ Prefer `index_by` over `map { ... }.to_h`.
+            [el.to_sym, el]
+          end.to_h
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        wrapping do
+          x.index_by do |el|
+            el.to_sym
+          end
+        end
+      RUBY
+    end
+  end
+
   it 'registers an offense for `Hash[map { ... }]`' do
     expect_offense(<<~RUBY)
       Hash[x.map { |el| [el.to_sym, el] }]

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -107,6 +107,27 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       end
     end
 
+    context 'when enclosed in another block' do
+      it 'registers an offense for `map { ... }.to_h`' do
+        expect_offense(<<~RUBY)
+          wrapping do
+            x.map do |el|
+            ^^^^^^^^^^^^^ Prefer `index_with` over `map { ... }.to_h`.
+              [el, el.to_sym]
+            end.to_h
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          wrapping do
+            x.index_with do |el|
+              el.to_sym
+            end
+          end
+        RUBY
+      end
+    end
+
     it 'registers an offense for `Hash[map { ... }]`' do
       expect_offense(<<~RUBY)
         Hash[x.map { |el| [el, el.to_sym] }]


### PR DESCRIPTION
Related to https://github.com/rubocop/rubocop-rails/issues/1315.

While working on https://github.com/rubocop/rubocop-rails/pull/1405, I noticed another fix applied to `Style/HashTransform{Keys,Values}` that also affects `Rails/Index{By,With}` (https://github.com/rubocop/rubocop/pull/10171).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/