### PR TITLE
[Fix #1477] Fix an error for `Rails/SchemaComment` when the comment is passed as a local variable

### DIFF
--- a/changelog/fix_schema_comment_local_var.md
+++ b/changelog/fix_schema_comment_local_var.md
@@ -1,0 +1,1 @@
+* [#1477](https://github.com/rubocop/rubocop-rails/issues/1477): Fix an error for `Rails/SchemaComment` when the comment is passed as a local variable. ([@earlopain][])

--- a/lib/rubocop/cop/rails/schema_comment.rb
+++ b/lib/rubocop/cop/rails/schema_comment.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         # @!method comment_present?(node)
         def_node_matcher :comment_present?, <<~PATTERN
-          (hash <(pair {(sym :comment) (str "comment")} (_ !blank?)) ...>)
+          (hash <(pair {(sym :comment) (str "comment")} !{nil (str blank?)}) ...>)
         PATTERN
 
         # @!method add_column?(node)

--- a/spec/rubocop/cop/rails/schema_comment_spec.rb
+++ b/spec/rubocop/cop/rails/schema_comment_spec.rb
@@ -142,5 +142,14 @@ RSpec.describe RuboCop::Cop::Rails::SchemaComment, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when the comment is a local variable' do
+      expect_no_offenses(<<~RUBY)
+        create_table :users, comment: 'Table' do |t|
+          i_am_a_comment = 'I am a column'
+          t.integer :column, comment: i_am_a_comment
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fix #1477

To do that, be more specific about what type you expect to call blank? on (strings only).

Caused by https://github.com/rubocop/rubocop-rails/pull/1467

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
