### PR TITLE
[Fix #1488] Fix an error for `Rails/ReadWriteAttribute` cop

### DIFF
--- a/changelog/fix_an_error_for_rails_read_write_attribute_cop.md
+++ b/changelog/fix_an_error_for_rails_read_write_attribute_cop.md
@@ -1,0 +1,1 @@
+* [#1488](https://github.com/rubocop/rubocop-rails/issues/1488): Fix an error for `Rails/ReadWriteAttribute` with a frozen string attribute name. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -66,7 +66,7 @@ module RuboCop
           return false unless enclosing_method
 
           shadowing_method_name = first_arg.value.to_s
-          shadowing_method_name << '=' if node.method?(:write_attribute)
+          shadowing_method_name += '=' if node.method?(:write_attribute)
           enclosing_method.method?(shadowing_method_name)
         end
 

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -235,6 +235,21 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute, :config do
       RUBY
     end
 
+    it 'corrects assignment with chained methods when using string attribute name' do
+      expect_offense(<<~RUBY)
+        def attr2=(k)
+          write_attribute("attr", 'test_' + postfix)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `self["attr"] = 'test_' + postfix`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def attr2=(k)
+          self["attr"] = 'test_' + postfix
+        end
+      RUBY
+    end
+
     it 'autocorrects multiline' do
       expect_offense(<<~RUBY)
         write_attribute(


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop-rails/issues/1488

Basically we should not assume AST literals are not frozen.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
