### PR TITLE
[Fix #1463] Mark `Rails/IndexWith` as unsafe autocorrect

### DIFF
--- a/changelog/change_mark_rails_index_with_as_unsafe.md
+++ b/changelog/change_mark_rails_index_with_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#1463](https://github.com/rubocop/rubocop-rails/pull/1463): Mark `Rails/IndexWith` as unsafe autocorrect. ([@tejasbubane][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -647,8 +647,9 @@ Rails/IndexBy:
 Rails/IndexWith:
   Description: 'Prefer `index_with` over `each_with_object`, `to_h`, or `map`.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '2.5'
-  VersionChanged: '2.8'
+  VersionChanged: '<<next>>'
 
 Rails/Inquiry:
   Description: "Prefer Ruby's comparison operators over Active Support's `Array#inquiry` and `String#inquiry`."

--- a/lib/rubocop/cop/rails/index_with.rb
+++ b/lib/rubocop/cop/rails/index_with.rb
@@ -8,6 +8,10 @@ module RuboCop
       # an enumerable into a hash where the keys are the original elements.
       # Rails provides the `index_with` method for this purpose.
       #
+      # This cop is marked as unsafe autocorrection, because `nil.to_h` returns {}
+      # but `nil.with_index` throws `NoMethodError`. Therefore, autocorrection is not
+      # compatible if the receiver is nil.
+      #
       # @example
       #   # bad
       #   [1, 2, 3].each_with_object({}) { |el, h| h[el] = foo(el) }


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop-rails/issues/1463

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/