### PR TITLE
Fix wrong autocorrect for `Rails/FindByOrAssignmentMemoization`

### DIFF
--- a/changelog/fix_autocorrect_for_find_by_memo.md
+++ b/changelog/fix_autocorrect_for_find_by_memo.md
@@ -1,0 +1,1 @@
+* [#1516](https://github.com/rubocop/rubocop-rails/pull/1516): Fix wrong autocorrect for `Rails/FindByOrAssignmentMemoization`. ([@earlopain][])


### PR DESCRIPTION
Followup to https://github.com/rubocop/rubocop-rails/commit/501e5d39f0815b189f0ce480b5a58855071c7bb9

This type of autocorrect can only happen if the method contains no other code. Otherwise, it would exist early if followed by other code. Docs only contained example code for it happening inside of a method in that way, but the cop actually checks for the pattern regardless of context. In such cases, the longer form of autocorrect must happen.

Ref https://github.com/rubocop/rubocop-rails/issues/1513

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
