### PR TITLE
Fix a false positive for `Rails/RelativeDateConstant` when assigning a lambda/proc with numblock

### DIFF
--- a/changelog/fix_false_positive_relative_date_const_numblock.md
+++ b/changelog/fix_false_positive_relative_date_const_numblock.md
@@ -1,0 +1,1 @@
+* [#1458](https://github.com/rubocop/rubocop-rails/pull/1458): Fix a false positive for `Rails/RelativeDateConstant` when assigning a lambda/proc with numblock. ([@earlopain][])

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -90,7 +90,7 @@ module RuboCop
         end
 
         def nested_relative_date(node, &callback)
-          return if node.nil? || node.block_type?
+          return if node.nil? || node.any_block_type?
 
           node.each_child_node do |child|
             nested_relative_date(child, &callback)

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe RuboCop::Cop::Rails::RelativeDateConstant, :config do
       RUBY
     end
 
+    it 'accepts a lambda with numblock' do
+      expect_no_offenses(<<~RUBY)
+        class SomeClass
+          EXPIRED_AT = -> { _1.year.ago }
+        end
+      RUBY
+    end
+
     it 'accepts a proc' do
       expect_no_offenses(<<~RUBY)
         class SomeClass


### PR DESCRIPTION
Not much of these left here I think

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
