### PR TITLE
Fix a false positive for `Rails/ReversibleMigration` in `drop_table` with numblock

### DIFF
--- a/changelog/fix_false_positive_reversible_migration_numblock.md
+++ b/changelog/fix_false_positive_reversible_migration_numblock.md
@@ -1,0 +1,1 @@
+* [#1457](https://github.com/rubocop/rubocop-rails/pull/1457): Fix a false positive for `Rails/ReversibleMigration` in `drop_table` with numblock. ([@earlopain][])

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -218,7 +218,7 @@ module RuboCop
           return unless (last_argument = node.last_argument)
 
           drop_table_call(node) do
-            unless node.parent.block_type? || last_argument.block_pass_type?
+            unless node.parent.any_block_type? || last_argument.block_pass_type?
               add_offense(node, message: format(MSG, action: 'drop_table(without block)'))
             end
           end

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
       end
     RUBY
 
+    it_behaves_like 'accepts', 'drop_table(with numblock)', <<~RUBY
+      drop_table :users do
+        _1.string :name
+      end
+    RUBY
+
     it_behaves_like 'accepts', 'drop_table(with symbol proc)', <<~RUBY
       drop_table :users, &:timestamps
     RUBY


### PR DESCRIPTION
There's also up_only and similar, but they don't yield any arguments

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
