### PR TITLE
Suggestion: Rails/FilePath: Use Rails.root.join('path/to').to_path instead of .to_s .

### DIFF
--- a/changelog/fix_rails_file_path_uses_to_path.md
+++ b/changelog/fix_rails_file_path_uses_to_path.md
@@ -1,0 +1,1 @@
+- [#1480](https://github.com/rubocop/rubocop-rails/pull/1480): Rails/FilePath: Use Rails.root.join('path/to').to_path instead of .to_s. ([@kaibadash][])

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, '/app/models', '/user.rb')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app/models/user.rb").to_s
+          Rails.root.join("app/models/user.rb").to_path
         RUBY
       end
     end
@@ -92,11 +92,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, 'app', 'models')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app/models").to_s
+          Rails.root.join("app/models").to_path
         RUBY
       end
     end
@@ -105,11 +105,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           ::File.join(Rails.root, 'app', 'models')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app/models").to_s
+          Rails.root.join("app/models").to_path
         RUBY
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join([Rails.root, 'foo'])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_no_corrections
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense for nested arrays' do
         expect_offense(<<~RUBY)
           File.join([Rails.root, 'foo', ['bar']])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_no_corrections
@@ -196,11 +196,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           foo(bar(File.join(Rails.root, "app", "models")))
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          foo(bar(Rails.root.join("app/models").to_s))
+          foo(bar(Rails.root.join("app/models").to_path))
         RUBY
       end
     end
@@ -249,11 +249,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, ['app', 'models'])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*['app', 'models']).to_s
+          Rails.root.join(*['app', 'models']).to_path
         RUBY
       end
     end
@@ -262,11 +262,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, "app", ["models", "goober"])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app", *["models", "goober"]).to_s
+          Rails.root.join("app", *["models", "goober"]).to_path
         RUBY
       end
     end
@@ -275,11 +275,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, ["app", "models"], "goober")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*["app", "models"], "goober").to_s
+          Rails.root.join(*["app", "models"], "goober").to_path
         RUBY
       end
     end
@@ -288,11 +288,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, %w[app models])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*%w[app models]).to_s
+          Rails.root.join(*%w[app models]).to_path
         RUBY
       end
     end
@@ -301,11 +301,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, "app", %w[models goober])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app", *%w[models goober]).to_s
+          Rails.root.join("app", *%w[models goober]).to_path
         RUBY
       end
     end
@@ -314,11 +314,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, %w[app models], "goober")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path/to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*%w[app models], "goober").to_s
+          Rails.root.join(*%w[app models], "goober").to_path
         RUBY
       end
     end
@@ -491,11 +491,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, 'app', 'models')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app", "models").to_s
+          Rails.root.join("app", "models").to_path
         RUBY
       end
     end
@@ -504,11 +504,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, '/app/models', '/user.rb')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app", "models", "user.rb").to_s
+          Rails.root.join("app", "models", "user.rb").to_path
         RUBY
       end
     end
@@ -569,11 +569,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           foo(bar(File.join(Rails.root, "app", "models")))
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          foo(bar(Rails.root.join("app", "models").to_s))
+          foo(bar(Rails.root.join("app", "models").to_path))
         RUBY
       end
     end
@@ -641,11 +641,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, ['app', 'models'])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*['app', 'models']).to_s
+          Rails.root.join(*['app', 'models']).to_path
         RUBY
       end
     end
@@ -654,11 +654,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, "app", ["models", "goober"])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app", *["models", "goober"]).to_s
+          Rails.root.join("app", *["models", "goober"]).to_path
         RUBY
       end
     end
@@ -667,11 +667,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, ["app", "models"], "goober")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*["app", "models"], "goober").to_s
+          Rails.root.join(*["app", "models"], "goober").to_path
         RUBY
       end
     end
@@ -680,11 +680,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, %w[app models])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*%w[app models]).to_s
+          Rails.root.join(*%w[app models]).to_path
         RUBY
       end
     end
@@ -693,11 +693,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, "app", %w[models goober])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join("app", *%w[models goober]).to_s
+          Rails.root.join("app", *%w[models goober]).to_path
         RUBY
       end
     end
@@ -706,11 +706,11 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'registers an offense once' do
         expect_offense(<<~RUBY)
           File.join(Rails.root, %w[app models], "goober")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_s`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Rails.root.join('path', 'to').to_path`.
         RUBY
 
         expect_correction(<<~RUBY)
-          Rails.root.join(*%w[app models], "goober").to_s
+          Rails.root.join(*%w[app models], "goober").to_path
         RUBY
       end
     end


### PR DESCRIPTION
Currently, `Rails/FilePath` recommends using `Rails.root.join('app', 'models', 'goober').to_s`, but would `.to_path` be more appropriate?
When we use `.to_s`, we expect to get its class name and address.

Example:
```
[1] pry(main)> User.first.to_s
=> “#<User:0x0000ffff7872b6e0>”
```

Similarly, I'm worried that `Rails.root.join('app', 'models', 'goober').to_s` might return that.
On the other hand, `.to_path` does not have this fear. It's an alias to `to_s`.
https://docs.ruby-lang.org/en/master/Pathname.html#method-i-to_path

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). : no related issues
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
