### PR TITLE
Fix `Rails/OrderArguments` cop false positives

### DIFF
--- a/changelog/fix_rails_order_arguments_cop_false_positives.md
+++ b/changelog/fix_rails_order_arguments_cop_false_positives.md
@@ -1,0 +1,1 @@
+* [#1510](https://github.com/rubocop/rubocop-rails/pull/1510): Fix `Rails/OrderArguments` cop false positives when using column index argument. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/order_arguments.rb
+++ b/lib/rubocop/cop/rails/order_arguments.rb
@@ -52,6 +52,7 @@ module RuboCop
           order_arguments.map! { |arg| extract_column_and_direction(arg.strip) }
 
           return if order_arguments.any?(&:nil?)
+          return if order_arguments.any? { |column_name, _| positional_column?(column_name) }
 
           convert_to_preferred_arguments(order_arguments).join(', ')
         end
@@ -66,6 +67,10 @@ module RuboCop
               "#{column}: :#{direction}"
             end
           end
+        end
+
+        def positional_column?(column_name)
+          column_name.match?(/\A\d+\z/)
         end
 
         def extract_column_and_direction(order_expression)

--- a/spec/rubocop/cop/rails/order_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/order_arguments_spec.rb
@@ -128,4 +128,30 @@ RSpec.describe RuboCop::Cop::Rails::OrderArguments, :config do
       User.order('LEFT(first_name, 1)')
     RUBY
   end
+
+  context 'with numeric string literal column name' do
+    it 'does not register an offense for `order` with a string argument' do
+      expect_no_offenses(<<~RUBY)
+        User.order('1')
+      RUBY
+    end
+
+    it 'does not register an offense for `order` with multiple string arguments' do
+      expect_no_offenses(<<~RUBY)
+        User.order('1', 'last_name')
+      RUBY
+    end
+
+    it 'does not registers an offense for `order` with a string argument with DESC direction' do
+      expect_no_offenses(<<~RUBY)
+        User.order('1 DESC')
+      RUBY
+    end
+
+    it 'does not register an offense for `order` with a string argument with ASC order' do
+      expect_no_offenses(<<~RUBY)
+        User.order('1 ASC')
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
ref: https://github.com/rubocop/rubocop-rails/pull/1501

```shell
echo 'User.order("1")' | bundle exec rubocop --stdin bug.rb -A --only Rails/OrderArguments
Inspecting 1 file
F

Offenses:

bug.rb:1:12: C: [Corrected] Rails/OrderArguments: Prefer :1 instead. (https://rails.rubystyle.guide/#order-arguments)
User.order("1")
           ^^^
bug.rb:1:13: F: Lint/Syntax: invalid symbol
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
User.order(:1)

bug.rb:1:13: F: Lint/Syntax: unexpected integer; expected a ) to close the arguments
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
User.order(:1)
            ^
bug.rb:1:14: F: Lint/Syntax: unexpected ')', expecting end-of-input
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
User.order(:1)
             ^

1 file inspected, 4 offenses detected, 1 offense corrected
====================
User.order(:1)
```

The same happens for these cases:

```
order("1 ASC")          # => User.order(:1)
order("1 DESC")         # => User.order(1: :desc)
order("id ASC, 2 DESC") # => User.order(:id, 2: :desc)
```

`order("1")` can be autocorrected to `order(1)`, but this can be done separately.


Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
