### PR TITLE
Fix an incorrect behavior when using `AllCops: MigratedSchemaVersion`

### DIFF
--- a/changelog/fix_an_incorrect_behavior_when_using_migrated_schema_version.md
+++ b/changelog/fix_an_incorrect_behavior_when_using_migrated_schema_version.md
@@ -1,0 +1,1 @@
+* [#1444](https://github.com/rubocop/rubocop-rails/pull/1444): Fix an incorrect behavior when using `AllCops: MigratedSchemaVersion`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -28,7 +28,7 @@ AllCops:
   # By specifying `MigratedSchemaVersion` option, migration files that have been migrated can be ignored.
   # When `MigratedSchemaVersion: '20241231000000'` is set. Migration files lower than or equal to '20250101000000' will be ignored.
   # For example, this is the timestamp in db/migrate/20250101000000_create_articles.rb.
-  MigratedSchemaVersion: ~
+  MigratedSchemaVersion: '19700101000000' # NOTE: Used as a sentinel value for the UNIX epoch time.
 
 Lint/NumberConversion:
   # Add Rails' duration methods to the ignore list for `Lint/NumberConversion`


### PR DESCRIPTION
This PR fixes an incorrect behavior when using `AllCops: MigratedSchemaVersion`.

This suppresses the following warning when `MigratedSchemaVersion` is defined on the user side:

```console
$ bundle exec rubocop
(snip)

Warning: AllCops does not support MigratedSchemaVersion parameter.

Supported parameters are:

  - RubyInterpreters
  - Include
  - Exclude
  - DefaultFormatter
  - DisplayCopNames
  - DisplayStyleGuide
  - StyleGuideBaseURL
  - DocumentationBaseURL
  - DocumentationExtension
  - ExtraDetails
  - StyleGuideCopsOnly
  - EnabledByDefault
  - DisabledByDefault
  - NewCops
  - UseCache
  - MaxFilesInCache
  - CacheRootDirectory
  - AllowSymlinksInCacheRootDirectory
  - TargetRubyVersion
  - ParserEngine
  - SuggestExtensions
  - ActiveSupportExtensionsEnabled
  - StringLiteralsFrozenByDefault
```

The default value of `AllCops: MigratedSchemaVersion` in `config/default.yml` will change from `null` to the UNIX epoch time, but typically, there should be no migration files older than the UNIX epoch time.

This is a bug fix related to the plugin migration in https://github.com/rubocop/rubocop-rails/pull/1434.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
