### PR TITLE
Support the HTTP QUERY method in route and test cops

### DIFF
--- a/changelog/change_support_http_query_method_in_route_and_test_cops.md
+++ b/changelog/change_support_http_query_method_in_route_and_test_cops.md
@@ -1,0 +1,1 @@
+* [#1653](https://github.com/rubocop/rubocop-rails/pull/1653): Support the HTTP QUERY method (Rails 8.2) in `Rails/MatchRoute`, `Rails/MultipleRoutePaths`, and `Rails/HttpPositionalArguments`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -600,6 +600,7 @@ Rails/HttpPositionalArguments:
   Description: 'Use keyword arguments instead of positional arguments in http method calls.'
   Enabled: true
   VersionAdded: '0.44'
+  VersionChanged: '<<next>>'
   Include:
     - '**/spec/**/*'
     - '**/test/**/*'
@@ -726,10 +727,11 @@ Rails/MailerName:
 Rails/MatchRoute:
   Description: >-
                   Don't use `match` to define any routes unless there is a need to map multiple request types
-                  among [:get, :post, :patch, :put, :delete] to a single action using the `:via` option.
+                  among [:get, :post, :patch, :put, :delete, :query] to a single action using the `:via` option.
   StyleGuide: 'https://rails.rubystyle.guide/#no-match-routes'
   Enabled: 'pending'
   VersionAdded: '2.7'
+  VersionChanged: '<<next>>'
   Include:
     - '**/config/routes.rb'
     - '**/config/routes/**/*.rb'
@@ -747,6 +749,7 @@ Rails/MultipleRoutePaths:
   Enabled: pending
   Severity: warning
   VersionAdded: '2.29'
+  VersionChanged: '<<next>>'
   Include:
     - '**/config/routes.rb'
     - '**/config/routes/**/*.rb'

--- a/lib/rubocop/cop/mixin/routes_helper.rb
+++ b/lib/rubocop/cop/mixin/routes_helper.rb
@@ -6,7 +6,7 @@ module RuboCop
     module RoutesHelper
       extend NodePattern::Macros
 
-      HTTP_METHODS = %i[get post put patch delete].freeze
+      HTTP_METHODS = %i[get post put patch delete query].freeze
 
       def_node_matcher :routes_draw?, <<~PATTERN
         (send (send _ :routes) :draw)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -28,7 +28,7 @@ module RuboCop
         MSG = 'Use keyword arguments instead of positional arguments for http call: `%<verb>s`.'
         KEYWORD_ARGS = %i[method params session body flash xhr as headers env to].freeze
         ROUTING_METHODS = %i[draw routes].freeze
-        RESTRICT_ON_SEND = %i[get post put patch delete head].freeze
+        RESTRICT_ON_SEND = %i[get post put patch delete head query].freeze
 
         minimum_target_rails_version 5.0
 

--- a/lib/rubocop/cop/rails/match_route.rb
+++ b/lib/rubocop/cop/rails/match_route.rb
@@ -7,7 +7,10 @@ module RuboCop
       # can be replaced with a specific HTTP method.
       #
       # Don't use `match` to define any routes unless there is a need to map multiple request types
-      # among [:get, :post, :patch, :put, :delete] to a single action using the `:via` option.
+      # among [:get, :post, :patch, :put, :delete, :query] to a single action using the `:via` option.
+      #
+      # NOTE: `via: :query` is registered as an offense only when the target Rails version is 8.2
+      # or higher, where the `query` route helper is available.
       #
       # @example
       #   # bad
@@ -80,7 +83,10 @@ module RuboCop
         end
 
         def http_method?(method)
-          HTTP_METHODS.include?(method.to_sym)
+          method = method.to_sym
+          return false if method == :query && target_rails_version < 8.2
+
+          HTTP_METHODS.include?(method)
         end
 
         def replacement(path_node, options_node)

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments, :config do
       expect_no_offenses('head :destroy, id: @user.id')
     end
 
+    it 'does not register an offense for query method' do
+      expect_no_offenses('query :create, user_id: @user.id')
+    end
+
     it 'does not register an offense for process method' do
       expect_no_offenses(<<~RUBY)
         process :new, method: :get, params: { user_id: @user.id }
@@ -166,6 +170,17 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments, :config do
 
       expect_correction(<<~RUBY)
         head :create, params: { user_id: @user.id }
+      RUBY
+    end
+
+    it 'registers an offense for query method' do
+      expect_offense(<<~RUBY)
+        query :create, user_id: @user.id
+                       ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `query`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        query :create, params: { user_id: @user.id }
       RUBY
     end
 

--- a/spec/rubocop/cop/rails/match_route_spec.rb
+++ b/spec/rubocop/cop/rails/match_route_spec.rb
@@ -113,4 +113,31 @@ RSpec.describe RuboCop::Cop::Rails::MatchRoute, :config do
       end
     RUBY
   end
+
+  context 'Rails >= 8.2', :rails82 do
+    it 'registers an offense and corrects when using `match` with `via: :query`' do
+      expect_offense(<<~RUBY)
+        routes.draw do
+          match 'search', to: 'search#index', via: :query
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `query` instead of `match` to define a route.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        routes.draw do
+          query 'search', to: 'search#index'
+        end
+      RUBY
+    end
+  end
+
+  context 'Rails <= 8.1', :rails81 do
+    it 'does not register an offense when using `match` with `via: :query`' do
+      expect_no_offenses(<<~RUBY)
+        routes.draw do
+          match 'search', to: 'search#index', via: :query
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rails/multiple_route_paths_spec.rb
+++ b/spec/rubocop/cop/rails/multiple_route_paths_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe RuboCop::Cop::Rails::MultipleRoutePaths, :config do
     RUBY
   end
 
+  it 'registers an offense when using `query` with multiple route paths' do
+    expect_offense(<<~RUBY)
+      Rails.application.routes.draw do
+        query '/users', '/other_path/users', to: 'users#index'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use separate routes instead of combining multiple route paths in a single route.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rails.application.routes.draw do
+        query '/users', to: 'users#index'
+        query '/other_path/users', to: 'users#index'
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using single string path method calls' do
     expect_no_offenses(<<~RUBY)
       Rails.application.routes.draw do

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -43,3 +43,7 @@ end
 RSpec.shared_context 'with Rails 8.1', :rails81 do
   let(:rails_version) { 8.1 }
 end
+
+RSpec.shared_context 'with Rails 8.2', :rails82 do
+  let(:rails_version) { 8.2 }
+end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/57973.

Rails 8.2 will support the HTTP QUERY method (RFC 10008), adding the `query` routing helper, `via: :query`, and `query` request helpers for both integration tests and `ActionController::TestCase`. Note that the Rails PR description says no `ActionController::TestCase` wrapper is added (mirroring `options`), but the merged implementation does add one, so controller tests are covered as well. This change makes the existing cops aware of the new method:

## `Rails/MatchRoute` cop

`Rails/MatchRoute` cop corrects `match 'x', via: :query` to `query 'x'`. This is limited to `TargetRailsVersion` 8.2 or higher because the `query` routing helper does not exist on older Rails and the correction would raise `NoMethodError` at route drawing time.

## `Rails/MultipleRoutePaths` cop

`Rails/MultipleRoutePaths` cop detects `query` routes with multiple paths. Drawing a route with multiple paths has already been removed and raises `ArgumentError` at route drawing time, so the cop catches such routes before boot and splits them into separate routes.

## `Rails/HttpPositionalArguments` cop

`Rails/HttpPositionalArguments` cop converts positional arguments of the `query` test request helpers to keyword arguments. The positional style raises `ArgumentError` at runtime in both `ActionController::TestCase` and integration tests, and the corrected `params:` form works.

No version gate is needed because using the helper implies a newer Rails.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
