### PR TITLE
[Fix #1071] Fix `Rails/FilePath` cop to correctly handle `File.join` with variables and ignore leading and multiple slashes in string literal arguments for `Rails.root.join` and `File.join`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,9 @@ InternalAffairs/OnSendWithoutOnCSend:
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 179
+  Max: 163
+  Exclude:
+    - 'lib/rubocop/cop/rails/file_path.rb'
 
 # Offense count: 41
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/changelog/fix_an_error_occurring_in_the_rails_file_path_cop_when_file_join_is_used_with_a_variable.md
+++ b/changelog/fix_an_error_occurring_in_the_rails_file_path_cop_when_file_join_is_used_with_a_variable.md
@@ -1,0 +1,1 @@
+* [#1071](https://github.com/rubocop/rubocop-rails/issues/1071): Fix `Rails/FilePath` cop to correctly handle `File.join` with variables and ignore leading and multiple slashes in string literal arguments for `Rails.root.join` and `File.join`. ([@ydakuka][])

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -322,6 +322,128 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
         RUBY
       end
     end
+
+    context 'when using File.join with a local variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          default_path = '/models'
+          File.join(Rails.root, 'app', default_path)
+        RUBY
+      end
+    end
+
+    context 'when using File.join with an instance variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app', @default_path)
+        RUBY
+      end
+    end
+
+    context 'when using File.join with a class variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app', @@default_path)
+        RUBY
+      end
+    end
+
+    context 'when using File.join with a global variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app', $default_path)
+        RUBY
+      end
+    end
+
+    context 'when using File.join with a constant' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app', DEFAULT_PATH)
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with a local variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          default_path = '/models'
+          Rails.root.join(Rails.root, 'app', default_path)
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with an instance variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app', @default_path)
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with a class variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app', @@default_path)
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with a global variable' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app', $default_path)
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with a constant' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app', DEFAULT_PATH)
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with a leading slash' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('/app/models')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with mixed leading and normal path strings' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('/app', 'models')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with mixed normal and leading path strings' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app', '/models')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with multiple slashes in a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('public//', 'assets')
+        RUBY
+      end
+    end
+
+    context 'when using File.join with multiple slashes in a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'public//', 'assets')
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is `arguments`' do
@@ -589,6 +711,46 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
         expect_correction(<<~RUBY)
           Rails.root.join(*%w[app models], "goober").to_s
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with a leading slash' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('/app/models')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with mixed leading and normal path strings' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('/app', 'models')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with mixed normal and leading path strings' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app', '/models')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with multiple slashes in a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('public//', 'assets')
+        RUBY
+      end
+    end
+
+    context 'when using File.join with multiple slashes in a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'public//', 'assets')
         RUBY
       end
     end


### PR DESCRIPTION
Fix #1071

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.