### PR TITLE
[Fix #1389] Handle `TypeError` caused by passing array literals as arguments to `File` methods in `Rails/RootPathnameMethods` cop

### DIFF
--- a/changelog/fix_rails_root_pathname_to_handle_type_error_caused_by_an_array.md
+++ b/changelog/fix_rails_root_pathname_to_handle_type_error_caused_by_an_array.md
@@ -1,0 +1,1 @@
+* [#1389](https://github.com/rubocop/rubocop-rails/issues/1389): Handle `TypeError` caused by passing array literals as arguments to `File` methods in `Rails/RootPathnameMethods` cop. ([@ydakuka][])

--- a/lib/rubocop/cop/rails/root_pathname_methods.rb
+++ b/lib/rubocop/cop/rails/root_pathname_methods.rb
@@ -237,7 +237,12 @@ module RuboCop
           end
 
           replacement = "#{path_replacement}.#{method}"
-          replacement += "(#{args.map(&:source).join(', ')})" unless args.empty?
+
+          if args.any?
+            formatted_args = args.map { |arg| arg.array_type? ? "*#{arg.source}" : arg.source }
+            replacement += "(#{formatted_args.join(', ')})"
+          end
+
           replacement
         end
 

--- a/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
+++ b/spec/rubocop/cop/rails/root_pathname_methods_spec.rb
@@ -210,4 +210,70 @@ RSpec.describe RuboCop::Cop::Rails::RootPathnameMethods, :config do
       file = Rails.root.join('docs', 'invoice.pdf').open
     RUBY
   end
+
+  it 'registers an offense when using only [] syntax' do
+    expect_offense(<<~RUBY)
+      File.join(Rails.root, ['app', 'models'])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join(*['app', 'models'])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.root.join(*['app', 'models'])
+    RUBY
+  end
+
+  it 'registers an offense when using a leading string and an array using [] syntax' do
+    expect_offense(<<~RUBY)
+      File.join(Rails.root, "app", ["models", "goober"])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join("app", *["models", "goober"])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.root.join("app", *["models", "goober"])
+    RUBY
+  end
+
+  it 'registers an offense when using an array using [] syntax and a trailing string' do
+    expect_offense(<<~RUBY)
+      File.join(Rails.root, ["app", "models"], "goober")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join(*["app", "models"], "goober")`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.root.join(*["app", "models"], "goober")
+    RUBY
+  end
+
+  it 'registers an offense when using only %w[] syntax' do
+    expect_offense(<<~RUBY)
+      File.join(Rails.root, %w[app models])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join(*%w[app models])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.root.join(*%w[app models])
+    RUBY
+  end
+
+  it 'registers an offense when using a leading string and an array using %w[] syntax' do
+    expect_offense(<<~RUBY)
+      File.join(Rails.root, "app", %w[models goober])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join("app", *%w[models goober])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.root.join("app", *%w[models goober])
+    RUBY
+  end
+
+  it 'registers an offense when using an array using %w[] syntax and a trailing string' do
+    expect_offense(<<~RUBY)
+      File.join(Rails.root, %w[app models], "goober")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rails.root` is a `Pathname`, so you can use `Rails.root.join(*%w[app models], "goober")`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.root.join(*%w[app models], "goober")
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop-rails/issues/1389

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
