### PR TITLE
Use node groups in node patterns to replace unions of types

### DIFF
--- a/lib/rubocop/cop/rails/belongs_to.rb
+++ b/lib/rubocop/cop/rails/belongs_to.rb
@@ -66,7 +66,7 @@ module RuboCop
 
         def_node_matcher :match_belongs_to_with_options, <<~PATTERN
           (send _ :belongs_to ...
-            (hash <$(pair (sym :required) ${true false}) ...>)
+            (hash <$(pair (sym :required) $boolean) ...>)
           )
         PATTERN
 

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -61,7 +61,7 @@ module RuboCop
         def_node_matcher :good_touch?, <<~PATTERN
           {
             (send (const {nil? cbase} :FileUtils) :touch ...)
-            (send _ :touch {true false})
+            (send _ :touch boolean)
           }
         PATTERN
 


### PR DESCRIPTION
`rubocop-ast` defines some node groups (https://github.com/rubocop/rubocop-ast/blob/85bfe84/lib/rubocop/ast/node.rb#L89-L116) that can be used in place of a union of node types.