### PR TITLE
Add `AllowedPredicates` configuration option to `Rails/Env`

### DIFF
--- a/changelog/new_rails_env_allowed_predicates_config.md
+++ b/changelog/new_rails_env_allowed_predicates_config.md
@@ -1,0 +1,1 @@
+* [#1617](https://github.com/rubocop/rubocop-rails/pull/1617): Add `AllowedPredicates` configuration option to `Rails/Env`. Users can now customize which predicate methods on `Rails.env` are exempt from the cop (e.g. to allow `Rails.env.local?` or a custom monkey-patched predicate). ([@dduugg][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -472,6 +472,23 @@ Rails/Env:
   Description: 'Use Feature Flags or config instead of `Rails.env`.'
   Enabled: false
   VersionAdded: '2.34'
+  VersionChanged: "<<next>>"
+  AllowedPredicates:
+    - unicode_normalized?
+    - exclude?
+    - empty?
+    - acts_like_string?
+    - include?
+    - is_utf8?
+    - casecmp?
+    - match?
+    - starts_with?
+    - ends_with?
+    - start_with?
+    - end_with?
+    - valid_encoding?
+    - ascii_only?
+    - between?
 
 Rails/EnvLocal:
   Description: 'Use `Rails.env.local?` instead of `Rails.env.development? || Rails.env.test?`.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -474,21 +474,21 @@ Rails/Env:
   VersionAdded: '2.34'
   VersionChanged: "<<next>>"
   AllowedPredicates:
-    - unicode_normalized?
-    - exclude?
-    - empty?
     - acts_like_string?
-    - include?
-    - is_utf8?
-    - casecmp?
-    - match?
-    - starts_with?
-    - ends_with?
-    - start_with?
-    - end_with?
-    - valid_encoding?
     - ascii_only?
     - between?
+    - casecmp?
+    - empty?
+    - end_with?
+    - ends_with?
+    - exclude?
+    - include?
+    - is_utf8?
+    - match?
+    - start_with?
+    - starts_with?
+    - unicode_normalized?
+    - valid_encoding?
 
 Rails/EnvLocal:
   Description: 'Use `Rails.env.local?` instead of `Rails.env.development? || Rails.env.test?`.'

--- a/lib/rubocop/cop/rails/env.rb
+++ b/lib/rubocop/cop/rails/env.rb
@@ -3,7 +3,24 @@
 module RuboCop
   module Cop
     module Rails
-      # Checks for usage of `Rails.env` which can be replaced with Feature Flags
+      # Checks for usage of `Rails.env` which can be replaced with Feature Flags.
+      #
+      # Predicate methods listed in `AllowedPredicates` are not flagged. The default
+      # list covers the `String` / `StringInquirer` predicates that aren't
+      # environment-specific (e.g. `empty?`, `match?`, `between?`). The configured
+      # value fully replaces the default — to exempt an additional predicate
+      # such as `Rails.env.local?` (or a custom predicate monkey-patched onto
+      # the environment inquirer) while preserving the defaults, list them all
+      # together. Merge semantics can be opted into via RuboCop's `inherit_mode`.
+      #
+      # [source,yaml]
+      # ----
+      #  Rails/Env:
+      #    AllowedPredicates:
+      #      - empty?
+      #      - match?
+      #      - local?
+      # ----
       #
       # @example
       #
@@ -18,28 +35,6 @@ module RuboCop
       class Env < Base
         MSG = 'Use Feature Flags or config instead of `Rails.env`.'
         RESTRICT_ON_SEND = %i[env].freeze
-        # This allow list is derived from:
-        # (Rails.env.methods - Object.instance_methods).select { |m| m.to_s.end_with?('?') }
-        # and then removing the environment specific methods like development?, test?, production?, local?
-        ALLOWED_LIST = Set.new(
-          %i[
-            unicode_normalized?
-            exclude?
-            empty?
-            acts_like_string?
-            include?
-            is_utf8?
-            casecmp?
-            match?
-            starts_with?
-            ends_with?
-            start_with?
-            end_with?
-            valid_encoding?
-            ascii_only?
-            between?
-          ]
-        ).freeze
 
         def on_send(node)
           return unless node.receiver&.const_name == 'Rails'
@@ -47,9 +42,15 @@ module RuboCop
           parent = node.parent
           return unless parent.respond_to?(:predicate_method?) && parent.predicate_method?
 
-          return if ALLOWED_LIST.include?(parent.method_name)
+          return if allowed_predicates.include?(parent.method_name)
 
           add_offense(parent)
+        end
+
+        private
+
+        def allowed_predicates
+          @allowed_predicates ||= Array(cop_config['AllowedPredicates']).to_set(&:to_sym)
         end
       end
     end

--- a/spec/rubocop/cop/rails/env_spec.rb
+++ b/spec/rubocop/cop/rails/env_spec.rb
@@ -35,9 +35,31 @@ RSpec.describe RuboCop::Cop::Rails::Env, :config do
     RUBY
   end
 
+  it 'registers an offense for `Rails.env.local?` under the default `AllowedPredicates`' do
+    expect_offense(<<~RUBY)
+      Rails.env.local?
+      ^^^^^^^^^^^^^^^^ Use Feature Flags or config instead of `Rails.env`.
+    RUBY
+  end
+
   it 'does not register an offense for unrelated config' do
     expect_no_offenses(<<~RUBY)
       Rails.environment
     RUBY
+  end
+
+  context 'with `AllowedPredicates` overridden' do
+    let(:cop_config) { { 'AllowedPredicates' => ['local?'] } }
+
+    it 'does not register an offense for a predicate listed in the config' do
+      expect_no_offenses('raise unless Rails.env.local?')
+    end
+
+    it 'registers an offense for a predicate omitted from the config' do
+      expect_offense(<<~RUBY)
+        Rails.env.empty?
+        ^^^^^^^^^^^^^^^^ Use Feature Flags or config instead of `Rails.env`.
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
## Summary

Replace `Rails/Env`'s hard-coded `ALLOWED_LIST` constant with a configurable `AllowedPredicates` option. The default value is the previous `ALLOWED_LIST` content — `String` / `StringInquirer` predicates like `empty?`, `match?`, `between?` — so out-of-the-box behavior is unchanged.

The motivation is to let users exempt additional predicates from the cop without forking or disabling it. Two concrete cases this addresses:

- **`Rails.env.local?`** — the built-in alias for "development or test", introduced in Rails 7.1. Some users treat it as a legitimate guard rail for code that should only ever execute in dev or test (sanity checks, devtools, seed data) rather than as an environment-rollout mechanism, and want it exempt from the cop.
- **Custom predicates monkey-patched onto the environment inquirer.** Apps with their own `Rails.env.beta_user?` / `Rails.env.internal?` style helpers can now opt those in.

The configured value **fully replaces** the default — it is not merged. Users who want to inherit the defaults and add to them can opt in via RuboCop's [`inherit_mode`](https://docs.rubocop.org/rubocop/configuration.html#merging-arrays-using-inherit_mode):

```yaml
Rails/Env:
  AllowedPredicates:
    - empty?
    - match?
    - local?
```

## Compatibility with `Rails/EnvLocal`

[`Rails/EnvLocal`](https://docs.rubocop.org/rubocop-rails/latest/cops_rails.html#railsenvlocal) autocorrects `Rails.env.development? || Rails.env.test?` → `Rails.env.local?`. Under the default `AllowedPredicates`, `Rails/Env` will still flag the autocorrected `Rails.env.local?`. Users who run both cops can now resolve that conflict by including `local?` in their `AllowedPredicates` rather than disabling either cop.

## Test coverage

A new context block uses `let(:cop_config)` to override `AllowedPredicates` and verifies (a) a predicate in the override is not flagged, and (b) a predicate omitted from the override is flagged — confirming the override is exhaustive (no implicit merge with defaults).

## Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (no related issue).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added an entry to the changelog folder.
* [ ] If this is a new cop, consider making a corresponding update to the Rails Style Guide (N/A — existing cop).
