### PR TITLE
[Fix #1486] Fix false positives for `Rails/Output`

### DIFF
--- a/changelog/fix_false_positives_for_rails_output.md
+++ b/changelog/fix_false_positives_for_rails_output.md
@@ -1,0 +1,1 @@
+* [#1486](https://github.com/rubocop/rubocop-rails/issues/1486): Fix false positives for `Rails/Output` when `p` method is a DSL. ([@koic][])

--- a/lib/rubocop/cop/rails/output.rb
+++ b/lib/rubocop/cop/rails/output.rb
@@ -38,9 +38,11 @@ module RuboCop
             ...)
         PATTERN
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def on_send(node)
           return if node.parent&.call_type? || node.block_node
           return if !output?(node) && !io_output?(node)
+          return if node.arguments.any? { |arg| arg.type?(:hash, :block_pass) }
 
           range = offense_range(node)
 
@@ -48,6 +50,7 @@ module RuboCop
             corrector.replace(range, 'Rails.logger.debug')
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         private
 

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -134,9 +134,32 @@ RSpec.describe RuboCop::Cop::Rails::Output, :config do
     RUBY
   end
 
+  it 'registers an offense when `p` method with positional argument' do
+    expect_offense(<<~RUBY)
+      p(do_something)
+      ^ Do not write to stdout. Use Rails's logger if you want to log.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.logger.debug(do_something)
+    RUBY
+  end
+
   it 'does not register an offense when a method is called to a local variable with the same name as a print method' do
     expect_no_offenses(<<~RUBY)
       p.do_something
+    RUBY
+  end
+
+  it 'does not register an offense when `p` method with keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      p(class: 'this `p` method is a DSL')
+    RUBY
+  end
+
+  it 'does not register an offense when `p` method with symbol proc' do
+    expect_no_offenses(<<~RUBY)
+      p(&:this_p_method_is_a_dsl)
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes false positives for `Rails/Output` when `p` method is a DSL.

Fixes #1486.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
