### PR TITLE
Add support for chained method calls in `Rails/Presence`

### DIFF
--- a/changelog/change_presence_to_support_chained_calls.md
+++ b/changelog/change_presence_to_support_chained_calls.md
@@ -1,0 +1,1 @@
+* [#932](https://github.com/rubocop/rubocop-rails/issues/932): Add support for chained method calls in `Rails/Presence`. ([@vlad-pisanov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -809,6 +809,7 @@ Rails/Presence:
   Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
   Enabled: true
   VersionAdded: '0.52'
+  VersionChanged: '<<next>>'
 
 Rails/Present:
   Description: 'Enforces use of `present?`.'

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -233,6 +233,81 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
     RUBY
   end
 
+  context 'when a method is called on the receiver' do
+    it 'registers an offense and corrects when `a.present? ? a.foo : nil' do
+      expect_offense(<<~RUBY)
+        a.present? ? a.foo : nil
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `a.presence&.foo` instead of `a.present? ? a.foo : nil`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.presence&.foo
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `a.blank? ? nil : a.foo' do
+      expect_offense(<<~RUBY)
+        a.blank? ? nil : a.foo
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `a.presence&.foo` instead of `a.blank? ? nil : a.foo`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.presence&.foo
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `a.foo if a.present?`' do
+      expect_offense(<<~RUBY)
+        a.foo if a.present?
+        ^^^^^^^^^^^^^^^^^^^ Use `a.presence&.foo` instead of `a.foo if a.present?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.presence&.foo
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `a.foo unless a.blank?`' do
+      expect_offense(<<~RUBY)
+        a.foo unless a.blank?
+        ^^^^^^^^^^^^^^^^^^^^^ Use `a.presence&.foo` instead of `a.foo unless a.blank?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.presence&.foo
+      RUBY
+    end
+
+    it 'registers an offense and corrects when chained method takes parameters' do
+      expect_offense(<<~RUBY)
+        a.present? ? a.foo(42, key: :value) : nil
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `a.presence&.foo(42, key: :value)` instead of `a.present? ? a.foo(42, key: :value) : nil`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.presence&.foo(42, key: :value)
+      RUBY
+    end
+
+    it 'does not register an offense when chained method is `[]`' do
+      expect_no_offenses(<<~RUBY)
+        a.present? ? a[1] : nil
+      RUBY
+    end
+
+    it 'does not register an offense when chained method is an arithmetic operation' do
+      expect_no_offenses(<<~RUBY)
+        a.present? ? a + 42 : nil
+      RUBY
+    end
+
+    it 'does not register an offense when multiple methods are chained' do
+      expect_no_offenses(<<~RUBY)
+        a.present? ? a.foo.bar : nil
+      RUBY
+    end
+  end
+
   context 'when multiline ternary can be replaced' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rails/issues/932

Enhance `Rails/Presence` to detect and autocorrect a common scenario where a method is invoked on the receiver when it's `present?`, and `nil` otherwise:

```ruby
# bad
name.present? ? name.upcase : nil
name.blank? ? nil : name.upcase
name.upcase if name.present?

# good
name.presence&.upcase
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
