### PR TITLE
Exclude controllers and mailers from `Lint/UselessMethodDefinition`

### DIFF
--- a/changelog/change_exclude_controllers_and_mailers_from.md
+++ b/changelog/change_exclude_controllers_and_mailers_from.md
@@ -1,0 +1,1 @@
+* [#1500](https://github.com/rubocop/rubocop-rails/pull/1500): Exclude controllers and mailers from `Lint/UselessMethodDefinition`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -91,6 +91,12 @@ Lint/UselessAccessModifier:
     - concern
     - concerning
 
+Lint/UselessMethodDefinition:
+  # Avoids conflict with `Rails/LexicallyScopedActionFilter` cop.
+  Exclude:
+    - '**/app/controllers/**/*.rb'
+    - '**/app/mailers/**/*.rb'
+
 Rails:
   Enabled: true
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails


### PR DESCRIPTION
This is a proposal to address the following issues:

- https://github.com/rubocop/rubocop/issues/8667
- https://github.com/rubocop/rubocop-rails/issues/343

Currently, `Rails/LexicallyScopedActionFilter` is enabled by default for controllers and mailers. 

https://github.com/rubocop/rubocop-rails/blob/f57c3bacb1d57da2e3c2b14fcd6c3403016df27c/config/default.yml#L670-L678

Given this, I thought it would be reasonable to disable `Lint/UselessMethodDefinition` by default for them as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
