### PR TITLE
Future-proof `Rails/Output` for `itblock`

### DIFF
--- a/lib/rubocop/cop/rails/output.rb
+++ b/lib/rubocop/cop/rails/output.rb
@@ -23,7 +23,6 @@ module RuboCop
 
         MSG = "Do not write to stdout. Use Rails's logger if you want to log."
         RESTRICT_ON_SEND = %i[ap p pp pretty_print print puts binwrite syswrite write write_nonblock].freeze
-        ALLOWED_TYPES = %i[send csend block numblock].freeze
 
         def_node_matcher :output?, <<~PATTERN
           (send nil? {:ap :p :pp :pretty_print :print :puts} ...)
@@ -40,7 +39,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if ALLOWED_TYPES.include?(node.parent&.type)
+          return if node.parent&.call_type? || node.block_node
           return if !output?(node) && !io_output?(node)
 
           range = offense_range(node)


### PR DESCRIPTION
This way it's just checking for a block body instead of caring about the specific type

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
