### PR TITLE
Fix bugs in `Rails/PluckId` and `Rails/PluckInWhere`

### DIFF
--- a/changelog/fix_bugs_in_rails_pluck_id_and_rails_pluck_in_where.md
+++ b/changelog/fix_bugs_in_rails_pluck_id_and_rails_pluck_in_where.md
@@ -1,0 +1,1 @@
+* [#1497](https://github.com/rubocop/rubocop-rails/pull/1497): Fix bugs in `Rails/PluckId` and `Rails/PluckInWhere`. ([@r7kamura][])

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -106,7 +106,7 @@ module RuboCop
         send_node = node.each_ancestor(:call).first
         return false unless send_node
 
-        return true if WHERE_METHODS.include?(send_node.method_name)
+        return true if WHERE_METHODS.include?(send_node.method_name) && send_node.receiver != node
 
         receiver = send_node.receiver
         return false unless receiver&.send_type?

--- a/spec/rubocop/cop/rails/pluck_id_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_id_spec.rb
@@ -55,4 +55,17 @@ RSpec.describe RuboCop::Cop::Rails::PluckId, :config do
       Post.where(user_id: User.pluck(:id))
     RUBY
   end
+
+  context 'when `pluck` is the receiver of `where`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        Post.pluck(:id).where(id: 1..10)
+             ^^^^^^^^^^ Use `ids` instead of `pluck(:id)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Post.ids.where(id: 1..10)
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rails/pluck_in_where_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_in_where_spec.rb
@@ -132,6 +132,14 @@ RSpec.describe RuboCop::Cop::Rails::PluckInWhere, :config do
         RUBY
       end
     end
+
+    context 'when `pluck` is the receiver of `where`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          Post.pluck(:id).where(id: 1..10)
+        RUBY
+      end
+    end
   end
 
   context 'EnforcedStyle: aggressive' do


### PR DESCRIPTION
I found a bug in the implementation of `#in_where?`.

In the previous implementation, it would return `true` not only when the node was included in the arguments of `where`, but also when the node was the receiver of the `where` call.

This bug causes false negatives in `Rails/PluckId`:

```console
$ echo 'Post.pluck(:id).where(id: 1)' | bundle exec rubocop --stdin example.rb --only Rails/PluckId
Inspecting 1 file
.

1 file inspected, no offenses detected
```

and also causes false positives in `Rails/PluckInWhere`:

```console
$ echo 'Post.pluck(:id).where(id: 1)' | bundle exec rubocop --stdin example.rb --only Rails/PluckInWhere
Inspecting 1 file
C

Offenses:

example.rb:1:6: C: [Correctable] Rails/PluckInWhere: Use select instead of pluck within where query method.
Post.pluck(:id).where(id: 1)
     ^^^^^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

As far as I could tell from searching with `grep`, this method is only used in these two cops.

```console
$ git grep "in_where?"
lib/rubocop/cop/mixin/active_record_helper.rb:      def in_where?(node)
lib/rubocop/cop/rails/pluck_id.rb:          return if !pluck_id_call?(node) || in_where?(node)
lib/rubocop/cop/rails/pluck_in_where.rb:          return unless in_where?(node)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
