### PR TITLE
[Fix #1417] Fix an incorrect autocorrect for `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_strong_parameters_expect.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_strong_parameters_expect.md
@@ -1,0 +1,1 @@
+* [#1417](https://github.com/rubocop/rubocop-rails/issues/1417): Fix an incorrect autocorrect for `Rails/StrongParametersExpect` when using a leading dot multiline call to `require` with `permit`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -59,7 +59,7 @@ module RuboCop
           end
 
           add_offense(range, message: format(MSG, prefer: prefer)) do |corrector|
-            corrector.remove(require_method.loc.dot.join(require_method.source_range.end))
+            corrector.remove(require_method.receiver.source_range.end.join(require_method.source_range.end))
             corrector.replace(permit_method.loc.selector, 'expect')
             if replace_argument
               corrector.insert_before(permit_method.first_argument, "#{require_key(require_method)}[")

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -98,6 +98,20 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'registers an offense when using a leading dot multiline call to `params.require(:user).permit(:name, :age)`' do
+      expect_offense(<<~RUBY)
+        params
+          .require(:user)
+           ^^^^^^^^^^^^^^ Use `expect(user: [:name, :age])` instead.
+          .permit(:name, :age)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        params
+          .expect(user: [:name, :age])
+      RUBY
+    end
+
     it 'does not register an offense when using `params.expect(user: [:name, :age])`' do
       expect_no_offenses(<<~RUBY)
         params.expect(user: [:name, :age])


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Rails/StrongParametersExpect` when using a leading dot multiline call to `params.require(:user).permit(:name, :age)`.

Fixes #1417.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
