### PR TITLE
[Fix rubocop#1177] Enhance `Rails/FilePath` to properly handle trailing slashes

### DIFF
--- a/changelog/fix_rails_file_path_to_properly_handle_trailing_slashes.md
+++ b/changelog/fix_rails_file_path_to_properly_handle_trailing_slashes.md
@@ -1,0 +1,1 @@
+* [#1177](https://github.com/rubocop/rubocop-rails/issues/1177): Enhance `Rails/FilePath` to properly handle trailing slashes. ([@ydakuka][])

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -140,6 +140,123 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when using File.join with Rails.root and a single forward slash as a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, "/")
+        RUBY
+      end
+    end
+
+    context 'when using File.join with Rails.root and a single forward slash as the last argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app', '/')
+        RUBY
+      end
+    end
+
+    context 'when using File.join with Rails.root and multiple string paths with different trailing slash placements' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models/', 'goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models/', '/goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models', 'goober/')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models/', 'goober/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join and a single forward slash as a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join("/")
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join and a single forward slash as the last argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app', '/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join and multiple string paths with different trailing slash placements' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models/', 'goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models/', '/goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models', 'goober/')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models/', 'goober/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with Rails.root and a single forward slash as a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, "/")
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with Rails.root and a single forward slash as the last argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app', '/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with Rails.root and multiple string paths ' \
+            'with different trailing slash placements' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models/', 'goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models/', '/goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models', 'goober/')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models/', 'goober/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root in string interpolation followed by a forward slash' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          "#{Rails.root}/"
+        RUBY
+      end
+    end
+
     context 'when using Rails.root called by double quoted string' do
       it 'registers an offense' do
         expect_offense(<<~'RUBY')
@@ -522,6 +639,123 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
         expect_correction(<<~RUBY)
           Rails.root.join('app', "models", "goober")
+        RUBY
+      end
+    end
+
+    context 'when using File.join with Rails.root and a single forward slash as a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, "/")
+        RUBY
+      end
+    end
+
+    context 'when using File.join with Rails.root and a single forward slash as the last argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app', '/')
+        RUBY
+      end
+    end
+
+    context 'when using File.join with Rails.root and multiple string paths with different trailing slash placements' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models/', 'goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models/', '/goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models', 'goober/')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          File.join(Rails.root, 'app/models/', 'goober/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join and a single forward slash as a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join("/")
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join and a single forward slash as the last argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app', '/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join and multiple string paths with different trailing slash placements' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models/', 'goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models/', '/goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models', 'goober/')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join('app/models/', 'goober/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with Rails.root and a single forward slash as a path' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, "/")
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with Rails.root and a single forward slash as the last argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app', '/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join with Rails.root and multiple string paths ' \
+            'with different trailing slash placements' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models/', 'goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models/', '/goober')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models', 'goober/')
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          Rails.root.join(Rails.root, 'app/models/', 'goober/')
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root in string interpolation followed by a forward slash' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          "#{Rails.root}/"
         RUBY
       end
     end


### PR DESCRIPTION
Fix #1177

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.