### PR TITLE
[Fix #1495] Fix false positives for `Rails/TransactionExitStatement`

### DIFF
--- a/changelog/fix_false_positives_for_rails_transaction_exit_statement.md
+++ b/changelog/fix_false_positives_for_rails_transaction_exit_statement.md
@@ -1,0 +1,1 @@
+* [#1495](https://github.com/rubocop/rubocop-rails/issues/1495): Fix false positives for `Rails/TransactionExitStatement` when `break` is used in loop in transactions. ([@koic][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -97,9 +97,11 @@ module RuboCop
 
         def in_transaction_block?(node)
           return false unless transaction_method_name?(node.method_name)
-          return false unless (parent = node.parent)
+          return false unless node.parent&.body
 
-          parent.any_block_type? && parent.body
+          node.right_siblings.none? do |sibling|
+            sibling.respond_to?(:loop_keyword?) && sibling.loop_keyword?
+          end
         end
 
         def statement(statement_node)

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
       RUBY
     end
 
+    it 'does not register an offense when `break` is used in `while` in transactions' do
+      expect_no_offenses(<<~RUBY)
+        ApplicationRecord.#{method} do
+          while proceed_looping? do
+            break if condition
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `break` is used in `until` in transactions' do
+      expect_no_offenses(<<~RUBY)
+        ApplicationRecord.#{method} do
+          until stop_looping? do
+            break if condition
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense when `break` is used in `each` with numblock in transactions' do
       expect_no_offenses(<<~RUBY)
         ApplicationRecord.#{method} do


### PR DESCRIPTION
This PR fixes false positives for `Rails/TransactionExitStatement` when `break` is used in loop in transactions.

Fixes #1495.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
