### PR TITLE
Fix `Rails/TimeZone` cop error on invalid string literal encoding

### DIFF
--- a/changelog/fix_rails_time_zone_cop_error_on_invalid_string_literal_encoding.md
+++ b/changelog/fix_rails_time_zone_cop_error_on_invalid_string_literal_encoding.md
@@ -1,0 +1,1 @@
+* [#1475](https://github.com/rubocop/rubocop-rails/pull/1475): Fix `Rails/TimeZone` cop error on invalid string literal encoding. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -135,7 +135,9 @@ module RuboCop
         end
 
         def attach_timezone_specifier?(date)
-          date.respond_to?(:value) && TIMEZONE_SPECIFIER.match?(date.value.to_s)
+          return false unless date.respond_to?(:value)
+
+          !date.value.to_s.valid_encoding? || TIMEZONE_SPECIFIER.match?(date.value.to_s)
         end
 
         def build_message(klass, method_name, node)

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
+  shared_examples 'with invalid timezone literal encoding' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~'RUBY')
+        Time.new("l\366, 26 maj 2001 00:15:58")
+      RUBY
+    end
+  end
+
   context 'when EnforcedStyle is "strict"' do
     let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
+
+    include_context 'with invalid timezone literal encoding'
 
     it 'registers an offense for Time.now' do
       expect_offense(<<~RUBY)
@@ -333,6 +343,8 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
 
   context 'when EnforcedStyle is "flexible"' do
     let(:cop_config) { { 'EnforcedStyle' => 'flexible' } }
+
+    include_context 'with invalid timezone literal encoding'
 
     it 'registers an offense for Time.now' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
In some cases (e.g. for testing purposes) we might to want to use invalid string literal -- in that case IMO we should not register an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [X] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
