### PR TITLE
Fix an error for `Rails/FindBy` when `where` takes a block

### DIFF
--- a/changelog/fix_error_find_by_block.md
+++ b/changelog/fix_error_find_by_block.md
@@ -1,0 +1,1 @@
+* [#1522](https://github.com/rubocop/rubocop-rails/pull/1522): Fix an error for `Rails/FindBy` when `where` takes a block. ([@earlopain][])

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -46,7 +46,7 @@ module RuboCop
         private
 
         def where_method?(receiver)
-          return false unless receiver
+          return false if !receiver || receiver.any_block_type?
 
           receiver.respond_to?(:method?) && receiver.method?(:where)
         end

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -103,6 +103,12 @@ RSpec.describe RuboCop::Cop::Rails::FindBy, :config do
     RUBY
   end
 
+  it 'does not register an offense when where takes a block' do
+    expect_no_offenses(<<~RUBY)
+      where { foo }.take
+    RUBY
+  end
+
   context 'when `IgnoreWhereFirst: true' do
     let(:cop_config) do
       { 'IgnoreWhereFirst' => true }


### PR DESCRIPTION
The rails method doesn't take a block, so it should do nothing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
