### PR TITLE
Add new Rails/InGroupsOf cop

### DIFF
--- a/changelog/new_in_groups_of_cop.md
+++ b/changelog/new_in_groups_of_cop.md
@@ -1,0 +1,1 @@
+* [#1654](https://github.com/rubocop/rubocop-rails/pull/1653): Add new `Rails/InGroupsOf` cop that prefers `each_slice` over `in_groups_of` to avoid bugs from implicit `nil` padding. ([@jcoleman][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -665,6 +665,16 @@ Rails/IgnoredSkipActionFilterOption:
     - '**/app/controllers/**/*.rb'
     - '**/app/mailers/**/*.rb'
 
+Rails/InGroupsOf:
+  Description: 'Prefer `each_slice` over `in_groups_of` to avoid padding groups with `nil`.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '<<next>>'
+  EnforcedStyle: each_slice
+  SupportedStyles:
+    - each_slice
+    - explicit
+
 Rails/IndexBy:
   Description: 'Prefer `index_by` over `each_with_object`, `to_h`, or `map`.'
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -78,6 +78,7 @@ based on the https://rails.rubystyle.guide/[Rails Style Guide].
 * xref:cops_rails.adoc#railsi18nlocaletexts[Rails/I18nLocaleTexts]
 * xref:cops_rails.adoc#railsignoredcolumnsassignment[Rails/IgnoredColumnsAssignment]
 * xref:cops_rails.adoc#railsignoredskipactionfilteroption[Rails/IgnoredSkipActionFilterOption]
+* xref:cops_rails.adoc#railsingroupsof[Rails/InGroupsOf]
 * xref:cops_rails.adoc#railsindexby[Rails/IndexBy]
 * xref:cops_rails.adoc#railsindexwith[Rails/IndexWith]
 * xref:cops_rails.adoc#railsinquiry[Rails/Inquiry]

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3551,6 +3551,108 @@ end
 
 * https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-_normalize_callback_options
 
+[#railsingroupsof]
+== Rails/InGroupsOf
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| No
+| No
+| <<next>>
+| -
+|===
+
+Identifies places where Active Support's `Enumerable#in_groups_of` is used to
+chunk a collection and, where possible, encourages the Ruby built-in
+`Enumerable#each_slice` instead.
+
+When `in_groups_of` is called without a second argument, the final group is
+padded with `nil` so that every group has the same size. This padding is easy
+to forget about and frequently leads to a `NoMethodError` on `nil` (or another
+`TypeError`) downstream, because the code assumed every element was a real
+member of the collection. `each_slice` performs the same chunking without
+inserting `nil` padding, so preferring it prevents this class of bug.
+
+Passing an explicit `false` as the second argument (`in_groups_of(number, false)`)
+is exactly equivalent to `each_slice(number)`, so those calls are reported too under
+the default `each_slice` style. Any other explicit second argument (including an
+explicit `nil`) signals that padding is intentional and is left alone.
+
+When `EnforcedStyle` is set to `explicit`, calls without a second argument are
+instead reported with a suggestion to add an explicit second argument, making the
+padding behavior obvious at the call site rather than switching to `each_slice`. In
+this style any explicit second argument is accepted, including `false`.
+
+This cop does not support autocorrection because it cannot determine whether an
+omitted second argument reflects an intentional desire to pad groups with `nil`
+or an oversight that should be replaced with `each_slice`.
+
+[#safety-railsingroupsof]
+=== Safety
+
+This cop is unsafe because `each_slice` and `in_groups_of` are only defined on
+different receivers (`in_groups_of` is an Active Support extension), and their
+return values differ: `each_slice` without a block returns an `Enumerator`,
+while `in_groups_of` without a block returns an `Array`.
+
+[#examples-railsingroupsof]
+=== Examples
+
+[source,ruby]
+----
+# bad
+collection.in_groups_of(3)
+
+# bad
+collection.in_groups_of(3, false)
+
+# good
+collection.each_slice(3)
+
+# good
+collection.in_groups_of(3, 0)
+----
+
+[#enforcedstyle_-each_slice-_default_-railsingroupsof]
+==== EnforcedStyle: each_slice (default)
+
+[source,ruby]
+----
+# bad
+collection.in_groups_of(3)
+
+# good
+collection.each_slice(3)
+----
+
+[#enforcedstyle_-explicit-railsingroupsof]
+==== EnforcedStyle: explicit
+
+[source,ruby]
+----
+# bad
+collection.in_groups_of(3)
+
+# good
+collection.in_groups_of(3, false)
+
+# good
+collection.in_groups_of(3, nil)
+----
+
+[#configurable-attributes-railsingroupsof]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyle
+| `each_slice`
+| `each_slice`, `explicit`
+|===
+
 [#railsindexby]
 == Rails/IndexBy
 

--- a/lib/rubocop/cop/rails.rb
+++ b/lib/rubocop/cop/rails.rb
@@ -72,6 +72,7 @@ module RuboCop
       register_cop :I18nLocaleTexts, "#{__dir__}/rails/i18n_locale_texts"
       register_cop :IgnoredColumnsAssignment, "#{__dir__}/rails/ignored_columns_assignment"
       register_cop :IgnoredSkipActionFilterOption, "#{__dir__}/rails/ignored_skip_action_filter_option"
+      register_cop :InGroupsOf, "#{__dir__}/rails/in_groups_of"
       register_cop :IndexBy, "#{__dir__}/rails/index_by"
       register_cop :IndexWith, "#{__dir__}/rails/index_with"
       register_cop :Inquiry, "#{__dir__}/rails/inquiry"

--- a/lib/rubocop/cop/rails/in_groups_of.rb
+++ b/lib/rubocop/cop/rails/in_groups_of.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Identifies places where Active Support's `Enumerable#in_groups_of` is used to
+      # chunk a collection and, where possible, encourages the Ruby built-in
+      # `Enumerable#each_slice` instead.
+      #
+      # When `in_groups_of` is called without a second argument, the final group is
+      # padded with `nil` so that every group has the same size. This padding is easy
+      # to forget about and frequently leads to a `NoMethodError` on `nil` (or another
+      # `TypeError`) downstream, because the code assumed every element was a real
+      # member of the collection. `each_slice` performs the same chunking without
+      # inserting `nil` padding, so preferring it prevents this class of bug.
+      #
+      # Passing an explicit `false` as the second argument (`in_groups_of(number, false)`)
+      # is exactly equivalent to `each_slice(number)`, so those calls are reported too under
+      # the default `each_slice` style. Any other explicit second argument (including an
+      # explicit `nil`) signals that padding is intentional and is left alone.
+      #
+      # When `EnforcedStyle` is set to `explicit`, calls without a second argument are
+      # instead reported with a suggestion to add an explicit second argument, making the
+      # padding behavior obvious at the call site rather than switching to `each_slice`. In
+      # this style any explicit second argument is accepted, including `false`.
+      #
+      # This cop does not support autocorrection because it cannot determine whether an
+      # omitted second argument reflects an intentional desire to pad groups with `nil`
+      # or an oversight that should be replaced with `each_slice`.
+      #
+      # @safety
+      #   This cop is unsafe because `each_slice` and `in_groups_of` are only defined on
+      #   different receivers (`in_groups_of` is an Active Support extension), and their
+      #   return values differ: `each_slice` without a block returns an `Enumerator`,
+      #   while `in_groups_of` without a block returns an `Array`.
+      #
+      # @example
+      #   # bad
+      #   collection.in_groups_of(3)
+      #
+      #   # bad
+      #   collection.in_groups_of(3, false)
+      #
+      #   # good
+      #   collection.each_slice(3)
+      #
+      #   # good
+      #   collection.in_groups_of(3, 0)
+      #
+      # @example EnforcedStyle: each_slice (default)
+      #   # bad
+      #   collection.in_groups_of(3)
+      #
+      #   # good
+      #   collection.each_slice(3)
+      #
+      # @example EnforcedStyle: explicit
+      #   # bad
+      #   collection.in_groups_of(3)
+      #
+      #   # good
+      #   collection.in_groups_of(3, false)
+      #
+      #   # good
+      #   collection.in_groups_of(3, nil)
+      class InGroupsOf < Base
+        include ConfigurableEnforcedStyle
+
+        MSG_EACH_SLICE = 'Use `each_slice` instead of `in_groups_of` to avoid padding groups with `nil`.'
+        MSG_EACH_SLICE_FALSE = 'Prefer `each_slice` instead of `in_groups_of(..., false)` for clarity and simplicity.'
+        MSG_EXPLICIT = 'Specify an explicit second argument to `in_groups_of` to make padding behavior explicit.'
+
+        RESTRICT_ON_SEND = %i[in_groups_of].freeze
+
+        def on_send(node)
+          return if node.first_argument.nil?
+
+          fill_argument = node.arguments[1]
+
+          if fill_argument.nil?
+            add_offense(node.loc.selector, message: style == :explicit ? MSG_EXPLICIT : MSG_EACH_SLICE)
+          elsif fill_argument.false_type? && style != :explicit
+            add_offense(node.loc.selector, message: MSG_EACH_SLICE_FALSE)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rails/in_groups_of_spec.rb
+++ b/spec/rubocop/cop/rails/in_groups_of_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::InGroupsOf, :config do
+  context 'when EnforcedStyle is `each_slice`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'each_slice' } }
+
+    it 'registers an offense when the second argument is absent' do
+      expect_offense(<<~RUBY)
+        collection.in_groups_of(3)
+                   ^^^^^^^^^^^^ Use `each_slice` instead of `in_groups_of` to avoid padding groups with `nil`.
+      RUBY
+    end
+
+    it 'registers an offense when the second argument is explicitly `false`' do
+      expect_offense(<<~RUBY)
+        collection.in_groups_of(3, false)
+                   ^^^^^^^^^^^^ Prefer `each_slice` instead of `in_groups_of(..., false)` for clarity and simplicity.
+      RUBY
+    end
+
+    it 'registers an offense when a block is passed and the second argument is absent' do
+      expect_offense(<<~RUBY)
+        collection.in_groups_of(3) { |group| do_something(group) }
+                   ^^^^^^^^^^^^ Use `each_slice` instead of `in_groups_of` to avoid padding groups with `nil`.
+      RUBY
+    end
+
+    it 'does not register an offense when the second argument is an explicit fill value' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of(3, 0)
+      RUBY
+    end
+
+    it 'does not register an offense when the second argument is an explicit `nil`' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of(3, nil)
+      RUBY
+    end
+
+    it 'does not register an offense when the second argument is a variable' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of(3, fill)
+      RUBY
+    end
+
+    it 'does not register an offense when there are no arguments' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of
+      RUBY
+    end
+  end
+
+  context 'when EnforcedStyle is `explicit`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'explicit' } }
+
+    it 'registers an offense suggesting an explicit second argument when it is absent' do
+      expect_offense(<<~RUBY)
+        collection.in_groups_of(3)
+                   ^^^^^^^^^^^^ Specify an explicit second argument to `in_groups_of` to make padding behavior explicit.
+      RUBY
+    end
+
+    it 'does not register an offense when the second argument is explicitly `false`' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of(3, false)
+      RUBY
+    end
+
+    it 'does not register an offense when the second argument is an explicit fill value' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of(3, 0)
+      RUBY
+    end
+
+    it 'does not register an offense when the second argument is an explicit `nil`' do
+      expect_no_offenses(<<~RUBY)
+        collection.in_groups_of(3, nil)
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/lazy_loading_spec.rb
+++ b/spec/rubocop/lazy_loading_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'cop lazy loading' do # rubocop:disable RSpec/DescribeClass
       puts "loaded_mixin_files=\#{loaded_mixins.size}"
     RUBY
 
-    expect(output).to include('registered=138', 'loaded_cop_files=0', 'loaded_mixin_files=0')
+    expect(output).to include('registered=139', 'loaded_cop_files=0', 'loaded_mixin_files=0')
   end
 
   it 'overrides the deprecated `EnforceSuperclass` autoload registered by RuboCop core' do


### PR DESCRIPTION
### What

Prefer Ruby's built-in `Enumerable#each_slice` over Active Support's `in_groups_of` when the collection is chunked without an intentional fill value.

The cop reports calls with no second argument and calls passing an explicit `false` (which is equivalent to `each_slice`). Any other explicit second argument is treated as an intentional fill value and left alone.

An `explicit` EnforcedStyle instead asks for an explicit second argument on calls that omit one, making the padding behavior obvious at the call site; in that style any explicit second argument, including `false`, is accepted.

Autocorrection is not supported because an omitted second argument may reflect an intentional desire to pad with `nil` rather than a bug.

### Why

We've noticed that it's `in_groups_of` is a common source of bugs. Calling `in_groups_of` without a second argument pads the final group with `nil`, which is easy to overlook and frequently leads to a NoMethodError on nil (or another type error) downstream.

While `in_groups_of` is useful in e.g. HTML table generation (where padding is likely the default requirement), the now-builtin Ruby `each_slice` is semantically more correct by default for most code we've seen.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide). https://github.com/rubocop/rails-style-guide/pull/382

[1]: https://chris.beams.io/posts/git-commit/
