### PR TITLE
Make `Rails/TransactionExitStatement` aware of numblocks

### DIFF
--- a/changelog/fix_transaction_exit_numblocks.md
+++ b/changelog/fix_transaction_exit_numblocks.md
@@ -1,0 +1,1 @@
+* [#1453](https://github.com/rubocop/rubocop-rails/pull/1453): Make `Rails/TransactionExitStatement` aware of numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -99,7 +99,7 @@ module RuboCop
           return false unless transaction_method_name?(node.method_name)
           return false unless (parent = node.parent)
 
-          parent.block_type? && parent.body
+          parent.any_block_type? && parent.body
         end
 
         def statement(statement_node)
@@ -113,7 +113,7 @@ module RuboCop
         end
 
         def nested_block?(statement_node)
-          name = statement_node.ancestors.find(&:block_type?).children.first.method_name
+          name = statement_node.ancestors.find(&:any_block_type?).children.first.method_name
           !transaction_method_name?(name)
         end
 


### PR DESCRIPTION
This fixes both false positives and negatives:
* Since Rails 7.2, the first argument yielded is the transaction itself
* Don't register an offense when breaking out of a numblock loop

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
