### PR TITLE
Fix a false positive for `Rails/UniqBeforePluck` when using a numblock with `uniq`

### DIFF
--- a/changelog/fix_false_positive_uniq_before_pluck_numblock.md
+++ b/changelog/fix_false_positive_uniq_before_pluck_numblock.md
@@ -1,0 +1,1 @@
+* [#1459](https://github.com/rubocop/rubocop-rails/pull/1459): Fix a false positive for `Rails/UniqBeforePluck` when using a numblock with `uniq`. ([@earlopain][])

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -52,7 +52,7 @@ module RuboCop
         MSG = 'Use `distinct` before `pluck`.'
         RESTRICT_ON_SEND = %i[uniq].freeze
 
-        def_node_matcher :uniq_before_pluck, '[!^block $(send $(send _ :pluck ...) :uniq ...)]'
+        def_node_matcher :uniq_before_pluck, '[!^any_block $(send $(send _ :pluck ...) :uniq ...)]'
 
         def on_send(node)
           uniq_before_pluck(node) do |uniq_node, pluck_node|

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
         Model.where(foo: 1).pluck(:name).uniq { |k| k[0] }
       RUBY
     end
+
+    it 'ignores uniq with a numblock' do
+      expect_no_offenses(<<~RUBY)
+        Model.where(foo: 1).pluck(:name).uniq { _1[0] }
+      RUBY
+    end
   end
 
   it 'registers an offense' do


### PR DESCRIPTION
Another one

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
