### PR TITLE
[Fix #1423] Fix an error for `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_an_error_for_rails_strong_parameters_expect.md
+++ b/changelog/fix_an_error_for_rails_strong_parameters_expect.md
@@ -1,0 +1,1 @@
+* [#1423](https://github.com/rubocop/rubocop-rails/issues/1423): Fix an error for `Rails/StrongParametersExpect` when using `permit` with no arguments. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -32,7 +32,7 @@ module RuboCop
         def_node_matcher :params_require_permit, <<~PATTERN
           $(call
             $(call
-              (send nil? :params) :require _) :permit ...)
+              (send nil? :params) :require _) :permit _+)
         PATTERN
 
         def_node_matcher :params_permit_require, <<~PATTERN

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -136,6 +136,12 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `params.require(:target).permit`' do
+      expect_no_offenses(<<~RUBY)
+        params.require(:target).permit
+      RUBY
+    end
+
     it 'does not register an offense when using `params[:name]`' do
       expect_no_offenses(<<~RUBY)
         params[:name]


### PR DESCRIPTION
This PR fixes an error for `Rails/StrongParametersExpect` when using `permit` with no arguments.

Fixes #1423.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
