### PR TITLE
[Fix #1651] Support Oj in Rails/ResponseParsedBody

### DIFF
--- a/changelog/fix_response_parsed_body_oj.md
+++ b/changelog/fix_response_parsed_body_oj.md
@@ -1,0 +1,1 @@
+* [#1651](https://github.com/rubocop/rubocop-rails/issues/1651): Support `Oj.load(response.body)` in `Rails/ResponseParsedBody`. ([@saidM][])

--- a/lib/rubocop/cop/rails/response_parsed_body.rb
+++ b/lib/rubocop/cop/rails/response_parsed_body.rb
@@ -14,6 +14,7 @@ module RuboCop
       # @example
       #   # bad
       #   JSON.parse(response.body)
+      #   Oj.load(response.body)
       #   Nokogiri::HTML(response.body)
       #   Nokogiri::HTML4(response.body)
       #   Nokogiri::HTML5(response.body)
@@ -34,13 +35,18 @@ module RuboCop
 
         HTML = %i[HTML HTML4 HTML5].to_set.freeze
 
-        RESTRICT_ON_SEND = [:parse, *HTML].freeze
+        RESTRICT_ON_SEND = [:parse, :load, *HTML].freeze
 
         minimum_target_rails_version 5.0
 
         # @!method json_parse_response_body?(node)
         def_node_matcher :json_parse_response_body?, <<~PATTERN
           (send #json? :parse #response_body?)
+        PATTERN
+
+        # @!method oj_load_response_body?(node)
+        def_node_matcher :oj_load_response_body?, <<~PATTERN
+          (send #oj? :load #response_body?)
         PATTERN
 
         # @!method nokogiri_html_response_body?(node)
@@ -61,6 +67,11 @@ module RuboCop
         # @!method json?(node)
         def_node_matcher :json?, <<~PATTERN
           (const {nil? cbase} :JSON)
+        PATTERN
+
+        # @!method oj?(node)
+        def_node_matcher :oj?, <<~PATTERN
+          (const {nil? cbase} :Oj)
         PATTERN
 
         # @!method nokogiri?(node)
@@ -96,7 +107,7 @@ module RuboCop
         end
 
         def json_offense?(node)
-          json_parse_response_body?(node)
+          json_parse_response_body?(node) || oj_load_response_body?(node)
         end
 
         def support_response_parsed_body_for_html?

--- a/spec/rubocop/cop/rails/response_parsed_body_spec.rb
+++ b/spec/rubocop/cop/rails/response_parsed_body_spec.rb
@@ -43,6 +43,48 @@ RSpec.describe RuboCop::Cop::Rails::ResponseParsedBody, :config do
     end
   end
 
+  context 'when `Oj.load(response.body)` is used' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        expect(Oj.load(response.body)).to eq('foo' => 'bar')
+               ^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response.parsed_body).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+
+  context 'when `::Oj.load(response.body)` is used' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        expect(::Oj.load(response.body)).to eq('foo' => 'bar')
+               ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response.parsed_body).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+
+  context 'when `Oj.load(response.body)` is used with options' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        expect(Oj.load(response.body, mode: :strict)).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+
+  context 'when `Oj.load` is used with another source' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        expect(Oj.load(payload)).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+
   context 'when `Nokogiri::HTML(response.body)` is used on Rails 7.0', :rails70 do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
`Rails/ResponseParsedBody` handles `JSON.parse(response.body)`, but not
`Oj.load(response.body)`.

This adds support for `Oj.load` and `::Oj.load` and autocorrects them to
`response.parsed_body`. Calls with options or other inputs are left unchanged.

Fixes #1651

---

Before submitting the PR make sure the following are checked:

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote a good commit message.
- [x] Commit message starts with `[Fix #1651]`.
- [x] Feature branch is up-to-date with `master`.
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
- [x] Added an entry to the changelog folder.
- [x] If this is a new cop, consider making a corresponding update to the Rails Style Guide. Not applicable; this updates an existing cop.