### PR TITLE
Allow TransactionExitStatement to be configured to be enabled for all Rails versions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1202,6 +1202,9 @@ Rails/TransactionExitStatement:
   Enabled: pending
   VersionAdded: '2.14'
   TransactionMethods: []
+  # This rule is disabled by default in Rails 7.2 and above
+  # Set EnableForAllRailsVersions to true to enable this rule regardless of Rails version
+  EnableForAllRailsVersions: false
 
 Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -80,7 +80,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if target_rails_version >= 7.2
+          return unless enable_for_all_rails_versions? || target_rails_version < 7.2
           return unless in_transaction_block?(node)
 
           exit_statements(node.parent.body).each do |statement_node|
@@ -126,6 +126,10 @@ module RuboCop
 
         def transaction_method?(method_name)
           cop_config.fetch('TransactionMethods', []).include?(method_name.to_s)
+        end
+
+        def enable_for_all_rails_versions?
+          cop_config.fetch('EnableForAllRailsVersions', false)
         end
       end
     end

--- a/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
+++ b/spec/rubocop/cop/rails/transaction_exit_statement_spec.rb
@@ -220,5 +220,15 @@ RSpec.describe RuboCop::Cop::Rails::TransactionExitStatement, :config do
         end
       RUBY
     end
+
+    context 'when EnableForAllRailsVersions is true' do
+      let(:cop_config) { { 'EnableForAllRailsVersions' => true } }
+      it_behaves_like 'flags transaction exit statements', :transaction
+      it_behaves_like 'flags transaction exit statements', :with_lock
+      context 'when `TransactionMethods: [writable_transaction]`' do
+        let(:cop_config) { super().merge({ 'TransactionMethods' => %w[writable_transaction] }) }
+        it_behaves_like 'flags transaction exit statements', :writable_transaction
+      end
+    end
   end
 end


### PR DESCRIPTION
Rails 7.2 restored the previous behavior of non-local returns in transaction and rubocop-rails [updated the TransactionExitStatement cop to be disabled in Rails 7.2 and above](https://github.com/rubocop/rubocop-rails/pull/1366). Even though we're back to the original behavior I'm not confident that the non-local return in transaction behavior is obvious or intuitive to all devs. I would prefer to be able to continue to enforce this cop in Rails 7.2 and beyond.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
