### PR TITLE
Disable `Rails/Delegate` for controllers

### DIFF
--- a/changelog/change_no_delegate_controllers.md
+++ b/changelog/change_no_delegate_controllers.md
@@ -1,0 +1,1 @@
+* [#1454](https://github.com/rubocop/rubocop-rails/issues/1454): Disable `Rails/Delegate` for controllers. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -367,11 +367,13 @@ Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: true
   VersionAdded: '0.21'
-  VersionChanged: '0.50'
+  VersionChanged: <<next>>
   # When set to true, using the target object as a prefix of the
   # method name without using the `delegate` method will be a
   # violation. When set to false, this case is legal.
   EnforceForPrefixed: true
+  Exclude:
+    - app/controllers/**/*.rb
 
 Rails/DelegateAllowBlank:
   Description: 'Do not use allow_blank as an option to delegate.'

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -15,6 +15,9 @@ module RuboCop
       # without using the `delegate` method will be a violation.
       # When set to `false`, this case is legal.
       #
+      # It is disabled for controllers in order to keep controller actions
+      # explicitly defined.
+      #
       # @example
       #   # bad
       #   def bar

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -353,4 +353,22 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
       delegate :foo, to: :$global_variable
     RUBY
   end
+
+  it 'is disabled for controllers' do
+    expect_no_offenses(<<~RUBY, "#{Bundler.root}/app/controllers/foo_controller.rb")
+      class FooController
+        before_action :load
+
+        def destroy
+          @foo.destroy
+        end
+
+        private
+
+        def load
+          @foo = Foo.find(params[:id])
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Followup to https://github.com/rubocop/rubocop-rails/pull/1450

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
