### PR TITLE
Fix version-gated cops to respect `AllCops: TargetRailsVersion`

### DIFF
--- a/changelog/fix_version_gated_cops_to_respect_target_rails_version.md
+++ b/changelog/fix_version_gated_cops_to_respect_target_rails_version.md
@@ -1,0 +1,1 @@
+* [#1657](https://github.com/rubocop/rubocop-rails/pull/1657): Fix version-gated cops using `minimum_target_rails_version` to respect `AllCops: TargetRailsVersion` so that an explicitly configured version takes precedence over the lockfile and enables these cops in projects without a lockfile. ([@koic][])

--- a/lib/rubocop/cop/mixin/target_rails_version.rb
+++ b/lib/rubocop/cop/mixin/target_rails_version.rb
@@ -58,6 +58,25 @@ module RuboCop
         def target_rails_version
           @target_rails_version ||= TargetRailsVersion.resolve(config)
         end
+
+        private
+
+        # Overrides `RuboCop::Cop::Base` so that `railties` requirements declared via
+        # `minimum_target_rails_version` are checked against the resolved target Rails version
+        # instead of the lockfile alone. This keeps `AllCops: TargetRailsVersion` effective for
+        # version-gated cops, including in projects without a lockfile.
+        def target_satisfies_all_gem_version_requirements?
+          self.class.gem_requirements.all? do |gem_name, version_requirement|
+            if gem_name == TARGET_GEM_NAME
+              version_requirement.satisfied_by?(Gem::Version.new(target_rails_version.to_s))
+            else
+              gem_versions_in_target = config.gem_versions_in_target
+              gem_version_in_target = gem_versions_in_target && gem_versions_in_target[gem_name]
+
+              gem_version_in_target && version_requirement.satisfied_by?(gem_version_in_target)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/target_rails_version_spec.rb
+++ b/spec/rubocop/cop/target_rails_version_spec.rb
@@ -176,4 +176,61 @@ RSpec.describe RuboCop::Cop::TargetRailsVersion do
       end
     end
   end
+
+  describe 'version gating for cops using `minimum_target_rails_version`' do
+    subject(:satisfied) { cop.send(:target_satisfies_all_gem_version_requirements?) }
+
+    include_context 'maintain registry'
+
+    let(:cop_class) do
+      stub_cop_class('RuboCop::Cop::Test::VersionGatedCop') do
+        # `described_class` is unavailable here because this block is class-evaled.
+        extend RuboCop::Cop::TargetRailsVersion # rubocop:disable RSpec/DescribedClass
+
+        minimum_target_rails_version 7.1
+      end
+    end
+    let(:cop) { cop_class.new(configuration) }
+
+    context 'when TargetRailsVersion satisfies the requirement and no lockfile exists', :isolated_environment do
+      let(:configuration) do
+        RuboCop::Config.new({ 'AllCops' => { 'TargetRailsVersion' => 7.1 } }, loaded_path)
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when TargetRailsVersion is below the requirement and the lockfile `railties` satisfies it' do
+      let(:configuration) do
+        configuration = RuboCop::Config.new({ 'AllCops' => { 'TargetRailsVersion' => 5.0 } }, loaded_path)
+        allow(configuration).to receive(:gem_versions_in_target).and_return({ 'railties' => Gem::Version.new('7.1.0') })
+        configuration
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when TargetRailsVersion is not set and the lockfile `railties` satisfies the requirement' do
+      let(:configuration) do
+        configuration = RuboCop::Config.new({ 'AllCops' => {} }, loaded_path)
+        allow(configuration).to receive(:gem_versions_in_target).and_return({ 'railties' => Gem::Version.new('7.2.0') })
+        configuration
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when neither TargetRailsVersion nor a lockfile exists', :isolated_environment do
+      let(:configuration) { RuboCop::Config.new({ 'AllCops' => {} }, loaded_path) }
+
+      it { is_expected.to be(false) }
+    end
+
+    # The override targets a private method of `RuboCop::Cop::Base`. This example fails loudly
+    # when RuboCop core renames it, in which case the override must follow; the behavior examples
+    # above cannot catch that because they call the override directly.
+    it 'overrides a private method that still exists in RuboCop core' do
+      expect(RuboCop::Cop::Base.private_method_defined?(:target_satisfies_all_gem_version_requirements?)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Cops gated by `minimum_target_rails_version` use the `requires_gem` API, whose check in RuboCop core only consults the lockfile. As a result, an explicitly configured `AllCops: TargetRailsVersion` was ignored by the gate: in a project without a lockfile the gated cops were silently disabled even when the configured version satisfied the requirement.

Override `Cop::Base#target_satisfies_all_gem_version_requirements?` so that `railties` requirements are checked against the resolved target Rails version, in which the explicit `TargetRailsVersion` setting takes precedence over the lockfile. This matches the documented semantics of `TargetRailsVersion` and keeps the setting effective for version-gated cops after RuboCop 2.0 removes its legacy Rails version check from `RuboCop::Cop::Team`.

Note that until now this gap was partially masked by an accident: the guard in RuboCop core's `Team#support_target_rails_version?` references `RuboCop::Rails::TargetRailsVersion::USES_REQUIRES_GEM_API`, which does not exist (the constant lives under `RuboCop::Cop`), so core's legacy per-cop version check still ran and applied `TargetRailsVersion` as an additional restriction. This change makes that behavior deliberate and owned by RuboCop Rails.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
