### PR TITLE
[Fix rubocop#1182] Fix a false positive for Rails/ActionControllerFlashBeforeRender

### DIFF
--- a/changelog/fix_false_negative_for_rails_action_controller_flash_before_render.md
+++ b/changelog/fix_false_negative_for_rails_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#x](https://github.com/rubocop/rubocop-rails/pull/x): Merge pull request #1522 from Earlopain/find-by-where-block. ([@][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -73,7 +73,7 @@ module RuboCop
             return false if use_redirect_to?(context)
 
             context = node
-          elsif context.right_siblings.empty?
+          elsif context.right_siblings.empty? && !use_redirect_to?(context.parent)
             return true
           end
           context = context.right_siblings

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -395,4 +395,36 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
       RUBY
     end
   end
+
+  context 'when using `flash` in a one-line iteration block before `redirect_to`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class HomeController < ApplicationController
+          def create
+            messages = %w[fizz buzz fizzbuzz]
+            messages.each { flash[:alert] = _1 }
+
+            redirect_to :index
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when using `flash` in a multi-line block before `redirect_to`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class HomeController < ApplicationController
+          def create
+            messages = %w[fizz buzz fizzbuzz]
+            messages.each do |message|
+              flash[:alert] = message
+            end
+
+            redirect_to :index
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
…shBeforeRender

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
