### PR TITLE
Fix `Rails/HttpPositionalArguments` cop false positives with arguments forwarding

### DIFF
--- a/changelog/fix_rails_http_positional_arguments_cop_false_positivies_with_arguments_forwarding.md
+++ b/changelog/fix_rails_http_positional_arguments_cop_false_positivies_with_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#1414](https://github.com/rubocop/rubocop-rails/pull/1414): Fix `Rails/HttpPositionalArguments` cop false positives with arguments forwarding. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -40,6 +40,10 @@ module RuboCop
           (hash (kwsplat _))
         PATTERN
 
+        def_node_matcher :forwarded_kwrestarg?, <<~PATTERN
+          (hash (forwarded-kwrestarg))
+        PATTERN
+
         def_node_matcher :include_rack_test_methods?, <<~PATTERN
           (send nil? :include
             (const
@@ -83,7 +87,9 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def needs_conversion?(data)
+          return false if data.forwarded_args_type? || forwarded_kwrestarg?(data)
           return true unless data.hash_type?
           return false if kwsplat_hash?(data)
 
@@ -91,6 +97,7 @@ module RuboCop
             special_keyword_arg?(pair.key) || (format_arg?(pair.key) && data.pairs.one?)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def special_keyword_arg?(node)
           node.sym_type? && KEYWORD_ARGS.include?(node.value)

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -432,6 +432,30 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments, :config do
       RUBY
     end
 
+    it 'does not register an offese for arguments forwaring' do
+      expect_no_offenses(<<~RUBY)
+        def perform_request(...)
+          get(:list, ...)
+        end
+      RUBY
+    end
+
+    it 'does not register an offese for keyword arguments forwaring' do
+      expect_no_offenses(<<~RUBY)
+        def perform_request(**options)
+          get(:list, **options)
+        end
+      RUBY
+    end
+
+    it 'does not register an offese for anonymous keyword arguments forwaring', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def perform_request(**)
+          get(:list, **)
+        end
+      RUBY
+    end
+
     context 'when using `include Rack::Test::Methods`' do
       it 'does not register an offense for get method' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Prior to these changes, these examples would be marked as offenses:

```ruby
# ruby >=3.2
def perform_request(**)
  get(:list, **)
end
```

```ruby
# ruby >=2.7
def perform_request(...)
  get(:list, ...)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
