### PR TITLE
[Fix #1356] Enhance `Rails/DuplicateAssociation` to handle alias

### DIFF
--- a/changelog/fix_rails_duplicate_association_to_handle_alias.md
+++ b/changelog/fix_rails_duplicate_association_to_handle_alias.md
@@ -1,0 +1,1 @@
+* [#1356](https://github.com/rubocop/rubocop-rails/issues/1356): Enhance `Rails/DuplicateAssociation` to handle alias. ([@ydakuka][])

--- a/lib/rubocop/cop/rails/duplicate_association.rb
+++ b/lib/rubocop/cop/rails/duplicate_association.rb
@@ -63,11 +63,15 @@ module RuboCop
         private
 
         def register_offense(name, nodes, message_template)
-          nodes.each do |node|
-            add_offense(node, message: format(message_template, name: name)) do |corrector|
-              next if same_line?(nodes.last, node)
+          last_node = nodes.last
 
-              corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
+          nodes.each_with_index do |node, index|
+            add_offense(node, message: format(message_template, name: name)) do |corrector|
+              if index.zero?
+                corrector.replace(node, last_node.source)
+              else
+                corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
+              end
             end
           end
         end

--- a/spec/rubocop/cop/rails/duplicate_association_spec.rb
+++ b/spec/rubocop/cop/rails/duplicate_association_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          belongs_to :bar
           belongs_to :foo
+          belongs_to :bar
           belongs_to :blah
         end
       RUBY
@@ -37,8 +37,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          belongs_to :bar
           belongs_to :foo, -> { active }
+          belongs_to :bar
           belongs_to :blah
         end
       RUBY
@@ -60,8 +60,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_many :bars
           has_many :foos
+          has_many :bars
           has_many :blahs
         end
       RUBY
@@ -81,9 +81,28 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_many :bars
           has_many 'foos', -> { active }
+          has_many :bars
           has_many :blahs
+        end
+      RUBY
+    end
+
+    it 'registers an offense with alias' do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          belongs_to :foos, -> { active }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Association `foos` is defined multiple times. Don't repeat associations.
+          alias bars foos
+          belongs_to :foos
+          ^^^^^^^^^^^^^^^^ Association `foos` is defined multiple times. Don't repeat associations.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Post < ApplicationRecord
+          belongs_to :foos
+          alias bars foos
         end
       RUBY
     end
@@ -104,8 +123,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_one :bar
           has_one :foo
+          has_one :bar
           has_one :blah
         end
       RUBY
@@ -125,8 +144,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_one :bar
           has_one :foo, -> { active }
+          has_one :bar
           has_one :blah
         end
       RUBY
@@ -148,8 +167,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_and_belongs_to_many :bars
           has_and_belongs_to_many :foos
+          has_and_belongs_to_many :bars
           has_and_belongs_to_many :blahs
         end
       RUBY
@@ -169,8 +188,8 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_and_belongs_to_many :bars
           has_and_belongs_to_many :foos, -> { active }
+          has_and_belongs_to_many :bars
           has_and_belongs_to_many :blahs
         end
       RUBY
@@ -200,12 +219,12 @@ RSpec.describe RuboCop::Cop::Rails::DuplicateAssociation, :config do
 
       expect_correction(<<~RUBY)
         class Post < ApplicationRecord
-          has_and_belongs_to_many :bars
           has_and_belongs_to_many :foos, -> { active }
+          has_and_belongs_to_many :bars
           has_and_belongs_to_many :blahs
 
-          has_one :top_comment, -> { order(likes: :desc) }, class_name: 'Comment'
           belongs_to :author
+          has_one :top_comment, -> { order(likes: :desc) }, class_name: 'Comment'
         end
       RUBY
     end


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop-rails/issues/1356

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
