### PR TITLE
Fix an error for `Rails/Delegate`

### DIFF
--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -110,9 +110,12 @@ module RuboCop
         end
 
         def full_const_name(node)
-          return node.source unless node.namespace
+          return unless node.const_type?
+          unless node.namespace
+            return node.absolute? ? "::#{node.source}" : node.source
+          end
 
-          "#{full_const_name(node.namespace)}::#{node.children.last}"
+          "#{full_const_name(node.namespace)}::#{node.short_name}"
         end
 
         def trivial_delegate?(def_node)

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -280,6 +280,19 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
     RUBY
   end
 
+  it 'detects delegation to a cbase namespaced constant' do
+    expect_offense(<<~RUBY)
+      def foo
+      ^^^ Use `delegate` to define delegations.
+        ::SomeModule::CONST.foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      delegate :foo, to: :'::SomeModule::CONST'
+    RUBY
+  end
+
   it 'detects delegation to an instance variable' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes the following error for `Rails/Delegate` when delegation to a cbase namespaced constant.

```console
  1) RuboCop::Cop::Rails::Delegate detects delegation to a cbase namespaced constant
     Failure/Error: return node.source unless node.namespace

     NoMethodError:
       undefined method 'namespace' for an instance of RuboCop::AST::Node
     # ./lib/rubocop/cop/rails/delegate.rb:113:in 'RuboCop::Cop::Rails::Delegate#full_const_name'
     # ./lib/rubocop/cop/rails/delegate.rb:115:in 'RuboCop::Cop::Rails::Delegate#full_const_name'
     # ./lib/rubocop/cop/rails/delegate.rb:115:in 'RuboCop::Cop::Rails::Delegate#full_const_name'
```

Follow-up to https://github.com/rubocop/rubocop-rails/pull/1438.

There is no changelog entry since this is a bug fix for the above PR that has not been released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
