### PR TITLE
[Fix #1410] Make registered cops aware of `AllCops: MigratedSchemaVersion`

### DIFF
--- a/changelog/change_make_registered_cops_aware_of_all_cops_migrated_schema_version.md
+++ b/changelog/change_make_registered_cops_aware_of_all_cops_migrated_schema_version.md
@@ -1,0 +1,1 @@
+* [#1410](https://github.com/rubocop/rubocop-rails/issues/1410): Make registered cops aware of `AllCops: MigratedSchemaVersion`. ([@koic][])

--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -15,6 +15,9 @@ RuboCop::Rails::Inject.defaults!
 
 require_relative 'rubocop/cop/rails_cops'
 
+require_relative 'rubocop/rails/migration_file_skippable'
+RuboCop::Rails::MigrationFileSkippable.apply_to_cops!
+
 RuboCop::Cop::Style::HashExcept.minimum_target_ruby_version(2.0)
 
 RuboCop::Cop::Style::InverseMethods.singleton_class.prepend(

--- a/lib/rubocop/cop/mixin/migrations_helper.rb
+++ b/lib/rubocop/cop/mixin/migrations_helper.rb
@@ -21,35 +21,6 @@ module RuboCop
           migration_class?(class_node)
         end
       end
-
-      # rubocop:disable Style/DocumentDynamicEvalDefinition
-      %i[on_send on_csend on_block on_numblock on_class].each do |method|
-        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          def #{method}(node)
-            return if already_migrated_file?
-
-            super if method(__method__).super_method
-          end
-        RUBY
-      end
-      # rubocop:enable Style/DocumentDynamicEvalDefinition
-
-      private
-
-      def already_migrated_file?
-        return false unless migrated_schema_version
-
-        match_data = File.basename(processed_source.file_path).match(/(?<timestamp>\d{14})/)
-        schema_version = match_data['timestamp'] if match_data
-
-        return false unless schema_version
-
-        schema_version <= migrated_schema_version.to_s # Ignore applied migration files.
-      end
-
-      def migrated_schema_version
-        config.for_all_cops.fetch('MigratedSchemaVersion', nil)
-      end
     end
   end
 end

--- a/lib/rubocop/cop/rails/add_column_index.rb
+++ b/lib/rubocop/cop/rails/add_column_index.rb
@@ -19,7 +19,7 @@ module RuboCop
       class AddColumnIndex < Base
         extend AutoCorrector
         include RangeHelp
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG = '`add_column` does not accept an `index` key, use `add_index` instead.'
         RESTRICT_ON_SEND = %i[add_column].freeze

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -65,7 +65,7 @@ module RuboCop
       #   end
       class BulkChangeTable < Base
         include DatabaseTypeResolvable
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG_FOR_CHANGE_TABLE = <<~MSG.chomp
           You can combine alter queries using `bulk: true` options.

--- a/lib/rubocop/cop/rails/dangerous_column_names.rb
+++ b/lib/rubocop/cop/rails/dangerous_column_names.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   add_column :users, :saved
       class DangerousColumnNames < Base # rubocop:disable Metrics/ClassLength
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         COLUMN_TYPE_METHOD_NAMES = %i[
           bigint

--- a/lib/rubocop/cop/rails/migration_class_name.rb
+++ b/lib/rubocop/cop/rails/migration_class_name.rb
@@ -20,7 +20,7 @@ module RuboCop
       #
       class MigrationClassName < Base
         extend AutoCorrector
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG = 'Replace with `%<camelized_basename>s` that matches the file name.'
 

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -41,7 +41,7 @@ module RuboCop
       #   change_column_null :products, :category_id, false
       class NotNullColumn < Base
         include DatabaseTypeResolvable
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG = 'Do not add a NOT NULL column without a default value.'
         RESTRICT_ON_SEND = %i[add_column add_reference].freeze

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -151,7 +151,7 @@ module RuboCop
       #     remove_index :users, column: :email
       #   end
       class ReversibleMigration < Base
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG = '%<action>s is not reversible.'
 

--- a/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
+++ b/lib/rubocop/cop/rails/reversible_migration_method_definition.rb
@@ -43,7 +43,7 @@ module RuboCop
       #     end
       #   end
       class ReversibleMigrationMethodDefinition < Base
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG = 'Migrations must contain either a `change` method, or both an `up` and a `down` method.'
 

--- a/lib/rubocop/cop/rails/schema_comment.rb
+++ b/lib/rubocop/cop/rails/schema_comment.rb
@@ -23,7 +23,7 @@ module RuboCop
       #
       class SchemaComment < Base
         include ActiveRecordMigrationsHelper
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         COLUMN_MSG = 'New database column without `comment`.'
         TABLE_MSG = 'New database table without `comment`.'

--- a/lib/rubocop/cop/rails/three_state_boolean_column.rb
+++ b/lib/rubocop/cop/rails/three_state_boolean_column.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   t.boolean :active, default: true, null: false
       #
       class ThreeStateBooleanColumn < Base
-        prepend MigrationsHelper
+        include MigrationsHelper
 
         MSG = 'Boolean columns should always have a default value and a `NOT NULL` constraint.'
         RESTRICT_ON_SEND = %i[add_column column boolean].freeze

--- a/lib/rubocop/rails/migration_file_skippable.rb
+++ b/lib/rubocop/rails/migration_file_skippable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Rails
+    # This module allows cops to detect and ignore files that have already been migrated
+    # by leveraging the `AllCops: MigratedSchemaVersion` configuration.
+    #
+    # [source,yaml]
+    # -----
+    # AllCops:
+    #   MigratedSchemaVersion: '20241225000000'
+    # -----
+    #
+    # When applied to cops, it overrides the `add_global_offense` and `add_offense` methods,
+    # ensuring that cops skip processing if the file is determined to be a migrated file
+    # based on the schema version.
+    #
+    # @api private
+    module MigrationFileSkippable
+      def add_global_offense(message = nil, severity: nil)
+        return if already_migrated_file?
+
+        super if method(__method__).super_method
+      end
+
+      def add_offense(node_or_range, message: nil, severity: nil, &block)
+        return if already_migrated_file?
+
+        super if method(__method__).super_method
+      end
+
+      def self.apply_to_cops!
+        RuboCop::Cop::Registry.all.each { |cop| cop.prepend(MigrationFileSkippable) }
+      end
+
+      private
+
+      def already_migrated_file?
+        return false unless migrated_schema_version
+
+        match_data = File.basename(processed_source.file_path).match(/(?<timestamp>\d{14})/)
+        schema_version = match_data['timestamp'] if match_data
+
+        return false unless schema_version
+
+        schema_version <= migrated_schema_version.to_s # Ignore applied migration files.
+      end
+
+      def migrated_schema_version
+        @migrated_schema_version ||= config.for_all_cops.fetch('MigratedSchemaVersion', nil)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -441,4 +441,16 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
       end
     RUBY
   end
+
+  context 'when inspection file that have already been migrated' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'MigratedSchemaVersion' => '20240101010101' })
+    end
+
+    it 'does not register an offense and corrects when `a.present? ? a : nil`' do
+      expect_no_offenses(<<~RUBY, '20190101010101_add_column_to_table.rb')
+        a.present? ? a : nil
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
When implementing #1383, the detection of `AllCops: MigratedSchemaVersion` was initially considered only for cops related to migrations.

However, feedback received later, such as in #1410, indicated that it is also expected to apply to `Style`, `Lint`, and other categories. This suggestion is reasonable, as warnings for migrated files may not be limited to database columns but could also include Ruby programming logic. Excluding `Style` and `Lint` from this consideration would not align with this feedback.

This PR modifies the behavior so that all registered cops can detect the value of `AllCops: MigratedSchemaVersion`.

Fixes #1410.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
