### PR TITLE
[Fix #1442] Fix an incorrect behavior when using `AllCops: TargetRailsVersion`

### DIFF
--- a/changelog/fix_an_error_when_using_target_rails_version.md
+++ b/changelog/fix_an_error_when_using_target_rails_version.md
@@ -1,0 +1,1 @@
+* [#1442](https://github.com/rubocop/rubocop-rails/issues/1442): Fix an incorrect behavior when using `AllCops: TargetRailsVersion`. ([@koic][])

--- a/lib/rubocop/rails/plugin.rb
+++ b/lib/rubocop/rails/plugin.rb
@@ -24,7 +24,24 @@ module RuboCop
 
         ConfigObsoletion.files << project_root.join('config', 'obsoletion.yml')
 
+        # FIXME: This is a dirty hack relying on a private constant to prevent
+        # "Warning: AllCops does not support TargetRailsVersion parameter".
+        # It should be updated to a better design in the future.
+        without_warnings do
+          ConfigValidator.const_set(:COMMON_PARAMS, ConfigValidator::COMMON_PARAMS.dup << 'TargetRailsVersion')
+        end
+
         LintRoller::Rules.new(type: :path, config_format: :rubocop, value: project_root.join('config', 'default.yml'))
+      end
+
+      private
+
+      def without_warnings
+        original_verbose = $VERBOSE
+        $VERBOSE = nil
+        yield
+      ensure
+        $VERBOSE = original_verbose
       end
     end
   end


### PR DESCRIPTION
This PR fixes an incorrect behavior when using `AllCops: TargetRailsVersion`.

This suppresses the following warning when `TargetRailsVersion` is defined on the user side:

```console
$ bundle exec rubocop
(snip)

Warning: AllCops does not support TargetRailsVersion parameter.

Supported parameters are:

  - RubyInterpreters
  - Include
  - Exclude
  - DefaultFormatter
  - DisplayCopNames
  - DisplayStyleGuide
  - StyleGuideBaseURL
  - DocumentationBaseURL
  - DocumentationExtension
  - ExtraDetails
  - StyleGuideCopsOnly
  - EnabledByDefault
  - DisabledByDefault
  - NewCops
  - UseCache
  - MaxFilesInCache
  - CacheRootDirectory
  - AllowSymlinksInCacheRootDirectory
  - TargetRubyVersion
  - ParserEngine
  - SuggestExtensions
  - ActiveSupportExtensionsEnabled
  - StringLiteralsFrozenByDefault
```

This is a dirty hack relying on a private constant to prevent the warning. It should be updated to a better design in the future.

Fixes #1442.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
