### PR TITLE
Don't load the active_support `blank` core extension

### DIFF
--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -3,7 +3,6 @@
 require 'rubocop'
 require 'rack/utils'
 require 'active_support/inflector'
-require 'active_support/core_ext/object/blank'
 
 require_relative 'rubocop/rails'
 require_relative 'rubocop/rails/version'

--- a/lib/rubocop/cop/mixin/database_type_resolvable.rb
+++ b/lib/rubocop/cop/mixin/database_type_resolvable.rb
@@ -29,8 +29,8 @@ module RuboCop
       end
 
       def database_from_env
-        url = ENV['DATABASE_URL'].presence
-        return unless url
+        url = ENV.fetch('DATABASE_URL', '')
+        return if url.blank?
 
         case url
         when %r{\A(mysql2|trilogy)://}

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -76,7 +76,7 @@ module RuboCop
         def autocorrect(corrector, class_config)
           class_value = class_config.value
           replacement = const_or_string(class_value)
-          return unless replacement.present?
+          return unless replacement
 
           corrector.replace(class_value, replacement.source.inspect)
         end

--- a/lib/rubocop/cop/rails/schema_comment.rb
+++ b/lib/rubocop/cop/rails/schema_comment.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         # @!method comment_present?(node)
         def_node_matcher :comment_present?, <<~PATTERN
-          (hash <(pair {(sym :comment) (str "comment")} (_ [present?])) ...>)
+          (hash <(pair {(sym :comment) (str "comment")} (_ !blank?)) ...>)
         PATTERN
 
         # @!method add_column?(node)


### PR DESCRIPTION
Rubocop already defined its own `blank?` method (🙁), so ruby always warns when it is loaded again.

There's no real point in using the extension though, so just not using it seems ideal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
