### PR TITLE
Fix autocorrection error with nested offenses for `Rails/IndexWith`

### DIFF
--- a/changelog/fix_index_with_nested_offenses.md
+++ b/changelog/fix_index_with_nested_offenses.md
@@ -1,0 +1,1 @@
+* [#1483](https://github.com/rubocop/rubocop-rails/pull/1483): Fix autocorrection error when `Rails/IndexWith` has nested offenses. ([@lovro-bikic][])

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -132,9 +132,13 @@ module RuboCop
         add_offense(
           node, message: "Prefer `#{new_method_name}` over `#{match_desc}`."
         ) do |corrector|
+          next if part_of_ignored_node?(node)
+
           correction = prepare_correction(node)
           execute_correction(corrector, node, correction)
         end
+
+        ignore_node(node)
       end
 
       def extract_captures(match)

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -325,6 +325,28 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
         end
       end
     end
+
+    context 'with nested offenses' do
+      it 'registers offenses and autocorrects' do
+        expect_offense(<<~RUBY)
+          x.each_with_object({}) do |el, h|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `each_with_object`.
+            h[el] = el.each_with_object({}) do |inner_el, inner_h|
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `each_with_object`.
+              inner_h[inner_el] = foo(inner_el)
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.index_with do |el|
+            el.each_with_object({}) do |inner_el, inner_h|
+              inner_h[inner_el] = foo(inner_el)
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when using Rails 5.2 or older', :rails52 do


### PR DESCRIPTION
Currently, code that registers nested offenses for `Rails/IndexWith`:
```ruby
x.each_with_object({}) do |el, h|
# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `each_with_object`.
  h[el] = el.each_with_object({}) do |inner_el, inner_h|
#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_with` over `each_with_object`.
    inner_h[inner_el] = foo(inner_el)
  end
end
```
will fail on autocorrection with `Parser::ClobberingError: Parser::Source::TreeRewriter detected clobbering` error.

This PR fixes autocorrection by ignoring the node after first autocorrection, so the correction is done in multiple passes.

Since this cop shares logic with `Rails/IndexBy`, technically that cop is affected as well by this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
