### PR TITLE
[Fix #1446] Fix false positives for `Rails/Delegate` when `module_function` is used

### DIFF
--- a/changelog/fix_false_positives_for_rails_delegate_when_module_function_is_used.md
+++ b/changelog/fix_false_positives_for_rails_delegate_when_module_function_is_used.md
@@ -1,0 +1,1 @@
+* [#1446](https://github.com/rubocop/rubocop-rails/issues/1446): Fix false positives for `Rails/Delegate` when `module_function` is used. ([@ydakuka][])

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -74,6 +74,7 @@ module RuboCop
         def on_def(node)
           return unless trivial_delegate?(node)
           return if private_or_protected_delegation(node)
+          return if module_function_declared?(node)
 
           register_offense(node)
         end
@@ -161,6 +162,12 @@ module RuboCop
 
         def private_or_protected_delegation(node)
           private_or_protected_inline(node) || node_visibility(node) != :public
+        end
+
+        def module_function_declared?(node)
+          node.each_ancestor(:module, :begin).any? do |ancestor|
+            ancestor.children.any? { |child| child.send_type? && child.method?(:module_function) }
+          end
         end
 
         def private_or_protected_inline(node)

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
     RUBY
   end
 
+  it 'does not find trivial delegate to `self` for separate `module_function` def' do
+    expect_no_offenses(<<~RUBY)
+      module A
+        module_function
+
+        def foo
+          self.foo
+        end
+      end
+    RUBY
+  end
+
+  it 'does not find trivial delegate to `self` for inline `module_function` def' do
+    expect_no_offenses(<<~RUBY)
+      module A
+        module_function def foo
+          self.foo
+        end
+      end
+    RUBY
+  end
+
   it 'finds trivial delegate with prefix' do
     expect_offense(<<~RUBY)
       def bar_foo


### PR DESCRIPTION
Fix #1446 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).
