### PR TITLE
[Fix #912] Enhance `Rails/Delegate` by adding delegation detection for `self.class`, constants, instance variables, and class variables

### DIFF
--- a/changelog/fix_rails_delegate_to_handle_self_class_constants_instance_variables_and_class_variables.md
+++ b/changelog/fix_rails_delegate_to_handle_self_class_constants_instance_variables_and_class_variables.md
@@ -1,0 +1,1 @@
+* [#912](https://github.com/rubocop/rubocop-rails/issues/912): Enhance `Rails/Delegate` by adding delegation detection for `self.class`, constants, class variables, global variables, and instance variables. ([@ydakuka][])


### PR DESCRIPTION
Fix #912

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.