### PR TITLE
Make `Rails/SaveBang` aware of numblocks

### DIFF
--- a/changelog/fix_save_bang_numblocks.md
+++ b/changelog/fix_save_bang_numblocks.md
@@ -1,0 +1,1 @@
+* [#1455](https://github.com/rubocop/rubocop-rails/pull/1455): Make `Rails/SaveBang` aware of numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -182,7 +182,7 @@ module RuboCop
         def right_assignment_node(assignment)
           node = assignment.node.child_nodes.first
 
-          return node unless node&.block_type?
+          return node unless node&.any_block_type?
 
           node.send_node
         end
@@ -305,7 +305,7 @@ module RuboCop
 
           node = assignable_node(node)
           method, sibling_index = find_method_with_sibling_index(node.parent)
-          return false unless method&.type?(:def, :block)
+          return false unless method&.type?(:def, :any_block)
 
           method.children.size == node.sibling_index + sibling_index
         end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -140,6 +140,23 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
       end
     end
 
+    it "when assigning the return value of #{method} with numblock" do
+      if update
+        expect_no_offenses(<<~RUBY)
+          x = object.#{method} do
+            _1.name = 'Tom'
+          end
+        RUBY
+      else
+        expect_offense(<<~RUBY, method: method)
+          x = object.#{method} do
+                     ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked. Or check `persisted?` on model returned from `#{method}`.
+            _1.name = 'Tom'
+          end
+        RUBY
+      end
+    end
+
     it "when using #{method} with if" do
       if update
         expect_no_offenses(<<~RUBY)
@@ -566,6 +583,23 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
           objects.each do |object|
             object.#{method}
                    ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
+          end
+        RUBY
+      end
+    end
+
+    it "when using #{method} as last method call of a numblock" do
+      if allow_implicit_return
+        expect_no_offenses(<<~RUBY)
+          objects.each do
+            _1.#{method}
+          end
+        RUBY
+      else
+        expect_offense(<<~RUBY, method: method)
+          objects.each do
+            _1.#{method}
+               ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
           end
         RUBY
       end


### PR DESCRIPTION
Yup

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
