### PR TITLE
[Fix #1353] Fix incorrect escaping of asterisk in docs and comments

### DIFF
--- a/lib/rubocop/cop/rails/arel_star.rb
+++ b/lib/rubocop/cop/rails/arel_star.rb
@@ -5,14 +5,14 @@ module RuboCop
     module Rails
       # Prevents usage of `"*"` on an Arel::Table column reference.
       #
-      # Using `arel_table["*"]` causes the outputted string to be a literal
-      # quoted asterisk (e.g. <tt>`my_model`.`*`</tt>). This causes the
-      # database to look for a column named <tt>`*`</tt> (or `"*"`) as opposed
+      # Using `arel_table["\*"]` causes the outputted string to be a literal
+      # quoted asterisk (e.g. `my_model`.`*`). This causes the
+      # database to look for a column named `\*` (or `"*"`) as opposed
       # to expanding the column list as one would likely expect.
       #
       # @safety
-      #   This cop's autocorrection is unsafe because it turns a quoted `*` into
-      #   an SQL `*`, unquoted. `*` is a valid column name in certain databases
+      #   This cop's autocorrection is unsafe because it turns a quoted `\*` into
+      #   an SQL `*`, unquoted. `\*` is a valid column name in certain databases
       #   supported by Rails, and even though it is usually a mistake,
       #   it might denote legitimate access to a column named `*`.
       #


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

Fixes #1353 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/

## After in local
![スクリーンショット 2025-03-26 0 42 48](https://github.com/user-attachments/assets/9b113db4-6240-409c-b06f-e55096bca9dc)
