### PR TITLE
Resolve `TargetRailsVersion` within RuboCop Rails itself

### DIFF
--- a/changelog/change_resolve_target_rails_version_within_rubocop_rails.md
+++ b/changelog/change_resolve_target_rails_version_within_rubocop_rails.md
@@ -1,0 +1,1 @@
+* [#1655](https://github.com/rubocop/rubocop-rails/pull/1655): Resolve `AllCops: TargetRailsVersion` within RuboCop Rails itself instead of relying on RuboCop core, in preparation for the removal of `TargetRailsVersion` support from RuboCop core in RuboCop 2.0. ([@koic][])

--- a/lib/rubocop/cop/mixin/target_rails_version.rb
+++ b/lib/rubocop/cop/mixin/target_rails_version.rb
@@ -11,6 +11,29 @@ module RuboCop
       # See https://github.com/rubocop/rubocop/pull/11289
       TARGET_GEM_NAME = 'railties' # :nodoc:
 
+      # Used when the target Rails version cannot be detected from `AllCops: TargetRailsVersion`
+      # or from the `railties` version in the target's lockfile.
+      DEFAULT_RAILS_VERSION = 5.0
+
+      # Resolves the target Rails version as a `major.minor` Float, using only stable RuboCop core APIs.
+      # Precedence: `AllCops: TargetRailsVersion`, then the `railties` version from the target's lockfile,
+      # then `DEFAULT_RAILS_VERSION`.
+      def self.resolve(config)
+        target_rails_version = config.for_all_cops['TargetRailsVersion']
+        return target_rails_version.to_f if target_rails_version
+
+        gem_versions_in_target = config.gem_versions_in_target
+        railties_version = gem_versions_in_target && gem_versions_in_target[TARGET_GEM_NAME]
+        return DEFAULT_RAILS_VERSION unless railties_version
+
+        segments = railties_version.segments
+        Float("#{segments[0]}.#{segments[1]}")
+      end
+
+      def self.extended(base)
+        base.include(InstanceMethods)
+      end
+
       def minimum_target_rails_version(version)
         case version
         when Integer, Float then requires_gem(TARGET_GEM_NAME, ">= #{version}")
@@ -25,6 +48,16 @@ module RuboCop
         return true unless gem_requirement # If we have no requirement, then we support all versions
 
         gem_requirement.satisfied_by?(Gem::Version.new(version))
+      end
+
+      # Instance methods for cops that use the resolved target Rails version at runtime,
+      # included automatically when a cop extends `TargetRailsVersion`.
+      # On RuboCop < 2.0, `#target_rails_version` shadows `RuboCop::Cop::Base#target_rails_version`,
+      # so the resolution is owned by rubocop-rails on all supported RuboCop versions.
+      module InstanceMethods
+        def target_rails_version
+          @target_rails_version ||= TargetRailsVersion.resolve(config)
+        end
       end
     end
   end

--- a/lib/rubocop/cop/rails/active_support_on_load.rb
+++ b/lib/rubocop/cop/rails/active_support_on_load.rb
@@ -19,6 +19,7 @@ module RuboCop
       #   ActiveSupport.on_load(:active_record) { include MyClass }
       class ActiveSupportOnLoad < Base
         extend AutoCorrector
+        extend TargetRailsVersion
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
         RESTRICT_ON_SEND = %i[prepend include extend].freeze

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -66,6 +66,7 @@ module RuboCop
       class BulkChangeTable < Base
         include DatabaseTypeResolvable
         include MigrationsHelper
+        extend TargetRailsVersion
 
         MSG_FOR_CHANGE_TABLE = <<~MSG.chomp
           You can combine alter queries using `bulk: true` options.

--- a/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
+++ b/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
@@ -35,6 +35,7 @@ module RuboCop
       class DeprecatedActiveModelErrorsMethods < Base
         include RangeHelp
         extend AutoCorrector
+        extend TargetRailsVersion
 
         MSG = 'Avoid manipulating ActiveModel errors as hash directly.'
         AUTOCORRECTABLE_METHODS = %i[<< clear keys].freeze

--- a/lib/rubocop/cop/rails/enum_hash.rb
+++ b/lib/rubocop/cop/rails/enum_hash.rb
@@ -25,6 +25,7 @@ module RuboCop
       #
       class EnumHash < Base
         extend AutoCorrector
+        extend TargetRailsVersion
 
         MSG = 'Enum defined as an array found in `%<enum>s` enum declaration. Use hash syntax instead.'
         RESTRICT_ON_SEND = %i[enum].freeze

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -138,6 +138,8 @@ module RuboCop
       #     has_many :posts, -> { order(published_at: :desc) }
       #   end
       class InverseOf < Base
+        extend TargetRailsVersion
+
         SPECIFY_MSG = 'Specify an `:inverse_of` option.'
         NIL_MSG = 'You specified `inverse_of: nil`, you probably meant to use `inverse_of: false`.'
         RESTRICT_ON_SEND = %i[has_many has_one belongs_to].freeze

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -152,6 +152,7 @@ module RuboCop
       #   end
       class ReversibleMigration < Base
         include MigrationsHelper
+        extend TargetRailsVersion
 
         MSG = '%<action>s is not reversible.'
 

--- a/lib/rubocop/cop/rails/transaction_exit_statement.rb
+++ b/lib/rubocop/cop/rails/transaction_exit_statement.rb
@@ -64,6 +64,8 @@ module RuboCop
       #   end
       #
       class TransactionExitStatement < Base
+        extend TargetRailsVersion
+
         MSG = 'Exit statement `%<statement>s` is not allowed. Use `raise` (rollback) or `next` (commit).'
         BUILT_IN_TRANSACTION_METHODS = %i[transaction with_lock].freeze
 

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -34,6 +34,8 @@ module RuboCop
       #   end
       #
       class UnknownEnv < Base
+        extend TargetRailsVersion
+
         MSG = 'Unknown environment `%<name>s`.'
         MSG_SIMILAR = 'Unknown environment `%<name>s`. Did you mean `%<similar>s`?'
 

--- a/spec/rubocop/cop/target_rails_version_spec.rb
+++ b/spec/rubocop/cop/target_rails_version_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Config do
+RSpec.describe RuboCop::Cop::TargetRailsVersion do
   include FileHelper
-
-  subject(:configuration) { described_class.new(hash, loaded_path) }
 
   let(:loaded_path) { 'example/.rubocop.yml' }
 
-  describe '#target_rails_version' do
+  describe '.resolve' do
+    subject(:resolved_version) { described_class.resolve(configuration) }
+
+    let(:configuration) { RuboCop::Config.new(hash, loaded_path) }
+
     context 'when TargetRailsVersion is set' do
       let(:hash) do
         {
@@ -19,10 +21,9 @@ RSpec.describe RuboCop::Config do
 
       context 'with patch version' do
         let(:rails_version) { '5.1.4' }
-        let(:rails_version_to_f) { 5.1 }
 
         it 'truncates the patch part and converts to a float' do
-          expect(configuration.target_rails_version).to eq rails_version_to_f
+          expect(resolved_version).to eq 5.1
         end
       end
 
@@ -30,7 +31,7 @@ RSpec.describe RuboCop::Config do
         let(:rails_version) { 6.0 }
 
         it 'uses TargetRailsVersion' do
-          expect(configuration.target_rails_version).to eq rails_version
+          expect(resolved_version).to eq rails_version
         end
       end
     end
@@ -44,8 +45,7 @@ RSpec.describe RuboCop::Config do
 
       context 'and lock files do not exist' do
         it 'uses the default rails version' do
-          default = described_class::DEFAULT_RAILS_VERSION
-          expect(configuration.target_rails_version).to eq default
+          expect(resolved_version).to eq described_class::DEFAULT_RAILS_VERSION
         end
       end
 
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Config do
                   1.16.1
               LOCKFILE
             create_file(lock_file_path, content)
-            expect(configuration.target_rails_version).to eq 4.1
+            expect(resolved_version).to eq 4.1
           end
 
           it "uses the multi digit Rails version in #{file_name}" do
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Config do
                   1.16.1
               LOCKFILE
             create_file(lock_file_path, content)
-            expect(configuration.target_rails_version).to eq 400.33
+            expect(resolved_version).to eq 400.33
           end
 
           it "does not use the DEPENDENCIES Rails version in #{file_name}" do
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Config do
                   1.16.1
               LOCKFILE
             create_file(lock_file_path, content)
-            expect(configuration.target_rails_version).not_to eq 900.88
+            expect(resolved_version).not_to eq 900.88
           end
 
           it "uses the default Rails when Rails is not in #{file_name}" do
@@ -170,8 +170,7 @@ RSpec.describe RuboCop::Config do
                   1.16.1
               LOCKFILE
             create_file(lock_file_path, content)
-            default = described_class::DEFAULT_RAILS_VERSION
-            expect(configuration.target_rails_version).to eq default
+            expect(resolved_version).to eq described_class::DEFAULT_RAILS_VERSION
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ end
 require 'rubocop-rails'
 require 'rubocop/rspec/support'
 require_relative 'support/file_helper'
+# The 'rails configuration' context must be registered before the 'with Rails N.N'
+# contexts in shared_contexts.rb. See support/rails_configuration.rb.
+require_relative 'support/rails_configuration'
 require_relative 'support/shared_contexts'
 
 # Requires supporting files with custom matchers and macros, etc,

--- a/spec/support/rails_configuration.rb
+++ b/spec/support/rails_configuration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Provides the Rails-specific configuration plumbing for cop specs, replacing the plumbing that
+# RuboCop core's `rubocop/rspec/support` provides until RuboCop 2.0.
+#
+# Registration order matters: this context must be registered after RuboCop core's 'config' shared context
+# (so its `let` definitions win) and before the 'with Rails N.N' contexts in `shared_contexts.rb`
+# (so their `rails_version` wins).
+RSpec.shared_context 'rails configuration' do
+  let(:rails_version) { nil }
+
+  let(:all_cops_config) do
+    all_cops = { 'TargetRubyVersion' => ruby_version }
+    all_cops['TargetRailsVersion'] = rails_version if rails_version
+    all_cops
+  end
+
+  # Keeps `railties` in the `gem_versions_in_target` stub so that cops gated by `minimum_target_rails_version`
+  # stay enabled in specs once RuboCop core stops stubbing `railties` itself.
+  let(:gem_versions) do
+    { 'railties' => (rails_version || RuboCop::Cop::TargetRailsVersion::DEFAULT_RAILS_VERSION).to_s }
+  end
+end
+
+RSpec.configure do |config|
+  config.include_context 'rails configuration', :config
+end


### PR DESCRIPTION
When the Rails cops were extracted from RuboCop core (rubocop/rubocop#5976), the `TargetRailsVersion` implementation was deliberately left in core with the stated goal of eventually moving it to RuboCop Rails. This change completes that move on the RuboCop Rails side so that core can deprecate and remove its machinery in RuboCop 2.0.

`RuboCop::Cop::TargetRailsVersion.resolve` resolves the target Rails version using only stable core APIs (`Config#for_all_cops` and `Config#gem_versions_in_target`), with the same precedence as core: `AllCops: TargetRailsVersion`, then the `railties` version in the lockfile, then 5.0 (This version will be revisited separately). The new `InstanceMethods#target_rails_version` shadows `RuboCop::Cop::Base#target_rails_version` on RuboCop < 2.0 and becomes the only definition once core removes it, so the behavior is identical across all supported RuboCop versions.

The spec plumbing that core's `rubocop/rspec/support` provides for `rails_version` is likewise replaced by a local 'rails configuration' shared context, so the suite keeps passing once RuboCop 2.0 drops the Rails plumbing from its shared contexts. The former spec/rubocop/config_spec.rb tested core's `Config#target_rails_version` and is repurposed as a spec for the new resolver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
