### PR TITLE
Optimize `HttpPositionalArguments` cop

### DIFF
--- a/changelog/change_improve_http_positional_arguments_performance.md
+++ b/changelog/change_improve_http_positional_arguments_performance.md
@@ -1,0 +1,1 @@
+* [#1652](https://github.com/rubocop/rubocop-rails/pull/1652): Improve `Rails/HttpPositionalArguments` performance by checking for `include Rack::Test::Methods` once per file instead of once per HTTP call. ([@moberegger][])

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -51,6 +51,10 @@ module RuboCop
                 (const {nil? cbase} :Rack) :Test) :Methods))
         PATTERN
 
+        def on_new_investigation
+          @use_rack_test_methods = nil
+        end
+
         def on_send(node)
           return if in_routing_block?(node) || use_rack_test_methods?
 
@@ -81,8 +85,11 @@ module RuboCop
           !!node.each_ancestor(:block).detect { |block| ROUTING_METHODS.include?(block.method_name) }
         end
 
+        # The result is the same for every node in a file, so scan the AST only once.
         def use_rack_test_methods?
-          processed_source.ast.each_descendant(:send).any? do |node|
+          return @use_rack_test_methods unless @use_rack_test_methods.nil?
+
+          @use_rack_test_methods = processed_source.ast.each_descendant(:send).any? do |node|
             include_rack_test_methods?(node)
           end
         end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -475,5 +475,20 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments, :config do
         RUBY
       end
     end
+
+    context 'when a source using `include Rack::Test::Methods` is followed by one that does not' do
+      it 'still registers an offense for the second source' do
+        expect_no_offenses(<<~RUBY)
+          include Rack::Test::Methods
+
+          get :create, user_id: @user.id
+        RUBY
+
+        expect_offense(<<~RUBY)
+          get :create, user_id: @user.id
+                       ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm trying to trim down my Rubocop run times in a rather large project. The `Rails/HttpPositionalArguments` came up as the most expensive one in our profiles. It took 11.15 s across 6,163 calls (about 1.8 ms per call).

I found a somewhat low hanging fruit that I am hoping will help. `use_rack_test_methods?` walks the entire AST of the file each time `get`, `post`, `put`, `patch`, `delete`, and `head` are used to see if `Rack::Test::Methods` is included. The result of that cannot change within one file, so we can memoize it. Note that we can't use `||=` here because `false` is a valid value that should be memoized.

I _think_ a new instance of a cop is created per file, but wasn't certain. I added a test case to ensure that the memoized result doesn't bleed over from source to source. The `FindByOrAssignmentMemoization` cop uses a similar memoization pattern which made me feel more confident in this approach.

Some benchmarks below

| http calls in file | before | after | speedup | offenses |
|---|---|---|---|---|
| 50 | 27.2 ms | 8.8 ms | 3.1x | 50 |
| 200 | 356.0 ms | 33.0 ms | 10.8x | 200 |
| 800 | 5562.4 ms | 128.3 ms | 43.3x | 800 |

(Full disclosure: I had Claude help me write the benchmarks. I am not too familiar with the Rubocop API so struggled to do this. I can share the source for that if you like... it is rather verbose, though)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
