### PR TITLE
Avoid warnings about redefined methods in EnforceSuperclass module

### DIFF
--- a/changelog/fix_avoid_warnings_about_redefined_methods.md
+++ b/changelog/fix_avoid_warnings_about_redefined_methods.md
@@ -1,0 +1,1 @@
+* [#1465](https://github.com/rubocop/rubocop-rails/issues/1465): Avoid warnings about methods of `RuboCop::Cop::EnforceSuperclass` being redefined. ([@davidrunger][])

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Cop
+  module Cop # rubocop:disable Style/Documentation
+    # The EnforceSuperclass module is also defined in `rubocop` (for backwards
+    # compatibility), so here we remove it before (re)defining it, to avoid
+    # warnings about methods in the module being redefined.
+    remove_const(:EnforceSuperclass) if defined?(EnforceSuperclass)
+
     # Common functionality for enforcing a specific superclass.
     module EnforceSuperclass
       def self.included(base)


### PR DESCRIPTION
Fix #1465

This change avoids the printing of warnings about some methods (`included`, `on_class`, and `on_send`) of the `RuboCop::Cop::EnforceSuperclass` module being redefined. These warnings are printed because, in addition to the definition of that module here in `rubocop-rails`, that module is first [also defined in `rubocop`][1]. (The module has been extracted to `rubocop-rails`, but is also left in `rubocop`, for backwards compatibility.)

[1]: https://github.com/rubocop/rubocop/blob/v1.73.2/lib/rubocop/cop/mixin/enforce_superclass.rb

This change avoids the warnings by first undefining the `RuboCop::Cop::EnforceSuperclass` module (the one from `rubocop`) before then redefining that module here in `rubocop-rails`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. _(I am not sure we can easily test this?)_
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] ~~If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).~~ _(Not applicable.)_

[1]: https://chris.beams.io/posts/git-commit/