### PR TITLE
[Fix #1389] Handle `TypeError` caused by passing array literals as arguments to `File` methods in `Rails/FilePath` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 163
+  Max: 179
 
 # Offense count: 41
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/changelog/fix_rails_file_path_to_handle_type_error_caused_by_an_array.md
+++ b/changelog/fix_rails_file_path_to_handle_type_error_caused_by_an_array.md
@@ -1,0 +1,1 @@
+* [#1389](https://github.com/rubocop/rubocop-rails/issues/1389): Handle `TypeError` caused by passing array literals as arguments to `File` methods in `Rails/FilePath` cop. ([@ydakuka][])

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -244,6 +244,84 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
         RUBY
       end
     end
+
+    context 'when using only [] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, ['app', 'models'])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*['app', 'models']).to_s
+        RUBY
+      end
+    end
+
+    context 'with a leading string and an array using [] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, "app", ["models", "goober"])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join("app", *["models", "goober"]).to_s
+        RUBY
+      end
+    end
+
+    context 'with an array using [] syntax and a trailing string' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, ["app", "models"], "goober")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*["app", "models"], "goober").to_s
+        RUBY
+      end
+    end
+
+    context 'when using only %w[] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, %w[app models])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*%w[app models]).to_s
+        RUBY
+      end
+    end
+
+    context 'with a leading string and an array using %w[] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, "app", %w[models goober])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join("app", *%w[models goober]).to_s
+        RUBY
+      end
+    end
+
+    context 'with an array using %w[] syntax and a trailing string' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, %w[app models], "goober")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*%w[app models], "goober").to_s
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is `arguments`' do
@@ -433,6 +511,84 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           join(Rails.root, path)
+        RUBY
+      end
+    end
+
+    context 'when using only [] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, ['app', 'models'])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*['app', 'models']).to_s
+        RUBY
+      end
+    end
+
+    context 'with a leading string and an array using [] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, "app", ["models", "goober"])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join("app", *["models", "goober"]).to_s
+        RUBY
+      end
+    end
+
+    context 'with an array using [] syntax and a trailing string' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, ["app", "models"], "goober")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*["app", "models"], "goober").to_s
+        RUBY
+      end
+    end
+
+    context 'when using only %w[] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, %w[app models])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*%w[app models]).to_s
+        RUBY
+      end
+    end
+
+    context 'with a leading string and an array using %w[] syntax' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, "app", %w[models goober])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join("app", *%w[models goober]).to_s
+        RUBY
+      end
+    end
+
+    context 'with an array using %w[] syntax and a trailing string' do
+      it 'registers an offense once' do
+        expect_offense(<<~RUBY)
+          File.join(Rails.root, %w[app models], "goober")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.root.join(*%w[app models], "goober").to_s
         RUBY
       end
     end


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop-rails/issues/1389

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
