### PR TITLE
Fix an error for `Rails/ReversibleMigration` when calling `drop_table` without any arguments

### DIFF
--- a/changelog/fix_error_reversible_migration.md
+++ b/changelog/fix_error_reversible_migration.md
@@ -1,0 +1,1 @@
+* [#1409](https://github.com/rubocop/rubocop-rails/pull/1409): Fix an error for `Rails/ReversibleMigration` when calling `drop_table` without any arguments. ([@earlopain][])

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -215,8 +215,10 @@ module RuboCop
         end
 
         def check_drop_table_node(node)
+          return unless (last_argument = node.last_argument)
+
           drop_table_call(node) do
-            unless node.parent.block_type? || node.last_argument.block_pass_type?
+            unless node.parent.block_type? || last_argument.block_pass_type?
               add_offense(node, message: format(MSG, action: 'drop_table(without block)'))
             end
           end

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -121,6 +121,10 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     it_behaves_like 'offense', 'drop_table(without block)', <<~RUBY
       drop_table :users
     RUBY
+
+    it_behaves_like 'accepts', 'drop_table(without arguments)', <<~RUBY
+      drop_table
+    RUBY
   end
 
   context 'change_column' do


### PR DESCRIPTION
As it happens when you type it

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
