### PR TITLE
Fix false positive for `Rails/LexicallyScopedActionFilter` when action methods are delegated

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_lexically_scoped_action_filter.md
+++ b/changelog/fix_a_false_positive_for_rails_lexically_scoped_action_filter.md
@@ -1,0 +1,1 @@
+* [#1447](https://github.com/rubocop/rubocop-rails/issues/1447): Fix false positive for `Rails/LexicallyScopedActionFilter` when action methods are delegated. ([@vlad-pisanov][])

--- a/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
@@ -159,6 +159,27 @@ RSpec.describe RuboCop::Cop::Rails::LexicallyScopedActionFilter, :config do
     RUBY
   end
 
+  it 'does not register an offense when action method is delegated' do
+    expect_no_offenses(<<~RUBY)
+      class FooController < ApplicationController
+        before_action :authorize!, only: %i[index show]
+
+        delegate :index, :show, to: :foo
+      end
+    RUBY
+  end
+
+  it 'registers an offense when action method is not delegated' do
+    expect_offense(<<~RUBY)
+      class FooController < ApplicationController
+        before_action :authorize!, only: %i[foo show]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `foo` is not explicitly defined on the class.
+
+        delegate :show, to: :bar
+      end
+    RUBY
+  end
+
   it 'does not register an offense when action method is aliased by `alias`' do
     expect_no_offenses(<<~RUBY)
       class FooController < ApplicationController


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rails/issues/1447

Currently, `Rails/LexicallyScopedActionFilter` only looks for explicitly defined (`def`) action methods, and aliased action methods (`alias`, `alias_method`), but not action methods defined via delegation `delegate :my_action, to: ...`

This PR fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
