### PR TITLE
[Fix #1427] Fix an error for `Rails/UniqBeforePluck` with multi-line expression

### DIFF
--- a/changelog/fix_wrong_autocorrect_rails_pluck_uniq.md
+++ b/changelog/fix_wrong_autocorrect_rails_pluck_uniq.md
@@ -1,0 +1,1 @@
+* [#1427](https://github.com/rubocop/rubocop-rails/issues/1427): Fix an error for `Rails/UniqBeforePluck` when `pluck` and `unique` are on different lines. ([@earlopain][])

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
       RUBY
     end
 
+    it 'corrects when uniq and pluck are on different lines' do
+      expect_offense(<<~RUBY)
+        Model
+          .pluck(:name)
+          .uniq
+           ^^^^ Use `distinct` before `pluck`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Model
+          .distinct.pluck(:name)
+      RUBY
+    end
+
     it 'ignores uniq before pluck' do
       expect_no_offenses(<<~RUBY)
         Model.where(foo: 1).uniq.pluck(:something)
@@ -83,6 +97,12 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
     it 'ignores uniq on an association' do
       expect_no_offenses(<<~RUBY)
         instance.assoc.pluck(:name).uniq
+      RUBY
+    end
+
+    it 'ignores uniq without an receiver' do
+      expect_no_offenses(<<~RUBY)
+        pluck(:name).uniq
       RUBY
     end
   end


### PR DESCRIPTION
This introduces a bit of whitespace when the expression spans multiple lines, but that seesm fine. Layout cops can take care of that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
