### PR TITLE
Fix a false positive for `Rails/CreateTableWithTimestamps` with numblocks

### DIFF
--- a/changelog/fix_false_positive_table_timestamp_numblock.md
+++ b/changelog/fix_false_positive_table_timestamp_numblock.md
@@ -1,0 +1,1 @@
+* [#1456](https://github.com/rubocop/rubocop-rails/pull/1456): Fix a false positive for `Rails/CreateTableWithTimestamps` with numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/mixin/active_record_migrations_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_migrations_helper.rb
@@ -22,9 +22,9 @@ module RuboCop
       ].freeze
 
       def_node_matcher :create_table_with_block?, <<~PATTERN
-        (block
+        (any_block
           (send nil? :create_table ...)
-          (args (arg _var))
+          { _ | (args (arg _var)) }
           _)
       PATTERN
     end

--- a/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
+++ b/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps, :config do
     RUBY
   end
 
-  it 'registers an offense when not including timestampswith `to_proc` syntax' do
+  it 'registers an offense when not including timestamps with `to_proc` syntax' do
     expect_offense <<~RUBY
       create_table :users, &:extension_columns
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add timestamps when creating a new table.
@@ -53,13 +53,24 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps, :config do
     RUBY
   end
 
-  it 'does not register an offense when including timestampswith `to_proc` syntax' do
+  it 'does not register an offense when including timestamps in numblock' do
+    expect_no_offenses <<~RUBY
+      create_table :users do
+        _1.string :name
+        _1.string :email
+
+        _1.timestamps
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when including timestamps with `to_proc` syntax' do
     expect_no_offenses <<~RUBY
       create_table :users, &:timestamps
     RUBY
   end
 
-  it 'does not register an offense when including timestampswith options and `to_proc` syntax' do
+  it 'does not register an offense when including timestamps with options and `to_proc` syntax' do
     expect_no_offenses <<~RUBY
       create_table :users, id: :string, limit: 42, &:timestamps
     RUBY


### PR DESCRIPTION
This should also take care of https://github.com/rubocop/rubocop-rails/issues/1413, once `itblock` is introduces

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
