### PR TITLE
Make `Rails/EnvironmentComparison` aware of `Rails.env.to_sym`

### DIFF
--- a/changelog/change_recognize_to_sym_in_rails_environment_comparison.md
+++ b/changelog/change_recognize_to_sym_in_rails_environment_comparison.md
@@ -1,0 +1,1 @@
+* [#1481](https://github.com/rubocop/rubocop-rails/pull/1481): Recognize `Rails.env.to_sym` in `Rails/EnvironmentComparison`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/rails/environment_comparison_spec.rb
+++ b/spec/rubocop/cop/rails/environment_comparison_spec.rb
@@ -101,6 +101,70 @@ RSpec.describe RuboCop::Cop::Rails::EnvironmentComparison, :config do
     end
   end
 
+  context 'when comparing `Rails.env.to_sym` to a symbol' do
+    context 'when using equals' do
+      it 'registers an offense and corrects when `Rails.env.to_sym` is used on LHS' do
+        expect_offense(<<~RUBY)
+          Rails.env.to_sym == :production
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `Rails.env.production?` over `Rails.env.to_sym == :production`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.env.production?
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `Rails.env.to_sym` is used on RHS' do
+        expect_offense(<<~RUBY)
+          :production == Rails.env.to_sym
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `Rails.env.production?` over `:production == Rails.env.to_sym`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.env.production?
+        RUBY
+      end
+    end
+
+    context 'when using not equals' do
+      it 'registers an offense and corrects when `Rails.env.to_sym` is used on LHS' do
+        expect_offense(<<~RUBY)
+          Rails.env.to_sym != :production
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `!Rails.env.production?` over `Rails.env.to_sym != :production`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !Rails.env.production?
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `Rails.env.to_sym` is used on RHS' do
+        expect_offense(<<~RUBY)
+          :production != Rails.env.to_sym
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `!Rails.env.production?` over `:production != Rails.env.to_sym`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !Rails.env.production?
+        RUBY
+      end
+    end
+  end
+
+  context 'when comparing `Rails.env.to_sym` to a string' do
+    it 'does not register when `Rails.env.to_sym` is used on LHS' do
+      expect_no_offenses(<<~RUBY)
+        Rails.env.to_sym == 'production'
+      RUBY
+    end
+
+    it 'does not register when `Rails.env.to_sym` is used on RHS' do
+      expect_no_offenses(<<~RUBY)
+        'production' == Rails.env.to_sym
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using `#good_method`' do
     expect_no_offenses(<<~RUBY)
       Rails.env.production?


### PR DESCRIPTION
Adds support for `Rails.env.to_sym` to `Rails/EnvironmentComparison` cop. Code like:
```ruby
Rails.env.to_sym == :production
```
will be registered as an offense and autocorrected to:
```ruby
Rails.env.production?
```

`Rails.env.to_sym` is used [relatively commonly](https://github.com/search?q=%22Rails.env.to_sym%22%20language%3ARuby&type=code&l=Ruby), and [there are some examples of it used to check the current env](https://github.com/search?q=%2FRails%5C.env%5C.to_sym%20%5B!%3D%5D%3D%2F%20language%3ARuby&type=code), so I think this is a worthwhile addition to the cop.

If this PR is accepted, `Rails/UnknownEnv` should also be updated to support `Rails.env.to_sym`.

Lastly, I took the opportunity to refactor the cop a bit. Let me know if it's too much for this PR.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
