### PR TITLE
Support `it` block parameter in `Rails` cops

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
               -e "/gem 'rubocop-performance',/d" \
               -e "/gem 'rubocop-rspec',/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.72.1' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.75.0' # Specify the oldest supported RuboCop version
           EOF
       - uses: ruby/setup-ruby@v1
         with:

--- a/changelog/new_support_itblock_in_rails_cops.md
+++ b/changelog/new_support_itblock_in_rails_cops.md
@@ -1,0 +1,1 @@
+* [#1471](https://github.com/rubocop/rubocop-rails/pull/1471): Support `it` block parameter in `Rails` cops. ([@koic][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -58,7 +58,7 @@ module RuboCop
         end
 
         def set_new_arg_name(transformed_argname, corrector)
-          return if block_node.numblock_type?
+          return unless block_node.block_type?
 
           corrector.replace(block_node.arguments, "|#{transformed_argname}|")
         end
@@ -84,6 +84,7 @@ module RuboCop
       end
 
       alias on_numblock on_block
+      alias on_itblock on_block
 
       def on_send(node)
         on_bad_map_to_h(node) do |*match|

--- a/lib/rubocop/cop/rails/index_by.rb
+++ b/lib/rubocop/cop/rails/index_by.rb
@@ -37,6 +37,9 @@ module RuboCop
             (numblock
               (call _ :to_h) $1
               (array $_ (lvar :_1)))
+            (itblock
+              (call _ :to_h) $:it
+              (array $_ (lvar :it)))
           }
         PATTERN
 
@@ -50,6 +53,9 @@ module RuboCop
               (numblock
                 (call _ {:map :collect}) $1
                 (array $_ (lvar :_1)))
+              (itblock
+                (call _ {:map :collect}) $:it
+                (array $_ (lvar :it)))
             }
             :to_h)
         PATTERN
@@ -66,6 +72,9 @@ module RuboCop
               (numblock
                 (call _ {:map :collect}) $1
                 (array $_ (lvar :_1)))
+              (itblock
+                (call _ {:map :collect}) $:it
+                (array $_ (lvar :it)))
             }
           )
         PATTERN

--- a/lib/rubocop/cop/rails/index_with.rb
+++ b/lib/rubocop/cop/rails/index_with.rb
@@ -40,6 +40,9 @@ module RuboCop
             (numblock
               (call _ :to_h) $1
               (array (lvar :_1) $_))
+            (itblock
+              (call _ :to_h) $:it
+              (array (lvar :it) $_))
           }
         PATTERN
 
@@ -53,6 +56,9 @@ module RuboCop
               (numblock
                 (call _ {:map :collect}) $1
                 (array (lvar :_1) $_))
+              (itblock
+                (call _ {:map :collect}) $:it
+                (array (lvar :it) $_))
             }
             :to_h)
         PATTERN
@@ -69,6 +75,9 @@ module RuboCop
               (numblock
                 (call _ {:map :collect}) $1
                 (array (lvar :_1) $_))
+              (itblock
+                (call _ {:map :collect}) $:it
+                (array (lvar :it) $_))
             }
           )
         PATTERN

--- a/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
+++ b/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
@@ -85,18 +85,22 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
         def autocorrect(corrector, send_node, node)
           corrector.remove(send_node.receiver)
           corrector.remove(send_node.loc.dot)
-          corrector.remove(block_argument_range(send_node)) unless node.numblock_type?
+          corrector.remove(block_argument_range(send_node)) if node.block_type?
         end
 
+        # rubocop:disable Metrics/AbcSize
         def redundant_receiver?(send_nodes, node)
           proc = if node.numblock_type?
                    ->(n) { n.receiver.lvar_type? && n.receiver.source == '_1' }
+                 elsif node.itblock_type?
+                   ->(n) { n.receiver.lvar_type? && n.receiver.source == 'it' }
                  else
                    return false if node.arguments.empty?
 
@@ -106,6 +110,7 @@ module RuboCop
 
           send_nodes.all?(&proc)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def block_argument_range(node)
           block_node = node.each_ancestor(:block).first

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -205,6 +205,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |s|
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_dependency 'rack', '>= 1.1'
-  s.add_dependency 'rubocop', '>= 1.72.1', '< 2.0'
+  s.add_dependency 'rubocop', '>= 1.75.0', '< 2.0'
   s.add_dependency 'rubocop-ast', '>= 1.38.0', '< 2.0'
 end

--- a/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
+++ b/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps, :config do
     RUBY
   end
 
+  it 'does not register an offense when including timestamps in itblock', :ruby34, unsupported_on: :parser do
+    expect_no_offenses <<~RUBY
+      create_table :users do
+        it.string :name
+        it.string :email
+
+        it.timestamps
+      end
+    RUBY
+  end
+
   it 'does not register an offense when including timestamps with `to_proc` syntax' do
     expect_no_offenses <<~RUBY
       create_table :users, &:timestamps

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe RuboCop::Cop::Rails::Output, :config do
     RUBY
   end
 
+  it 'does not register an offense when io method is called with `it` parameter', :ruby34, unsupported_on: :parser do
+    expect_no_offenses(<<~RUBY)
+      obj.write { do_something(it) }
+    RUBY
+  end
+
   it 'does not register an offense when a method is ' \
      'safe navigation called to a local variable with the same name as a print method' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -129,6 +129,31 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
+      context 'when using Ruby 3.4 or newer', :ruby34, unsupported_on: :parser do
+        context 'when using `it` block parameter' do
+          context "when `#{method}` can be replaced with `pluck`" do
+            it 'registers an offense' do
+              expect_offense(<<~RUBY, method: method)
+                x.%{method} { it[:foo] }
+                  ^{method}^^^^^^^^^^^^^ Prefer `pluck(:foo)` over `%{method} { it[:foo] }`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                x.pluck(:foo)
+              RUBY
+            end
+          end
+
+          context 'when the `it` argument is used in `[]`' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<~RUBY)
+                x.#{method} { it[foo...it.to_something] }
+              RUBY
+            end
+          end
+        end
+      end
+
       context "when `#{method}` is used in block" do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_active_record_all_method_spec.rb
@@ -329,6 +329,12 @@ RSpec.describe RuboCop::Cop::Rails::RedundantActiveRecordAllMethod, :config do
         RUBY
       end
 
+      it "does not register an offense when using `#{method}` with `it` block", :ruby34, unsupported_on: :parser do
+        expect_no_offenses(<<~RUBY)
+          User.all.#{method} { it.do_something }
+        RUBY
+      end
+
       it "does not register an offense when using `#{method}` with symbol block" do
         expect_no_offenses(<<~RUBY)
           User.all.#{method}(&:do_something)

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -59,6 +59,36 @@ RSpec.describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
     end
   end
 
+  context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense and corrects using explicit receiver in `with_options`' do
+      expect_offense(<<~RUBY)
+        class Account < ApplicationRecord
+          with_options dependent: :destroy do
+            it.has_many :customers
+            ^^ Redundant receiver in `with_options`.
+            it.has_many :products
+            ^^ Redundant receiver in `with_options`.
+            it.has_many :invoices
+            ^^ Redundant receiver in `with_options`.
+            it.has_many :expenses
+            ^^ Redundant receiver in `with_options`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Account < ApplicationRecord
+          with_options dependent: :destroy do
+            has_many :customers
+            has_many :products
+            has_many :invoices
+            has_many :expenses
+          end
+        end
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using implicit receiver in `with_options`' do
     expect_no_offenses(<<~RUBY)
       class Account < ApplicationRecord

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe RuboCop::Cop::Rails::RelativeDateConstant, :config do
       RUBY
     end
 
+    it 'accepts a lambda with itblock', :ruby34, unsupported_on: :parser do
+      expect_no_offenses(<<~RUBY)
+        class SomeClass
+          EXPIRED_AT = -> { it.year.ago }
+        end
+      RUBY
+    end
+
     it 'accepts a proc' do
       expect_no_offenses(<<~RUBY)
         class SomeClass

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
+  context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+    it_behaves_like 'accepts', 'create_table using `it` parameter', <<~RUBY
+      create_table :users do
+        it.string :name
+      end
+    RUBY
+  end
+
   it_behaves_like 'offense', 'execute', <<~RUBY
     execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
   RUBY
@@ -117,6 +125,12 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     it_behaves_like 'accepts', 'drop_table(with numblock)', <<~RUBY
       drop_table :users do
         _1.string :name
+      end
+    RUBY
+
+    it_behaves_like 'accepts', 'drop_table(with itblock)', <<~RUBY, :ruby34, unsupported_on: :parser
+      drop_table :users do
+        it.string :name
       end
     RUBY
 
@@ -254,6 +268,14 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
       it_behaves_like 'offense', 'change_table(with change_default)', <<~RUBY
         change_table :users do
           _1.change_default :authorized, 1
+        end
+      RUBY
+    end
+
+    context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+      it_behaves_like 'offense', 'change_table(with change_default)', <<~RUBY
+        change_table :users do
+          it.change_default :authorized, 1
         end
       RUBY
     end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -157,6 +157,23 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
       end
     end
 
+    it "when assigning the return value of #{method} with `it` block", :ruby34, unsupported_on: :parser do
+      if update
+        expect_no_offenses(<<~RUBY)
+          x = object.#{method} do
+            it.name = 'Tom'
+          end
+        RUBY
+      else
+        expect_offense(<<~RUBY, method: method)
+          x = object.#{method} do
+                     ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked. Or check `persisted?` on model returned from `#{method}`.
+            it.name = 'Tom'
+          end
+        RUBY
+      end
+    end
+
     it "when using #{method} with if" do
       if update
         expect_no_offenses(<<~RUBY)
@@ -599,6 +616,23 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         expect_offense(<<~RUBY, method: method)
           objects.each do
             _1.#{method}
+               ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
+          end
+        RUBY
+      end
+    end
+
+    it "when using #{method} as last method call of an itblock", :ruby34, unsupported_on: :parser do
+      if allow_implicit_return
+        expect_no_offenses(<<~RUBY)
+          objects.each do
+            it.#{method}
+          end
+        RUBY
+      else
+        expect_offense(<<~RUBY, method: method)
+          objects.each do
+            it.#{method}
                ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
           end
         RUBY

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
         Model.where(foo: 1).pluck(:name).uniq { _1[0] }
       RUBY
     end
+
+    it 'ignores uniq with an `it` block', :ruby34, unsupported_on: :parser do
+      expect_no_offenses(<<~RUBY)
+        Model.where(foo: 1).pluck(:name).uniq { it[0] }
+      RUBY
+    end
   end
 
   it 'registers an offense' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ RSpec.configure do |config|
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
 
+  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
+  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
+
   config.example_status_persistence_file_path = 'spec/examples.txt'
   config.disable_monkey_patching!
   config.warnings = true


### PR DESCRIPTION
This PR supports `it` block parameter in `Rails` cops.

Closes #1413

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
