### PR TITLE
[Fix #1508] Fix an error for `Rails/TransactionExitStatement` when method is chained

### DIFF
--- a/changelog/fix_error_transaction_exit.md
+++ b/changelog/fix_error_transaction_exit.md
@@ -1,0 +1,1 @@
+* [#1508](https://github.com/rubocop/rubocop-rails/issues/1508): Fix an error for `Rails/TransactionExitStatement` when `transaction` is part of a method chain. ([@earlopain][])

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -97,7 +97,8 @@ module RuboCop
 
         def in_transaction_block?(node)
           return false unless transaction_method_name?(node.method_name)
-          return false unless node.parent&.body
+          return false unless (parent = node.parent)
+          return false unless parent.any_block_type? && parent.body
 
           node.right_siblings.none? do |sibling|
             sibling.respond_to?(:loop_keyword?) && sibling.loop_keyword?

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -189,6 +189,18 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when a method call is chained' do
+      expect_no_offenses(<<~RUBY)
+        #{method}.foo
+      RUBY
+    end
+
+    it 'does not register an offense when no receiver and no block' do
+      expect_no_offenses(<<~RUBY)
+        #{method}
+      RUBY
+    end
   end
 
   it_behaves_like 'flags transaction exit statements', :transaction


### PR DESCRIPTION
Fix #1508

In that case, it's not the rails transaction method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
